### PR TITLE
Detect and reject attempts to create cycles

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -79,6 +79,7 @@ module Untyped = struct
       method response = failwith "Can't use response on a sub-struct"
       method finish = failwith "Can't use finish on a sub-struct"
       method pp f = Fmt.pf f "pointer %d in %t" i t#pp
+      method blocker = failwith "struct_field: blocker"
     end
 
   let capability_field t f = t#cap [Xform.Field f]
@@ -98,10 +99,10 @@ module Untyped = struct
   let cap_index x = x
 
   let unknown_interface ~interface_id _req =
-    Service.fail "Unknown interface %a" Uint64.printer interface_id
+    Core_types.fail "Unknown interface %a" Uint64.printer interface_id
 
   let unknown_method ~interface_id ~method_id _req =
-    Service.fail "Unknown method %a.%d" Uint64.printer interface_id method_id
+    Core_types.fail "Unknown method %a.%d" Uint64.printer interface_id method_id
 end
 
 module Service = Service

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -101,9 +101,6 @@ module Service : sig
   (** [return_lwt fn] is a local promise for the result of Lwt thread [fn ()].
       If [fn ()] fails, the error is logged and an "Internal error" returned to the caller.
       Note that this does not support pipelining. *)
-
-  val fail : ('a, Format.formatter, unit, 'b StructRef.t) format4 -> 'a
-  (** [fail msg] is an exception with reason [msg]. *)
 end
 
 module Untyped : sig

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -152,6 +152,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
                       t.queue_send (`Release (id, count))
 
                     method shortest = self
+                    method blocker = None   (* Can't detect cycles over the network *)
                   end
                 in
                 register t cap message_target;

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -1,3 +1,5 @@
+module Log = Debug.Log
+
 module Make(C : S.CORE_TYPES) = struct
   open C
   module Local_struct_promise = Local_struct_promise.Make(C)
@@ -11,7 +13,7 @@ module Make(C : S.CORE_TYPES) = struct
     | Unresolved of (struct_resolver * Request.t * cap RO_array.t) Queue.t
     | Resolved of cap
 
-  class local_cap_promise =
+  class local_promise =
     object (self : #cap)
       inherit ref_counted
       val mutable state = Unresolved (Queue.create ())
@@ -24,9 +26,19 @@ module Make(C : S.CORE_TYPES) = struct
           (result :> struct_ref)
         | Resolved cap -> cap#call msg caps
 
-      method resolve cap =
+      method resolve (cap:cap) =
         match state with
         | Unresolved q ->
+          let cap =
+            match cap#blocker with
+            | Some blocker when blocker = (self :> base_ref) ->
+              let msg = Fmt.strf "@[<v>Attempt to create a cycle detected:@,\
+                                  Resolving %t with %t would create a cycle@]" self#pp cap#pp in
+              Log.info (fun f -> f "%s" msg);
+              cap#dec_ref;
+              C.broken_cap msg
+            | _ -> cap
+          in
           state <- Resolved cap;
           let forward (result, msg, caps) =
             let r = cap#call msg caps in
@@ -42,6 +54,11 @@ module Make(C : S.CORE_TYPES) = struct
         | Unresolved _ -> (self :> cap)
         | Resolved cap -> cap#shortest
 
+      method blocker =
+        match state with
+        | Unresolved _ -> Some (self :> base_ref)
+        | Resolved cap -> cap#blocker
+
       method pp f =
         match state with
         | Unresolved _ -> Fmt.string f "local-cap-promise -> (unresolved)"
@@ -51,7 +68,7 @@ module Make(C : S.CORE_TYPES) = struct
   let embargo underlying : embargo_cap =
     let cap =
       object
-        inherit local_cap_promise as super
+        inherit local_promise as super
 
         method disembargo =
           super#resolve underlying

--- a/capnp-rpc/cap_proxy.mli
+++ b/capnp-rpc/cap_proxy.mli
@@ -1,0 +1,13 @@
+module Make(C : S.CORE_TYPES) : sig
+  class type embargo_cap = object
+    inherit C.cap
+    method disembargo : unit
+  end
+
+  class local_promise : object
+    inherit C.cap
+    method resolve : C.cap -> unit
+  end
+
+  val embargo : C.cap -> embargo_cap
+end

--- a/capnp-rpc/capnp_rpc.ml
+++ b/capnp-rpc/capnp_rpc.ml
@@ -8,6 +8,7 @@ module Error = Error
 module Make (C : S.CONCRETE) (N : S.NETWORK_TYPES) = struct
   module Core_types = Core_types.Make(C)
   module Local_struct_promise = Local_struct_promise.Make(Core_types)
+  module Cap_proxy = Cap_proxy.Make(Core_types)
   module Protocol = Protocol.Make(Core_types)(N)
   module CapTP = CapTP.Make(Core_types)(N)
 end

--- a/capnp-rpc/capnp_rpc.mli
+++ b/capnp-rpc/capnp_rpc.mli
@@ -9,6 +9,7 @@ module Make (C : S.CONCRETE) (N : S.NETWORK_TYPES) : sig
   module Core_types : module type of Core_types.Make(C)
   module Protocol : module type of Protocol.Make(Core_types)(N)
   module Local_struct_promise : module type of Local_struct_promise.Make(Core_types)
+  module Cap_proxy : module type of Cap_proxy.Make(Core_types)
   module CapTP : sig
     module Make (P : Protocol.S) : sig
       type t

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -5,24 +5,36 @@ module Make (C : S.CORE_TYPES) = struct
 
   type target = (struct_ref -> unit) Queue.t
 
-  let rec local_promise () = object (_ : #struct_resolver)
-    inherit [target] Struct_proxy.t (Queue.create ())
+  let rec local_promise ?parent () = object (self : #struct_resolver)
+    inherit [target] Struct_proxy.t (Queue.create ()) as super
 
     method private do_pipeline q i msg caps =
-      let result = local_promise () in
+      let result = local_promise ~parent:self () in
       q |> Queue.add (fun p ->
           result#connect ((p#cap i)#call msg caps)
         );
       (result :> struct_ref)
 
     method! pp f =
-      let pp_promise f _ = Fmt.string f "(unresolved)" in
-      Fmt.pf f "local-struct-ref -> %a" (Struct_proxy.pp_state ~pp_promise) state
+      let pp_promise f _ =
+        match parent with
+        | None -> Fmt.string f "(unresolved)"
+        | Some p -> Fmt.pf f "blocked on %t" p#pp
+      in
+      Fmt.pf f "local-struct-ref(%a) -> %a"
+        (Fmt.styled `Blue Fmt.int) id
+        (Struct_proxy.pp_state ~pp_promise) state
 
     method private on_resolve q x =
       Queue.iter (fun fn -> fn x) q
 
     method private do_finish _ = ()
+
+    method! blocker =
+      match super#blocker, parent with
+      | None, _ -> None            (* Not blocked *)
+      | Some _self, Some b -> b#blocker
+      | Some _ as x, None -> x
   end
 
   let make () = (local_promise () :> struct_resolver)

--- a/capnp-rpc/rO_array.ml
+++ b/capnp-rpc/rO_array.ml
@@ -7,6 +7,18 @@ let map = Array.map
 let mapi = Array.mapi
 let iter = Array.iter
 let iteri = Array.iteri
+
+let find fn t =
+  let rec loop i =
+    if i = Array.length t then None
+    else (
+      let item = t.(i) in
+      if fn item then Some item
+      else loop (i + 1)
+    )
+  in
+  loop 0
+
 let empty = [| |]
 let pp x = Fmt.(brackets (array ~sep:(const string ", ") x))
 

--- a/capnp-rpc/rO_array.mli
+++ b/capnp-rpc/rO_array.mli
@@ -7,6 +7,7 @@ val map : ('a -> 'b) -> 'a t -> 'b t
 val mapi : (int -> 'a -> 'b) -> 'a t -> 'b t
 val iter : ('a -> unit) -> 'a t -> unit
 val iteri : (int -> 'a -> unit) -> 'a t -> unit
+val find : ('a -> bool) -> 'a t -> 'a option
 val empty : 'a t
 val pp : 'a Fmt.t -> 'a t Fmt.t
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool


### PR DESCRIPTION
Also, number promises for easier debugging, rename `Service.fail` to `Core_types.fail`, and add a `service` class to make it easier to define local services.