### PR TITLE
Fix embargoes with finished questions

### DIFF
--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -234,9 +234,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
          begin match ret with
          | `Results (msg, descs) ->
            let result, caps = P.Input.return_results t.p qid msg descs ~releaseParamCaps:false in
-           let is_cancelled = result#response = Some (Error `Cancelled) in
            let from_cap_desc = function
-             | `LocalEmbargo (c, _) when is_cancelled -> c (* Can't be anything pipelined after the cancel *)
              | `LocalEmbargo (c, disembargo_request) ->
                c#inc_ref;
                Log.info (fun f -> f ~tags:t.tags "Embargo %t until %a is delivered"

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -19,10 +19,14 @@ let () =
   Fmt.set_style_renderer Fmt.stderr `Ansi_tty
 
 let choose_int limit =
-  assert (limit < 256);
   try
     let x = Char.code (input_char stdin) in
-    x mod limit
+    if limit < 0x100 then x mod limit
+    else (
+      let y = Char.code (input_char stdin) in
+      assert (limit < 0x10000);
+      (x lor (y lsl 8)) mod limit
+    )
   with End_of_file -> raise End_of_fuzz_data
 
 let choose options =

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -155,8 +155,8 @@ let () =
   AflPersistent.run @@ fun () ->
 
   let v1 = make_vat () in
-  let v2 = make_vat ~bootstrap:test_service () in
-  let v3 = make_vat ~bootstrap:test_service () in
+  let v2 = make_vat ~bootstrap:(test_service ()) () in
+  let v3 = make_vat ~bootstrap:(test_service ()) () in
 
   let vats = [| v1; v2; v3|] in
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -14,7 +14,7 @@ let response_promise = Alcotest.(option (result (pair string (ro_array cap)) err
 
 let test_simple_connection () =
   let open CS in
-  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags Services.echo_service in
+  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags (Services.echo_service ()) in
   let servce_promise = C.bootstrap c in
   S.handle_msg s ~expect:"bootstrap";
   C.handle_msg c ~expect:"return:(boot)";
@@ -40,7 +40,7 @@ let init_pair ~bootstrap_service =
    at the client, it must be the original (local) object, not a proxy. *)
 let test_return () =
   let open CS in
-  let c, s, bs = init_pair ~bootstrap_service:Services.echo_service in
+  let c, s, bs = init_pair ~bootstrap_service:(Services.echo_service ()) in
   (* Pass callback *)
   let slot = ref ("empty", empty) in
   let local = Services.swap_service slot in
@@ -74,7 +74,7 @@ let call target msg caps =
 
 let test_share_cap () =
   let open CS in
-  let c, s, bs = init_pair ~bootstrap_service:Services.echo_service in
+  let c, s, bs = init_pair ~bootstrap_service:(Services.echo_service ()) in
   let q = call bs "msg" [bs; bs] in
   bs#dec_ref;
   S.handle_msg s ~expect:"call:msg";
@@ -89,7 +89,7 @@ let test_share_cap () =
    the object must arrive before ones sent directly. *)
 let test_local_embargo () =
   let open CS in
-  let c, s, bs = init_pair ~bootstrap_service:Services.echo_service in
+  let c, s, bs = init_pair ~bootstrap_service:(Services.echo_service ()) in
   let local = Services.logger () in
   let q = call bs "Get service" [(local :> Core_types.cap)] in
   let service = q#cap 0 in
@@ -115,7 +115,7 @@ let test_local_embargo () =
 (* The field must still be useable after the struct is released. *)
 let test_fields () =
   let open CS in
-  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags Services.echo_service in
+  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags (Services.echo_service ()) in
   let f0 = C.bootstrap c in
   let q1 = call f0 "c1" [] in
   S.handle_msg s ~expect:"bootstrap";

--- a/test/testbed/services.ml
+++ b/test/testbed/services.ml
@@ -2,7 +2,7 @@ open Capnp_direct.Core_types
 
 module RO_array = Capnp_rpc.RO_array
 
-let echo_service = object (self : cap)
+let echo_service () = object (self : cap)
   inherit ref_counted
   method call x caps =
     assert (ref_count > 0);

--- a/test/testbed/test_utils.ml
+++ b/test/testbed/test_utils.ml
@@ -1,7 +1,8 @@
-let pp_actor f = function
-  | `Client -> Fmt.(styled `Green (const string "client")) f ()
-  | `Server -> Fmt.(styled `Red (const string "server")) f ()
-  | `Unknown -> Fmt.(const string "------") f ()
+type actor = Fmt.style * string
+
+let pp_actor f (style, name) = Fmt.(styled style (const string name)) f ()
+
+let unknown = `Black, "------"
 
 let actor_tag = Logs.Tag.def "actor" pp_actor
 
@@ -18,7 +19,7 @@ let reporter =
     let actor =
       match Logs.Tag.find actor_tag tags with
       | Some x -> x
-      | None -> `Unknown
+      | None -> unknown
     in
     let qid = Logs.Tag.find Capnp_rpc.Debug.qid_tag tags in
     let print _ =
@@ -37,5 +38,5 @@ let () =
   Logs.set_reporter reporter;
   Logs.set_level (Some Logs.Info)
 
-let server_tags = Logs.Tag.(empty |> add actor_tag `Server)
-let client_tags = Logs.Tag.(empty |> add actor_tag `Client)
+let server_tags = Logs.Tag.(empty |> add actor_tag (`Red, "server"))
+let client_tags = Logs.Tag.(empty |> add actor_tag (`Green, "client"))


### PR DESCRIPTION
Before, we assumed that we didn't need an embargo for a capability returned to a finished question, because it was about to be discarded anyway. However, we now allow taking a capability from a question and continuing to use it even if the question is cancelled.

Found by the fuzz testing.

Also, extended the fuzzing to test with three vats.