### PR TITLE
Update fuzz tests and check they build with Travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces
     opam pin add -ny capnp-rpc . && \
     opam pin add -ny capnp-rpc-lwt . && \
     opam depext capnp-rpc-lwt
-RUN opam install capnp-rpc-lwt alcotest
+RUN opam install capnp-rpc-lwt alcotest afl-persistent
 ADD . /home/opam/capnp-rpc
 RUN sudo chown -R opam /home/opam/capnp-rpc
-RUN opam config exec -- make test
+RUN opam config exec -- make test build-fuzz

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ all:
 	rm -rf _build/_tests
 	jbuilder runtest --dev --no-buffer -j 1
 
-fuzz:
+build-fuzz:
 	jbuilder build --dev fuzz/fuzz.exe
-	#./_build/default/fuzz/fuzz.exe
+
+fuzz: build-fuzz
 	# TODO: remove -d
-	afl-fuzz -d -i _build/in -o _build/out ./_build/default/fuzz/fuzz.exe @@
+	afl-fuzz -d -i _build/in -o _build/out ./_build/default/fuzz/fuzz.exe
 
 clean:
 	rm -rf _build
@@ -19,4 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
+	#./_build/default/test/test.bc test core 7
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/capnp-rpc-lwt/jbuild
+++ b/capnp-rpc-lwt/jbuild
@@ -3,8 +3,8 @@
 (library (
   (name capnp_rpc_lwt)
   (public_name capnp-rpc-lwt)
-  (ocamlc_flags (:standard -w -53))
-  (ocamlopt_flags (:standard -w -53))
+  (ocamlc_flags (:standard -w -55-53))
+  (ocamlopt_flags (:standard -w -55-53))
   (libraries (lwt.unix astring capnp capnp-rpc fmt logs mirage-flow-lwt mirage-flow-unix))
 ))
 

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -25,7 +25,7 @@ module Make(C : S.CONCRETE) = struct
   end
 
   let pp_cap f x = x#pp f
-  let pp_cap_list f caps = Fmt.pf f "[%a]" (RO_array.pp pp_cap) caps
+  let pp_cap_list f caps = RO_array.pp pp_cap f caps
 
   class virtual ref_counted = object (self)
     val mutable ref_count = 1

--- a/capnp-rpc/protocol.ml
+++ b/capnp-rpc/protocol.ml
@@ -174,10 +174,10 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
 
     module Send : sig
       val bootstrap : t -> C.struct_resolver -> question * Out.QuestionId.t
-      val call : t -> C.struct_resolver -> message_target_cap -> cap RO_array.t ->
+      val call : t -> C.struct_resolver -> message_target_cap -> [< cap] RO_array.t ->
         question * Out.QuestionId.t * Out.message_target * Out.desc RO_array.t
 
-      val return_results : t -> answer -> C.Response.t -> cap RO_array.t -> Out.AnswerId.t * Out.return
+      val return_results : t -> answer -> C.Response.t -> [< cap] RO_array.t -> Out.AnswerId.t * Out.return
       val return_error : t -> answer -> string -> Out.AnswerId.t * Out.return
       val return_cancelled : t -> answer -> Out.AnswerId.t * Out.return
 
@@ -496,13 +496,13 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
         in
         question, question.question_id
 
-      let call t question_data (target : message_target_cap) (caps : cap RO_array.t) =
+      let call t question_data (target : message_target_cap) caps =
         let question = Questions.alloc t.questions (fun question_id ->
             {question_flags = 0; params_for_release = []; question_id; question_data; question_pipelined_fields = PathSet.empty}
           )
         in
         let descrs =
-          caps |> RO_array.map (fun (cap:cap) ->
+          caps |> RO_array.map (fun cap ->
               let descr, to_release = export t cap in
               question.params_for_release <- to_release @ question.params_for_release;
               descr

--- a/fuzz/jbuild
+++ b/fuzz/jbuild
@@ -2,5 +2,5 @@
 
 (executables (
   (names (fuzz))
-  (libraries (capnp-rpc alcotest examples logs.fmt testbed crowbar))
+  (libraries (capnp-rpc alcotest logs.fmt testbed afl-persistent))
 ))


### PR DESCRIPTION
- Using a cap from a cancelled struct. If you get a cap from a promised
  answer and then finish the question, we shouldn't cancel the question
  because we still need the cap.

- Importing the same cap multiple times.

- Releasing a cap sent in a message before the message was sent rather
  than after.

(there are plenty more bugs to find though!)