### PR TITLE
Fuzzing: check that message arrive in the correct order

### DIFF
--- a/capnp-rpc-lwt/xform.mli
+++ b/capnp-rpc-lwt/xform.mli
@@ -1,0 +1,8 @@
+type t =
+  | Field of int
+
+val pp : t Fmt.t
+
+val resolve : Schema.Reader.Payload.t -> t list -> int option
+(** [resolve payload path] is the index in the payload's cap descriptor table
+    of the interface at [path] within the payload's content. *)


### PR DESCRIPTION
When I tried disabling the test for whether a local embargo is needed, afl-fuzz found a counter-example within 15 seconds.