### PR TITLE
Add embargoes on promised answers

### DIFF
--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -240,11 +240,11 @@ let serialise ~tags : Proto.Out.t -> _ =
         Disembargo.Context.sender_loopback_set ctx (Protocol.EmbargoId.uint32 embargo_id)
     end;
     Message.to_message m
-  | `Disembargo_reply (`ReceiverHosted id, embargo_id) ->
+  | `Disembargo_reply (target, embargo_id) ->
     let m = Message.init_root () in
     let dis = Message.disembargo_init m in
     let ctx = Disembargo.context_init dis in
-    set_target (Disembargo.target_init dis) (`ReceiverHosted id);
+    set_target (Disembargo.target_init dis) target;
     Disembargo.Context.receiver_loopback_set ctx (Protocol.EmbargoId.uint32 embargo_id);
     Message.to_message m
   | `Return (aid, return) ->

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -293,5 +293,8 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
                      P.In.pp_desc target
                      embargo#pp);
         embargo#disembargo
+
+    let dump f t =
+      Fmt.pf f "@[<v 2>CapTP state:@,%a@]" P.dump t.p
   end
 end

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -65,6 +65,10 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
             | `Local _ -> ()
           )
 
+      let pp_promise f = function
+        | Some (q, _) -> P.pp_question f q
+        | None -> Fmt.string f "(not initialised)"
+
       let rec call t target msg caps =
         let result = make_remote_promise t in
         let con_caps = RO_array.map (to_cap_desc t) caps in
@@ -95,7 +99,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
             | None -> failwith "Not initialised!"
 
           method! pp f =
-            Fmt.pf f "remote-promise -> %a" Struct_proxy.pp_state state
+            Fmt.pf f "remote-promise -> %a" (Struct_proxy.pp_state ~pp_promise) state
 
           method set_question q =
             let finish = lazy (

--- a/capnp-rpc/capnp_rpc.mli
+++ b/capnp-rpc/capnp_rpc.mli
@@ -22,6 +22,8 @@ module Make (C : S.CONCRETE) (N : S.NETWORK_TYPES) : sig
       val stats : t -> Stats.t
 
       val create : ?bootstrap:Core_types.cap -> tags:Logs.Tag.set -> queue_send:(P.Out.t -> unit) -> t
+
+      val dump : t Fmt.t
     end
   end
 end

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -86,7 +86,7 @@ module Make(C : S.CONCRETE) = struct
 
   module Request_payload = struct
     type t = Request.t * cap RO_array.t
-    let pp f (msg, caps) = Fmt.pf f "%a%a" Request.pp msg pp_cap_list caps
+    let pp f (msg, caps) = Fmt.pf f "@[%a%a@]" Request.pp msg pp_cap_list caps
 
     let field (msg, caps) path =
       let i = Request.cap_index msg path in
@@ -95,7 +95,7 @@ module Make(C : S.CONCRETE) = struct
 
   module Response_payload = struct
     type t = Response.t * cap RO_array.t
-    let pp f (msg, caps) = Fmt.pf f "%a%a" Response.pp msg pp_cap_list caps
+    let pp f (msg, caps) = Fmt.pf f "@[%a%a@]" Response.pp msg pp_cap_list caps
 
     let field (msg, caps) path =
       let i = Response.cap_index msg path in

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -16,7 +16,8 @@ module Make (C : S.CORE_TYPES) = struct
       (result :> struct_ref)
 
     method! pp f =
-      Fmt.pf f "local-struct-ref -> %a" Struct_proxy.pp_state state
+      let pp_promise f _ = Fmt.string f "(unresolved)" in
+      Fmt.pf f "local-struct-ref -> %a" (Struct_proxy.pp_state ~pp_promise) state
 
     method private on_resolve q x =
       Queue.iter (fun fn -> fn x) q

--- a/capnp-rpc/protocol.ml
+++ b/capnp-rpc/protocol.ml
@@ -192,6 +192,8 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
       val disembargo_reply : t -> [`ReceiverHosted of import] -> [`ReceiverHosted of Out.ImportId.t]
     end
 
+    val dump : t Fmt.t
+
     val stats : t -> Stats.t
     val pp_question : question Fmt.t
   end
@@ -303,6 +305,28 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
 
     let pp_question f q =
       Fmt.pf f "q%a" T.QuestionId.pp q.question_id
+
+    let dump_question f q =
+      Fmt.pf f "%t" q.question_data#pp
+
+    let dump_answer f x =
+      Fmt.pf f "%t" x.answer_promise#pp
+
+    let dump_export f x =
+      Fmt.pf f "%t" x.export_service#pp
+
+    let dump_import f x =
+      Fmt.pf f "import"
+
+    let dump f t =
+      Fmt.pf f "@[<2>Questions:@,%a@]@,\
+                @[<2>Answers:@,%a@]@,\
+                @[<2>Exports:@,%a@]@,\
+                @[<2>Imports:@,%a@]"
+        (Questions.dump dump_question) t.questions
+        (Answers.dump dump_answer) t.answers
+        (Exports.dump dump_export) t.exports
+        (Imports.dump dump_import) t.imports
 
     let maybe_release_question t question =
       if question.question_flags - flag_returned - flag_finished = 0 then (

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -89,7 +89,7 @@ module type CORE_TYPES = sig
         If the response has arrived, this will extract the capability from it.
         If not, it may create a capability that will pipeline through the promised
         answer until the result arrives (at which point it will use the new, more
-        direct route). *)
+        direct route). The caller should call [cap#dec_ref] when done.  *)
   end
   (** The result of a call, which may not have arrived yet.
       It can be used to pipeline calls to capabilities that we hope will
@@ -141,7 +141,8 @@ module type CORE_TYPES = sig
     inherit struct_ref
 
     method connect : struct_ref -> unit
-    (** [r#connect x] causes [r] to behave as [x] in future. *)
+    (** [r#connect x] causes [r] to behave as [x] in future.
+        [r] takes ownership of [x] (is responsible for calling [finish] on it). *)
 
     method resolve : Response_payload.t or_error -> unit
     (** [r#resolve x] is [r#resolve (return x)]. *)

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -32,9 +32,9 @@ module Make (C : S.CORE_TYPES) = struct
     | Forwarding of struct_ref
     | Finished
 
-  let pp_state f = function
-    | Unresolved {cancelling = true; _} -> Fmt.pf f "(cancelling)"
-    | Unresolved _ -> Fmt.pf f "(unresolved)"
+  let pp_state ~pp_promise f = function
+    | Unresolved {target; cancelling = true; _} -> Fmt.pf f "%a (cancelling)" pp_promise target
+    | Unresolved {target; _} -> pp_promise f target
     | Forwarding p -> p#pp f
     | Finished -> Fmt.pf f "(finished)"
 
@@ -131,7 +131,8 @@ module Make (C : S.CORE_TYPES) = struct
         ~forwarding:(fun x -> x#cap path)
 
     method pp f =
-      Fmt.pf f "proxy -> %a" pp_state state
+      let pp_promise f _ = Fmt.string f "(unresolved)" in
+      Fmt.pf f "proxy -> %a" (pp_state ~pp_promise) state
 
     method connect x =
       Log.info (fun f -> f "@[Updating: %t@\n\

--- a/capnp-rpc/table.ml
+++ b/capnp-rpc/table.ml
@@ -24,6 +24,7 @@ module Allocating (Key : Id.S) = struct
       use x
 
   let release t x =
+    assert (Hashtbl.mem t.used x);
     Hashtbl.remove t.used x;
     t.free <- x :: t.free
 

--- a/capnp-rpc/table.ml
+++ b/capnp-rpc/table.ml
@@ -33,6 +33,15 @@ module Allocating (Key : Id.S) = struct
       failf "Key %a is no longer allocated!" Key.pp x
 
   let active t = Hashtbl.length t.used
+
+  let pp_item pp f (k, v) =
+    Fmt.pf f "%a -> @[%a@]" Key.pp k pp v
+
+  let dump pp f t =
+    let add k v acc = (k, v) :: acc in
+    let items = Hashtbl.fold add t.used [] in
+    let items = List.sort compare items in
+    (Fmt.Dump.list (pp_item pp)) f items
 end
 
 module Tracking (Key : Id.S) = struct
@@ -55,4 +64,13 @@ module Tracking (Key : Id.S) = struct
     | x -> x
 
   let active = Hashtbl.length
+
+  let pp_item pp f (k, v) =
+    Fmt.pf f "%a -> @[%a@]" Key.pp k pp v
+
+  let dump pp f t =
+    let add k v acc = (k, v) :: acc in
+    let items = Hashtbl.fold add t [] in
+    let items = List.sort compare items in
+    (Fmt.Dump.list (pp_item pp)) f items
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -64,6 +64,7 @@ let test_return_error () =
   (* Server echos args back *)
   CS.flush c s;
   Alcotest.(check response_promise) "Client got response" (Some (Error (`Exception "test-error"))) q#response;
+  q#finish;
   bs#dec_ref;
   CS.flush c s;
   CS.check_finished c s

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -32,6 +32,9 @@ module Endpoint
     recv_queue : In.t Queue.t;
   }
 
+  let dump f t =
+    Conn.dump f t.conn
+
   let create ?bootstrap ~tags xmit_queue recv_queue =
     let queue_send x = Queue.add x xmit_queue in
     let conn = Conn.create ?bootstrap ~tags ~queue_send in

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -103,7 +103,15 @@ module Make ( ) = struct
     let s_changed = S.step s in
     if c_changed || s_changed then flush c s
 
+  let dump c s =
+    Logs.info (fun f -> f ~tags:(C.Conn.tags c.C.conn) "%a" C.dump c);
+    Logs.info (fun f -> f ~tags:(S.Conn.tags s.S.conn) "%a" S.dump s)
+
   let check_finished c s =
-    Alcotest.(check stats) "Client finished" Stats.zero @@ C.Conn.stats c.C.conn;
-    Alcotest.(check stats) "Server finished" Stats.zero @@ S.Conn.stats s.S.conn
+    try
+      Alcotest.(check stats) "Client finished" Stats.zero @@ C.Conn.stats c.C.conn;
+      Alcotest.(check stats) "Server finished" Stats.zero @@ S.Conn.stats s.S.conn
+    with ex ->
+      dump c s;
+      raise ex
 end

--- a/test/testbed/services.ml
+++ b/test/testbed/services.ml
@@ -23,7 +23,7 @@ let manual () = object (self : #cap)
     Queue.add (x, caps, result) queue;
     (result :> struct_ref)
 
-  method pop = Queue.pop queue
+  method pop = Queue.pop queue  (* Caller takes ownership of caps *)
 
   method private release = ()
   method pp f = Fmt.string f "manual"


### PR DESCRIPTION
Before, we only embargoed on ReceiverHosted, but we need to do so for ReceiverAnswer too.

This PR also extends the fuzzing so each vat runs a test service that replies at random (rather than just an echo service), improves the ref-counting on fields, documents the ref-counting further, and improves diagnostic logging.