### PR TITLE
Disable inline attribute warning

### DIFF
--- a/capnp-rpc-lwt/jbuild
+++ b/capnp-rpc-lwt/jbuild
@@ -3,8 +3,8 @@
 (library (
   (name capnp_rpc_lwt)
   (public_name capnp-rpc-lwt)
-  (ocamlc_flags (:standard -w -55))
-  (ocamlopt_flags (:standard -w -55))
+  (ocamlc_flags (:standard -w -53))
+  (ocamlopt_flags (:standard -w -53))
   (libraries (lwt.unix astring capnp capnp-rpc fmt logs mirage-flow-lwt mirage-flow-unix))
 ))
 


### PR DESCRIPTION
OCaml 4.04.1+flambda complains about the generated file:

    Warning 53: the "inlined" attribute cannot appear in this context

However, removing the attribute makes the code run much slower!