### PR TITLE
Clean up API

### DIFF
--- a/capnp-rpc-lwt/capnp_core.ml
+++ b/capnp-rpc-lwt/capnp_core.ml
@@ -37,7 +37,9 @@ module Capnp_content = struct
   end
 end
 
-module Network_types = struct
+module Core_types = struct
+  include Capnp_rpc.Core_types(Capnp_content)
+
   type sturdy_ref
   type provision_id
   type recipient_id
@@ -45,4 +47,5 @@ module Network_types = struct
   type join_key_part
 end
 
-include Capnp_rpc.Make(Capnp_content)(Network_types)
+module Endpoint_types = Capnp_rpc.Message_types.Endpoint(Core_types)( )
+module Local_struct_promise = Capnp_rpc.Local_struct_promise.Make(Core_types)

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -2,319 +2,319 @@ module Log = Debug.Log
 
 let failf msg = Fmt.kstrf failwith msg
 
-module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
-  module Protocol = Protocol.Make(C)(N)
+module EmbargoId = Message_types.EmbargoId
 
-  module Make (P : Protocol.S) = struct
-    open C
-    module Cap_proxy = Cap_proxy.Make(C)
-    module Struct_proxy = Struct_proxy.Make(C)
-    module Local_struct_promise = Local_struct_promise.Make(C)
+module Make (EP : Message_types.ENDPOINT) = struct
+  module Core_types = EP.Core_types
+  module Wire = Core_types.Wire
+  module P = Protocol.Make(EP)
+  module Cap_proxy = Cap_proxy.Make(Core_types)
+  module Struct_proxy = Struct_proxy.Make(Core_types)
+  module Local_struct_promise = Local_struct_promise.Make(Core_types)
 
-    type t = {
-      queue_send : (P.Out.t -> unit);
-      p : P.t;
-      ours : (cap, P.message_target_cap) Hashtbl.t;              (* TODO: use weak table *)
-      tags : Logs.Tag.set;
-      embargoes : (Protocol.EmbargoId.t, Cap_proxy.embargo_cap) Hashtbl.t;
-      bootstrap : cap option;
+  type t = {
+    queue_send : (EP.Out.t -> unit);
+    p : P.t;
+    ours : (Core_types.cap, P.message_target_cap) Hashtbl.t;              (* TODO: use weak table *)
+    tags : Logs.Tag.set;
+    embargoes : (EmbargoId.t, Cap_proxy.embargo_cap) Hashtbl.t;
+    bootstrap : Core_types.cap option;
+  }
+
+  let create ?bootstrap ~tags ~queue_send =
+    {
+      queue_send;
+      p = P.create ~tags ();
+      ours = Hashtbl.create 10;
+      tags;
+      embargoes = Hashtbl.create 10;
+      bootstrap;
     }
 
-    let create ?bootstrap ~tags ~queue_send =
-      {
-        queue_send;
-        p = P.create ~tags ();
-        ours = Hashtbl.create 10;
-        tags;
-        embargoes = Hashtbl.create 10;
-        bootstrap;
-      }
+  let tags ?qid ?aid t =
+    match qid, aid with
+    | None, None -> t.tags
+    | Some qid, None -> Logs.Tag.add Debug.qid_tag (EP.Table.QuestionId.uint32 qid) t.tags
+    | None, Some aid -> Logs.Tag.add Debug.qid_tag (EP.Table.AnswerId.uint32 aid) t.tags
+    | Some _, Some _ -> assert false
 
-    let tags ?qid ?aid t =
-      match qid, aid with
-      | None, None -> t.tags
-      | Some qid, None -> Logs.Tag.add Debug.qid_tag (P.T.QuestionId.uint32 qid) t.tags
-      | None, Some aid -> Logs.Tag.add Debug.qid_tag (P.T.AnswerId.uint32 aid) t.tags
-      | Some _, Some _ -> assert false
+  let stats t = P.stats t.p
 
-    let stats t = P.stats t.p
+  let register t x y =
+    match Hashtbl.find t.ours x with
+    | exception Not_found -> Hashtbl.add t.ours x y
+    | existing -> assert (y = existing)
 
-    let register t x y =
-      match Hashtbl.find t.ours x with
-      | exception Not_found -> Hashtbl.add t.ours x y
-      | existing -> assert (y = existing)
+  let unwrap t x =
+    try Some (Hashtbl.find t.ours x)
+    with Not_found -> None
 
-    let unwrap t x =
-      try Some (Hashtbl.find t.ours x)
-      with Not_found -> None
+  module Self_proxy = struct
+    let to_cap_desc t (cap : Core_types.cap) =
+      let cap = cap#shortest in
+      match unwrap t cap with
+      | None -> `Local cap
+      | Some x -> (x :> [`Local of Core_types.cap | P.message_target_cap])
 
-    module Self_proxy = struct
-      let to_cap_desc t (cap : cap) =
-        let cap = cap#shortest in
-        match unwrap t cap with
-        | None -> `Local cap
-        | Some x -> (x :> [`Local of cap | P.message_target_cap])
+    type target = (P.question * unit Lazy.t) option  (* question, finish *)
 
-      type target = (P.question * unit Lazy.t) option  (* question, finish *)
+    (* We've just converted [caps] to [con_caps] and transmitted them.
+       [dec_ref] each [cap], unless we need to keep it around so the peer can refer
+       to it later. *)
+    let release_remote_caps caps con_caps =
+      con_caps |> RO_array.iteri (fun i -> function
+          | `ReceiverHosted _
+          | `ReceiverAnswer _ -> (RO_array.get caps i)#dec_ref
+          | `Local _ -> ()
+        )
 
-      (* We've just converted [caps] to [con_caps] and transmitted them.
-         [dec_ref] each [cap], unless we need to keep it around so the peer can refer
-         to it later. *)
-      let release_remote_caps caps con_caps =
-        con_caps |> RO_array.iteri (fun i -> function
-            | `ReceiverHosted _
-            | `ReceiverAnswer _ -> (RO_array.get caps i)#dec_ref
-            | `Local _ -> ()
-          )
+    let pp_promise f = function
+      | Some (q, _) -> P.pp_question f q
+      | None -> Fmt.string f "(not initialised)"
 
-      let pp_promise f = function
-        | Some (q, _) -> P.pp_question f q
-        | None -> Fmt.string f "(not initialised)"
-
-      let rec call t target msg caps =
-        let result = make_remote_promise t in
-        let con_caps = RO_array.map (to_cap_desc t) caps in
-        let question, qid, message_target, descs = P.Send.call t.p (result :> struct_resolver) target con_caps in
-        Log.info (fun f -> f ~tags:(tags ~qid t) "Sending: (%a).call %a"
-                     P.pp_cap target
-                     Request_payload.pp (msg, caps));
-        result#set_question question;
-        t.queue_send (`Call (qid, message_target, msg, descs));
-        release_remote_caps caps con_caps;
-        (result :> struct_ref)
-
-      (* A cap that sends to a promised answer's cap at other *)
-      and make_remote_promise t =
-        object (self : #struct_resolver)
-          inherit [target] Struct_proxy.t None as super
-
-          method do_pipeline question i msg caps =
-            match question with
-            | Some (target_q, _) ->
-              let target = `ReceiverAnswer (target_q, i) in
-              call t target msg caps
-            | None -> failwith "Not initialised!"
-
-          method on_resolve q _ =
-            match q with
-            | Some (_target_q, finish) -> Lazy.force finish
-            | None -> failwith "Not initialised!"
-
-          method! pp f =
-            Fmt.pf f "remote-promise -> %a" (Struct_proxy.pp_state ~pp_promise) state
-
-          method set_question q =
-            let finish = lazy (
-              let qid = P.Send.finish t.p q in
-              Log.info (fun f -> f ~tags:(tags ~qid t) "Send finish %t" self#pp);
-              t.queue_send (`Finish (qid, false));
-            ) in
-            self#update_target (Some (q, finish))
-
-          method! cap path =
-            let field = super#cap path in
-            begin match state with
-              | Unresolved u ->
-                begin match u.target with
-                  | None -> failwith "Not intialised!"
-                  | Some (target_q, _) ->
-                    register t field (`ReceiverAnswer (target_q, path));        (* TODO: unregister *)
-                end
-              | _ -> ()
-            end;
-            field
-
-          method do_finish = function
-            | Some (_, finish) -> Lazy.force finish
-            | None -> failwith "Not initialised!"
-        end
-
-      (* Turn a connection-scoped cap reference received from Other into a general-purpose
-         cap for users. If the resulting cap is remote, our wrapper forwards it to Other.
-         This will add a ref count to the cap if it already exists, or create a new
-         one with [ref_count = 1]. *)
-      let from_cap_desc t (desc:P.recv_cap) : cap =
-        match desc with
-        | `Local c -> c#inc_ref; c
-        | `ReceiverHosted import as message_target ->
-          P.import_proxy import
-            ~inc_ref:(fun c -> c#inc_ref)
-            ~create:(fun () ->
-                let cap =
-                  object (self : #cap)
-                    inherit ref_counted
-
-                    method call msg caps = call t message_target msg caps
-                    method pp f = Fmt.pf f "far-ref(rc=%d) -> %a" ref_count P.pp_cap message_target
-                    method private release =
-                      Log.info (fun f -> f ~tags:t.tags "Sending release %t" self#pp);
-                      let id, count = P.Send.release t.p import in
-                      t.queue_send (`Release (id, count))
-
-                    method shortest = self
-                    method blocker = None   (* Can't detect cycles over the network *)
-                  end
-                in
-                register t cap message_target;
-                cap
-              )
-        | `None -> null
-        | `ReceiverAnswer _ -> failwith "TODO: from_cap_desc ReceiverAnswer"
-        | `ThirdPartyHosted _ -> failwith "TODO: from_cap_desc ThirdPartyHosted"
-        | `LocalPromise (p, i) -> p#cap i
-
-      let reply_to_disembargo t target embargo_id =
-        let target = P.Send.disembargo_reply t.p target in
-        Log.info (fun f -> f ~tags:t.tags "Sending disembargo response to %a" P.Out.pp_desc target);
-        t.queue_send (`Disembargo_reply (target, embargo_id))
-
-      let disembargo t request =
-        Log.info (fun f -> f ~tags:t.tags "Sending disembargo %a" P.Out.pp_disembargo_request request);
-        t.queue_send (`Disembargo_request request);
-    end
-
-    let bootstrap t =
-      let result = Self_proxy.make_remote_promise t in
-      let question, qid = P.Send.bootstrap t.p (result :> struct_resolver) in
+    let rec call t target msg caps =
+      let result = make_remote_promise t in
+      let con_caps = RO_array.map (to_cap_desc t) caps in
+      let question, qid, message_target, descs = P.Send.call t.p (result :> Core_types.struct_resolver) target con_caps in
+      Log.info (fun f -> f ~tags:(tags ~qid t) "Sending: (%a).call %a"
+                   P.pp_cap target
+                   Core_types.Request_payload.pp (msg, caps));
       result#set_question question;
-      Log.info (fun f -> f ~tags:(tags ~qid t) "Sending: bootstrap");
-      t.queue_send (`Bootstrap qid);
-      let service = result#cap Path.root in
-      result#finish;
-      service
+      t.queue_send (`Call (qid, message_target, msg, descs));
+      release_remote_caps caps con_caps;
+      (result :> Core_types.struct_ref)
 
-    let return_results t answer =
-      let aid, ret =
-        let answer_promise = P.answer_promise answer in
-        match answer_promise#response with
-        | None -> assert false
-        | Some (Ok (msg, caps)) ->
-          RO_array.iter (fun c -> c#inc_ref) caps;        (* Copy everything stored in [answer]. *)
-          let con_caps = RO_array.map (Self_proxy.to_cap_desc t) caps in
-          let aid, ret = P.Send.return_results t.p answer msg con_caps in
-          Log.info (fun f -> f ~tags:(tags ~aid t) "Returning results: %a"
-                       Response_payload.pp (msg, caps));
-          Self_proxy.release_remote_caps caps con_caps;
-          aid, ret
-        | Some (Error (`Exception msg)) ->
-          let aid, ret = P.Send.return_error t.p answer msg in
-          Log.info (fun f -> f ~tags:(tags ~aid t) "Returning error: %s" msg);
-          aid, ret
-        | Some (Error `Cancelled) ->
-          let aid, ret = P.Send.return_cancelled t.p answer in
-          Log.info (fun f -> f ~tags:(tags ~aid t) "Returning cancelled");
-          aid, ret
-      in
-      t.queue_send (`Return (aid, ret))
+    (* A cap that sends to a promised answer's cap at other *)
+    and make_remote_promise t =
+      object (self : #Core_types.struct_resolver)
+        inherit [target] Struct_proxy.t None as super
 
-    let reply_to_call t = function
-      | `Bootstrap answer ->
-        let promise = P.answer_promise answer in
-        begin match t.bootstrap with
-          | Some service ->
-            service#inc_ref;
-            promise#resolve (Ok (Response.bootstrap, RO_array.of_list [service]));
-          | None ->
-            promise#resolve (Error (`Exception "No bootstrap service available"));
-        end;
-        return_results t answer
-      | `Call (answer, target, msg, caps) ->
-        Log.info (fun f -> f ~tags:t.tags "Handling call: (%t).call %a" target#pp Request_payload.pp (msg, caps));
-        let resp = target#call msg caps in  (* Takes ownership of [caps]. *)
-        target#dec_ref;
-        (P.answer_promise answer)#connect resp;
-        resp#when_resolved (fun _ -> return_results t answer)
+        method do_pipeline question i msg caps =
+          match question with
+          | Some (target_q, _) ->
+            let target = `ReceiverAnswer (target_q, i) in
+            call t target msg caps
+          | None -> failwith "Not initialised!"
 
-    let handle_msg t = function
-      | `Bootstrap qid ->
-         let promise = Local_struct_promise.make () in
-         let answer = P.Input.bootstrap t.p qid ~answer:promise in
-         reply_to_call t (`Bootstrap answer)
-      | `Call (aid, message_target, msg, descs) ->
-        Log.info (fun f -> f ~tags:(tags ~aid t) "Received call to %a" P.In.pp_desc message_target);
-        let promise = Local_struct_promise.make () in
-        let answer, target, caps = P.Input.call t.p aid message_target descs ~allowThirdPartyTailCall:false `Caller ~answer:promise in
-        let target = Self_proxy.from_cap_desc t target in
-        let caps = RO_array.map (Self_proxy.from_cap_desc t) caps in
-        reply_to_call t (`Call (answer, target, msg, caps))
-      | `Return (qid, ret) ->
-         begin match ret with
-         | `Results (msg, descs) ->
-           let result, caps = P.Input.return_results t.p qid msg descs ~releaseParamCaps:false in
-           let from_cap_desc = function
-             | `LocalEmbargo (c, disembargo_request) ->
-               c#inc_ref;
-               Log.info (fun f -> f ~tags:t.tags "Embargo %t until %a is delivered"
-                            c#pp
-                            P.Out.pp_disembargo_request disembargo_request
-                        );
-               (* We previously pipelined messages to [qid, index], which now turns out to be
-                  local service [c]. We need to send a disembargo to clear the pipeline before
-                  using [c]. *)
-               let embargo = Cap_proxy.embargo c in
-               let `Loopback (_target, embargo_id) = disembargo_request in
-               Hashtbl.add t.embargoes embargo_id embargo;
-               Self_proxy.disembargo t disembargo_request;
-               (embargo :> cap)
-             | #P.recv_cap as x -> Self_proxy.from_cap_desc t x
-           in
-           let caps = RO_array.map from_cap_desc caps in
-           Log.info (fun f -> f ~tags:(tags ~qid t) "Got results: %a"
-                        Response_payload.pp (msg, caps)
-                    );
-           result#resolve (Ok (msg, caps))
-         | `Exception msg ->
-           let result = P.Input.return_exception t.p qid ~releaseParamCaps:false in
-           Log.info (fun f -> f ~tags:(tags ~qid t) "Got exception: %s" msg);
-           result#resolve (Error (`Exception msg))
-         | `Cancelled ->
-           let result = P.Input.return_cancelled t.p qid ~releaseParamCaps:false in
-           Log.info (fun f -> f ~tags:(tags ~qid t) "Got cancelled");
-           result#resolve (Error `Cancelled)
-         | _ -> failwith "TODO: other return"
-         end
-      | `Finish (aid, releaseResultCaps) ->
-        let answer = P.Input.finish t.p aid ~releaseResultCaps in
-        Log.info (fun f -> f ~tags:(tags ~aid t) "Received finish for %t" answer#pp);
-        answer#finish
-      | `Release (id, referenceCount) ->
-        P.Input.release t.p id ~referenceCount
-      | `Disembargo_request request ->
-        begin
-          Log.info (fun f -> f ~tags:t.tags "Received disembargo %a" P.In.pp_disembargo_request request);
-          match P.Input.disembargo_request t.p request with
-          | `ReturnToSender ((answer_promise, path), id) ->
-            match answer_promise#response with
-            | None -> failwith "Got disembargo for unresolved promise!"
-            | Some (Error _) -> failwith "Got disembargo for exception!"
-            | Some (Ok payload) ->
-              let cap = Response_payload.field payload path in
-              match unwrap t cap with
-              | Some (`ReceiverHosted _ | `ReceiverAnswer _ as target) -> Self_proxy.reply_to_disembargo t target id
-              | None -> failwith "Protocol error: disembargo for invalid target"
-        end
-      | `Disembargo_reply (target, embargo_id) ->
-        P.Input.disembargo_reply t.p target embargo_id;
-        let embargo =
-          try Hashtbl.find t.embargoes embargo_id
-          with Not_found -> failf "Unexpected disembargo ID %a" Protocol.EmbargoId.pp embargo_id
-        in
-        Hashtbl.remove t.embargoes embargo_id;
-        Log.info (fun f -> f ~tags:t.tags "Received disembargo response %a -> %t"
-                     P.In.pp_desc target
-                     embargo#pp);
-        embargo#disembargo
+        method on_resolve q _ =
+          match q with
+          | Some (_target_q, finish) -> Lazy.force finish
+          | None -> failwith "Not initialised!"
 
-    let pp_embargoes f xs =
-      let pp_item f (id, proxy) =
-        Fmt.pf f "%a: @[%t@]" Protocol.EmbargoId.pp id proxy#pp
-      in
-      let add k v acc = (k, v) :: acc in
-      let items = Hashtbl.fold add xs [] in
-      let items = List.sort compare items in
-      (Fmt.Dump.list pp_item) f items
+        method! pp f =
+          Fmt.pf f "remote-promise -> %a" (Struct_proxy.pp_state ~pp_promise) state
 
-    let dump f t =
-      Fmt.pf f "@[<v 2>CapTP state:@,%a@,@[<2>Embargos:@,%a@]@]" P.dump t.p pp_embargoes t.embargoes
+        method set_question q =
+          let finish = lazy (
+            let qid = P.Send.finish t.p q in
+            Log.info (fun f -> f ~tags:(tags ~qid t) "Send finish %t" self#pp);
+            t.queue_send (`Finish (qid, false));
+          ) in
+          self#update_target (Some (q, finish))
+
+        method! cap path =
+          let field = super#cap path in
+          begin match state with
+            | Unresolved u ->
+              begin match u.target with
+                | None -> failwith "Not intialised!"
+                | Some (target_q, _) ->
+                  register t field (`ReceiverAnswer (target_q, path));        (* TODO: unregister *)
+              end
+            | _ -> ()
+          end;
+          field
+
+        method do_finish = function
+          | Some (_, finish) -> Lazy.force finish
+          | None -> failwith "Not initialised!"
+      end
+
+    (* Turn a connection-scoped cap reference received from Other into a general-purpose
+       cap for users. If the resulting cap is remote, our wrapper forwards it to Other.
+       This will add a ref count to the cap if it already exists, or create a new
+       one with [ref_count = 1]. *)
+    let from_cap_desc t (desc:P.recv_cap) : Core_types.cap =
+      match desc with
+      | `Local c -> c#inc_ref; c
+      | `ReceiverHosted import as message_target ->
+        P.import_proxy import
+          ~inc_ref:(fun c -> c#inc_ref)
+          ~create:(fun () ->
+              let cap =
+                object (self : #Core_types.cap)
+                  inherit Core_types.ref_counted
+
+                  method call msg caps = call t message_target msg caps
+                  method pp f = Fmt.pf f "far-ref(rc=%d) -> %a" ref_count P.pp_cap message_target
+                  method private release =
+                    Log.info (fun f -> f ~tags:t.tags "Sending release %t" self#pp);
+                    let id, count = P.Send.release t.p import in
+                    t.queue_send (`Release (id, count))
+
+                  method shortest = self
+                  method blocker = None   (* Can't detect cycles over the network *)
+                end
+              in
+              register t cap message_target;
+              cap
+            )
+      | `None -> Core_types.null
+      | `ReceiverAnswer _ -> failwith "TODO: from_cap_desc ReceiverAnswer"
+      | `ThirdPartyHosted _ -> failwith "TODO: from_cap_desc ThirdPartyHosted"
+      | `LocalPromise (p, i) -> p#cap i
+
+    let reply_to_disembargo t target embargo_id =
+      let target = P.Send.disembargo_reply t.p target in
+      Log.info (fun f -> f ~tags:t.tags "Sending disembargo response to %a" EP.Out.pp_desc target);
+      t.queue_send (`Disembargo_reply (target, embargo_id))
+
+    let disembargo t request =
+      Log.info (fun f -> f ~tags:t.tags "Sending disembargo %a" EP.Out.pp_disembargo_request request);
+      t.queue_send (`Disembargo_request request);
   end
+
+  let bootstrap t =
+    let result = Self_proxy.make_remote_promise t in
+    let question, qid = P.Send.bootstrap t.p (result :> Core_types.struct_resolver) in
+    result#set_question question;
+    Log.info (fun f -> f ~tags:(tags ~qid t) "Sending: bootstrap");
+    t.queue_send (`Bootstrap qid);
+    let service = result#cap Wire.Path.root in
+    result#finish;
+    service
+
+  let return_results t answer =
+    let aid, ret =
+      let answer_promise = P.answer_promise answer in
+      match answer_promise#response with
+      | None -> assert false
+      | Some (Ok (msg, caps)) ->
+        RO_array.iter (fun c -> c#inc_ref) caps;        (* Copy everything stored in [answer]. *)
+        let con_caps = RO_array.map (Self_proxy.to_cap_desc t) caps in
+        let aid, ret = P.Send.return_results t.p answer msg con_caps in
+        Log.info (fun f -> f ~tags:(tags ~aid t) "Returning results: %a"
+                     Core_types.Response_payload.pp (msg, caps));
+        Self_proxy.release_remote_caps caps con_caps;
+        aid, ret
+      | Some (Error (`Exception msg)) ->
+        let aid, ret = P.Send.return_error t.p answer msg in
+        Log.info (fun f -> f ~tags:(tags ~aid t) "Returning error: %s" msg);
+        aid, ret
+      | Some (Error `Cancelled) ->
+        let aid, ret = P.Send.return_cancelled t.p answer in
+        Log.info (fun f -> f ~tags:(tags ~aid t) "Returning cancelled");
+        aid, ret
+    in
+    t.queue_send (`Return (aid, ret))
+
+  let reply_to_call t = function
+    | `Bootstrap answer ->
+      let promise = P.answer_promise answer in
+      begin match t.bootstrap with
+        | Some service ->
+          service#inc_ref;
+          promise#resolve (Ok (Wire.Response.bootstrap, RO_array.of_list [service]));
+        | None ->
+          promise#resolve (Error (`Exception "No bootstrap service available"));
+      end;
+      return_results t answer
+    | `Call (answer, target, msg, caps) ->
+      Log.info (fun f -> f ~tags:t.tags "Handling call: (%t).call %a" target#pp Core_types.Request_payload.pp (msg, caps));
+      let resp = target#call msg caps in  (* Takes ownership of [caps]. *)
+      target#dec_ref;
+      (P.answer_promise answer)#connect resp;
+      resp#when_resolved (fun _ -> return_results t answer)
+
+  let handle_msg t = function
+    | `Bootstrap qid ->
+       let promise = Local_struct_promise.make () in
+       let answer = P.Input.bootstrap t.p qid ~answer:promise in
+       reply_to_call t (`Bootstrap answer)
+    | `Call (aid, message_target, msg, descs) ->
+      Log.info (fun f -> f ~tags:(tags ~aid t) "Received call to %a" EP.In.pp_desc message_target);
+      let promise = Local_struct_promise.make () in
+      let answer, target, caps = P.Input.call t.p aid message_target descs ~allowThirdPartyTailCall:false `Caller ~answer:promise in
+      let target = Self_proxy.from_cap_desc t target in
+      let caps = RO_array.map (Self_proxy.from_cap_desc t) caps in
+      reply_to_call t (`Call (answer, target, msg, caps))
+    | `Return (qid, ret) ->
+       begin match ret with
+       | `Results (msg, descs) ->
+         let result, caps = P.Input.return_results t.p qid msg descs ~releaseParamCaps:false in
+         let from_cap_desc = function
+           | `LocalEmbargo (c, disembargo_request) ->
+             c#inc_ref;
+             Log.info (fun f -> f ~tags:t.tags "Embargo %t until %a is delivered"
+                          c#pp
+                          EP.Out.pp_disembargo_request disembargo_request
+                      );
+             (* We previously pipelined messages to [qid, index], which now turns out to be
+                local service [c]. We need to send a disembargo to clear the pipeline before
+                using [c]. *)
+             let embargo = Cap_proxy.embargo c in
+             let `Loopback (_target, embargo_id) = disembargo_request in
+             Hashtbl.add t.embargoes embargo_id embargo;
+             Self_proxy.disembargo t disembargo_request;
+             (embargo :> Core_types.cap)
+           | #P.recv_cap as x -> Self_proxy.from_cap_desc t x
+         in
+         let caps = RO_array.map from_cap_desc caps in
+         Log.info (fun f -> f ~tags:(tags ~qid t) "Got results: %a"
+                      Core_types.Response_payload.pp (msg, caps)
+                  );
+         result#resolve (Ok (msg, caps))
+       | `Exception msg ->
+         let result = P.Input.return_exception t.p qid ~releaseParamCaps:false in
+         Log.info (fun f -> f ~tags:(tags ~qid t) "Got exception: %s" msg);
+         result#resolve (Error (`Exception msg))
+       | `Cancelled ->
+         let result = P.Input.return_cancelled t.p qid ~releaseParamCaps:false in
+         Log.info (fun f -> f ~tags:(tags ~qid t) "Got cancelled");
+         result#resolve (Error `Cancelled)
+       | _ -> failwith "TODO: other return"
+       end
+    | `Finish (aid, releaseResultCaps) ->
+      let answer = P.Input.finish t.p aid ~releaseResultCaps in
+      Log.info (fun f -> f ~tags:(tags ~aid t) "Received finish for %t" answer#pp);
+      answer#finish
+    | `Release (id, referenceCount) ->
+      P.Input.release t.p id ~referenceCount
+    | `Disembargo_request request ->
+      begin
+        Log.info (fun f -> f ~tags:t.tags "Received disembargo %a" EP.In.pp_disembargo_request request);
+        match P.Input.disembargo_request t.p request with
+        | `ReturnToSender ((answer_promise, path), id) ->
+          match answer_promise#response with
+          | None -> failwith "Got disembargo for unresolved promise!"
+          | Some (Error _) -> failwith "Got disembargo for exception!"
+          | Some (Ok payload) ->
+            let cap = Core_types.Response_payload.field payload path in
+            match unwrap t cap with
+            | Some (`ReceiverHosted _ | `ReceiverAnswer _ as target) -> Self_proxy.reply_to_disembargo t target id
+            | None -> failwith "Protocol error: disembargo for invalid target"
+      end
+    | `Disembargo_reply (target, embargo_id) ->
+      P.Input.disembargo_reply t.p target embargo_id;
+      let embargo =
+        try Hashtbl.find t.embargoes embargo_id
+        with Not_found -> failf "Unexpected disembargo ID %a" EmbargoId.pp embargo_id
+      in
+      Hashtbl.remove t.embargoes embargo_id;
+      Log.info (fun f -> f ~tags:t.tags "Received disembargo response %a -> %t"
+                   EP.In.pp_desc target
+                   embargo#pp);
+      embargo#disembargo
+
+  let pp_embargoes f xs =
+    let pp_item f (id, proxy) =
+      Fmt.pf f "%a: @[%t@]" EmbargoId.pp id proxy#pp
+    in
+    let add k v acc = (k, v) :: acc in
+    let items = Hashtbl.fold add xs [] in
+    let items = List.sort compare items in
+    (Fmt.Dump.list pp_item) f items
+
+  let dump f t =
+    Fmt.pf f "@[<v 2>CapTP state:@,%a@,@[<2>Embargos:@,%a@]@]" P.dump t.p pp_embargoes t.embargoes
 end

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -10,7 +10,7 @@ module Make(C : S.CORE_TYPES) = struct
   end
 
   type cap_promise_state =
-    | Unresolved of (struct_resolver * Request.t * cap RO_array.t) Queue.t
+    | Unresolved of (struct_resolver * Wire.Request.t * cap RO_array.t) Queue.t
     | Resolved of cap
 
   class local_promise =

--- a/capnp-rpc/capnp_rpc.ml
+++ b/capnp-rpc/capnp_rpc.ml
@@ -4,11 +4,10 @@ module Stats = Stats
 module Id = Id
 module Debug = Debug
 module Error = Error
+module EmbargoId = Protocol.EmbargoId
+module Core_types(C : S.WIRE) = Core_types.Make(C)
+module Local_struct_promise = Local_struct_promise
+module Cap_proxy = Cap_proxy
 
-module Make (C : S.CONCRETE) (N : S.NETWORK_TYPES) = struct
-  module Core_types = Core_types.Make(C)
-  module Local_struct_promise = Local_struct_promise.Make(Core_types)
-  module Cap_proxy = Cap_proxy.Make(Core_types)
-  module Protocol = Protocol.Make(Core_types)(N)
-  module CapTP = CapTP.Make(Core_types)(N)
-end
+module Message_types = Message_types
+module CapTP = CapTP

--- a/capnp-rpc/capnp_rpc.mli
+++ b/capnp-rpc/capnp_rpc.mli
@@ -4,27 +4,28 @@ module Stats = Stats
 module Id = Id
 module Debug = Debug
 module Error = Error
+module EmbargoId = Protocol.EmbargoId
+module Message_types = Message_types
+module Core_types (W : S.WIRE) : S.CORE_TYPES with module Wire = W
+module Local_struct_promise = Local_struct_promise
+module Cap_proxy = Cap_proxy
 
-module Make (C : S.CONCRETE) (N : S.NETWORK_TYPES) : sig
-  module Core_types : module type of Core_types.Make(C)
-  module Protocol : module type of Protocol.Make(Core_types)(N)
-  module Local_struct_promise : module type of Local_struct_promise.Make(Core_types)
-  module Cap_proxy : module type of Cap_proxy.Make(Core_types)
-  module CapTP : sig
-    module Make (P : Protocol.S) : sig
-      type t
+module CapTP : sig
+  module Make (EP : Message_types.ENDPOINT) : sig
+    type t
 
-      val tags : ?qid:P.T.QuestionId.t -> ?aid:P.T.AnswerId.t -> t -> Logs.Tag.set
+    module P : module type of Protocol.Make(EP)
 
-      val bootstrap : t -> Core_types.cap
+    val tags : ?qid:EP.Out.QuestionId.t -> ?aid:EP.Out.AnswerId.t -> t -> Logs.Tag.set
 
-      val handle_msg : t -> P.In.t -> unit
+    val bootstrap : t -> EP.Core_types.cap
 
-      val stats : t -> Stats.t
+    val handle_msg : t -> EP.In.t -> unit
 
-      val create : ?bootstrap:Core_types.cap -> tags:Logs.Tag.set -> queue_send:(P.Out.t -> unit) -> t
+    val stats : t -> Stats.t
 
-      val dump : t Fmt.t
-    end
+    val create : ?bootstrap:EP.Core_types.cap -> tags:Logs.Tag.set -> queue_send:(EP.Out.t -> unit) -> t
+
+    val dump : t Fmt.t
   end
 end

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -1,5 +1,7 @@
-module Make(C : S.CONCRETE) = struct
-  include  C
+module Make(Wire : S.WIRE) = struct
+  module Wire = Wire
+
+  open Wire
 
   type 'a or_error = ('a, Error.t) result
 
@@ -7,6 +9,8 @@ module Make(C : S.CONCRETE) = struct
     method pp : Format.formatter -> unit
     method blocker : base_ref option
   end
+
+  let pp f x = x#pp f
 
   class type struct_ref = object
     inherit base_ref
@@ -29,8 +33,7 @@ module Make(C : S.CONCRETE) = struct
     method connect : struct_ref -> unit
   end
 
-  let pp_cap f x = x#pp f
-  let pp_cap_list f caps = RO_array.pp pp_cap f caps
+  let pp_cap_list f caps = RO_array.pp pp f caps
 
   class virtual ref_counted = object (self)
     val mutable ref_count = 1

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -11,7 +11,7 @@ module Make (C : S.CORE_TYPES) = struct
     method private do_pipeline q i msg caps =
       let result = local_promise ~parent:self () in
       q |> Queue.add (fun p ->
-          Logs.info (fun f -> f "%d:%a forwarding %t" id Path.pp i p#pp);
+          Logs.info (fun f -> f "%d:%a forwarding %t" id Wire.Path.pp i p#pp);
           result#connect ((p#cap i)#call msg caps)      (* XXX: dec_ref? *)
         );
       (result :> struct_ref)

--- a/capnp-rpc/message_types.ml
+++ b/capnp-rpc/message_types.ml
@@ -1,0 +1,127 @@
+(* This module defines the information in the messages that goes over the wire.
+   These messages are turned into actual byte streams elsewhere.
+*)
+
+module EmbargoId = Id.Make ( )
+
+module type TABLE_TYPES = sig
+  (** For the unit tests it is convenient to pass in the types of table indexes.
+      This allows the tests to make both ends of a connection, with the types
+      matched up. *)
+
+  module QuestionId : Id.S
+  module AnswerId : Id.S
+  module ImportId : Id.S
+  module ExportId : Id.S
+end
+
+module Flip (T : TABLE_TYPES) = struct
+  (* [Flip T] is the types for the other end of [T]'s connection. *)
+
+  module QuestionId = T.AnswerId
+  module AnswerId = T.QuestionId
+  module ImportId = T.ExportId
+  module ExportId = T.ImportId
+end
+
+module Make (Network : S.NETWORK_TYPES) (T : TABLE_TYPES) = struct
+  (* This module defines the information in the messages that goes over the wire in one direction.
+     The types are from the point of view of the sender, as in the Cap'n Proto RPC specification. *)
+
+  open Network
+  open Network.Wire
+
+  include T
+
+  type third_party_desc = third_party_cap_id * ExportId.t
+
+  type message_target = [
+    | `ReceiverHosted of ImportId.t
+    | `ReceiverAnswer of QuestionId.t * Wire.Path.t
+  ]
+
+  type desc = [
+    message_target
+    | `None
+    | `SenderHosted of ExportId.t
+    | `SenderPromise of ExportId.t
+    | `ThirdPartyHosted of third_party_desc
+  ]
+
+  let pp_desc f = function
+    | `None                  -> Fmt.pf f "None"
+    | `Local local           -> Fmt.pf f "Local:%t" local#pp
+    | `ReceiverAnswer (x, p) -> Fmt.pf f "ReceiverAnswer:%a:%a" QuestionId.pp x Path.pp p
+    | `ReceiverHosted x      -> Fmt.pf f "ReceiverHosted:%a" ImportId.pp x
+    | `ThirdPartyHosted _    -> Fmt.pf f "ThirdPartyHosted"
+    | `SenderHosted x        -> Fmt.pf f "SenderHosted:%a" ExportId.pp x
+    | `SenderPromise x       -> Fmt.pf f "SenderPromise:%a" ExportId.pp x
+
+  type sendResultsTo = [
+    | `Caller
+    | `Yourself
+    | `ThirdParty of recipient_id
+  ]
+
+  type return = [
+    | `Results of Response.t * desc RO_array.t
+    | `Exception of string
+    | `Cancelled
+    | `ResultsSentElsewhere
+    | `TakeFromOtherQuestion
+    | `AcceptFromThirdParty
+  ]
+
+  type disembargo_request = [
+    | `Loopback of (QuestionId.t * Path.t) * EmbargoId.t
+  ]
+
+  let pp_return f = function
+    | `Results descrs -> Fmt.pf f "Results:%a" (Fmt.Dump.list pp_desc) descrs
+    | `Exception msg -> Fmt.pf f "Exception:%s" msg
+    | `Cancelled -> Fmt.pf f "Cancelled"
+    | `ResultsSentElsewhere -> Fmt.pf f "ResultsSentElsewhere"
+    | `TakeFromOtherQuestion -> Fmt.pf f "TakeFromOtherQuestion"
+    | `AcceptFromThirdParty -> Fmt.pf f "AcceptFromThirdParty"
+
+  let pp_disembargo_request : disembargo_request Fmt.t = fun f -> function
+    | `Loopback ((qid, p), id) -> Fmt.pf f "senderLoopback for question %a:%a (embargo_id = %a)"
+                                  QuestionId.pp qid Path.pp p
+                                  EmbargoId.pp id;
+
+  type t = [
+    | `Bootstrap of QuestionId.t
+    | `Call of QuestionId.t * message_target * Request.t * desc RO_array.t
+    | `Finish of (QuestionId.t * bool)      (* bool is release-caps *)
+    | `Release of ImportId.t * int
+    | `Disembargo_request of disembargo_request
+    | `Disembargo_reply of message_target * EmbargoId.t
+    | `Return of (AnswerId.t * return)
+  ]
+  (** A message sent over the network. *)
+end
+
+module type ENDPOINT = sig
+  module Core_types : S.NETWORK_TYPES
+  module Table : TABLE_TYPES
+
+  module Out : module type of Make(Core_types)(Table)
+  (** The type of messages sent by this endpoint. *)
+
+  module In : module type of Make(Core_types)(Flip(Table))
+  (** The type of messages received by this endpoint. *)
+end
+
+module Endpoint (Core_types : S.NETWORK_TYPES) ( ) = struct
+  module Core_types = Core_types
+
+  module Table = struct
+    module QuestionId = Id.Make ( )
+    module AnswerId = Id.Make ( )
+    module ImportId = Id.Make ( )
+    module ExportId = Id.Make ( )
+  end
+
+  module Out = Make(Core_types)(Table)
+  module In = Make(Core_types)(Flip(Table))
+end

--- a/capnp-rpc/protocol.ml
+++ b/capnp-rpc/protocol.ml
@@ -2,9 +2,9 @@ module Log = Debug.Log
 
 open Asetmap
 
-module IntMap = Map.Make(struct type t = int let compare (a:int) b = compare a b end)
+module EmbargoId = Message_types.EmbargoId
 
-module EmbargoId = Id.Make ( )
+module IntMap = Map.Make(struct type t = int let compare (a:int) b = compare a b end)
 
 let rec filter_map f = function
   | [] -> []
@@ -13,103 +13,16 @@ let rec filter_map f = function
     | None -> filter_map f xs
     | Some y -> y :: filter_map f xs
 
-module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
+module Make (EP: Message_types.ENDPOINT) = struct
+  module C = EP.Core_types
+  module Wire = EP.Core_types.Wire
+  module In = EP.In
+  module Out = EP.Out
 
-  module PathSet = Set.Make(C.Path)
-  module EmbargoId = EmbargoId
-  module Embargoes = Table.Allocating(EmbargoId)
-
-  type ('third, 'export) generic_third_party_desc = {
-    id : 'third;
-    vine_id : 'export;
-  }
-
-  module MessageTypes (T : S.TABLE_TYPES) = struct
-    module  N = N
-    include T
-
-    type third_party_desc = (N.third_party_cap_id, T.ExportId.t) generic_third_party_desc
-
-    type message_target = [
-      | `ReceiverHosted of T.ImportId.t
-      | `ReceiverAnswer of T.QuestionId.t * C.Path.t
-    ]
-
-    type desc = [
-      message_target
-      | `None
-      | `SenderHosted of T.ExportId.t
-      | `SenderPromise of T.ExportId.t
-      | `ThirdPartyHosted of third_party_desc
-    ]
-
-    let pp_desc f = function
-      | `None                  -> Fmt.pf f "None"
-      | `Local local           -> Fmt.pf f "Local:%t" local#pp
-      | `ReceiverAnswer (x, p) -> Fmt.pf f "ReceiverAnswer:%a:%a" T.QuestionId.pp x C.Path.pp p
-      | `ReceiverHosted x      -> Fmt.pf f "ReceiverHosted:%a" T.ImportId.pp x
-      | `ThirdPartyHosted _    -> Fmt.pf f "ThirdPartyHosted"
-      | `SenderHosted x        -> Fmt.pf f "SenderHosted:%a" T.ExportId.pp x
-      | `SenderPromise x       -> Fmt.pf f "SenderPromise:%a" T.ExportId.pp x
-
-    type sendResultsTo = [
-      | `Caller
-      | `Yourself
-      | `ThirdParty of N.recipient_id
-    ]
-
-    type return = [
-      | `Results of C.Response.t * desc RO_array.t
-      | `Exception of string
-      | `Cancelled
-      | `ResultsSentElsewhere
-      | `TakeFromOtherQuestion
-      | `AcceptFromThirdParty
-    ]
-
-    type disembargo_request = [
-      | `Loopback of (QuestionId.t * C.Path.t) * EmbargoId.t
-    ]
-
-    let pp_return f = function
-      | `Results descrs -> Fmt.pf f "Results:%a" (Fmt.Dump.list pp_desc) descrs
-      | `Exception msg -> Fmt.pf f "Exception:%s" msg
-      | `Cancelled -> Fmt.pf f "Cancelled"
-      | `ResultsSentElsewhere -> Fmt.pf f "ResultsSentElsewhere"
-      | `TakeFromOtherQuestion -> Fmt.pf f "TakeFromOtherQuestion"
-      | `AcceptFromThirdParty -> Fmt.pf f "AcceptFromThirdParty"
-
-    let pp_disembargo_request : disembargo_request Fmt.t = fun f -> function
-      | `Loopback ((qid, p), id) -> Fmt.pf f "senderLoopback for question %a:%a (embargo_id = %a)"
-                                    QuestionId.pp qid C.Path.pp p
-                                    EmbargoId.pp id;
-
-    type t = [
-      | `Bootstrap of T.QuestionId.t
-      | `Call of T.QuestionId.t * message_target * C.Request.t * desc RO_array.t
-      | `Finish of (T.QuestionId.t * bool)      (* bool is release-caps *)
-      | `Release of T.ImportId.t * int
-      | `Disembargo_request of disembargo_request
-      | `Disembargo_reply of message_target * EmbargoId.t
-      | `Return of (T.AnswerId.t * return)
-    ]
-  end
+  open EP.Table
 
   module type S = sig
     type t
-
-    module T : S.TABLE_TYPES
-
-    module Out : (module type of MessageTypes(T))
-    (** Types for messages we send. *)
-
-    module In : module type of MessageTypes(struct
-        module QuestionId = T.AnswerId
-        module AnswerId = T.QuestionId
-        module ImportId = T.ExportId
-        module ExportId = T.ImportId
-      end)
-    (** Types for messages we receive. *)
 
     type question
     type answer
@@ -118,7 +31,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
 
     type message_target_cap = [
       | `ReceiverHosted of import
-      | `ReceiverAnswer of question * C.Path.t
+      | `ReceiverAnswer of question * Wire.Path.t
     ]
 
     type cap = [
@@ -135,7 +48,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
       | `None
       | `ThirdPartyHosted of Out.third_party_desc
       | `Local of C.cap
-      | `LocalPromise of C.struct_resolver * C.Path.t
+      | `LocalPromise of C.struct_resolver * Wire.Path.t
     ]
 
     type recv_cap_with_embargo = [
@@ -161,7 +74,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
         In.sendResultsTo -> answer:C.struct_resolver ->
         answer * recv_cap * recv_cap RO_array.t
       val bootstrap : t -> In.QuestionId.t -> answer:C.struct_resolver -> answer
-      val return_results : t -> In.AnswerId.t -> releaseParamCaps:bool -> C.Response.t -> In.desc RO_array.t -> C.struct_resolver * recv_cap_with_embargo RO_array.t
+      val return_results : t -> In.AnswerId.t -> releaseParamCaps:bool -> Wire.Response.t -> In.desc RO_array.t -> C.struct_resolver * recv_cap_with_embargo RO_array.t
       val return_cancelled : t -> In.AnswerId.t -> releaseParamCaps:bool -> C.struct_resolver
       val return_exception : t -> In.AnswerId.t -> releaseParamCaps:bool -> C.struct_resolver
 
@@ -171,11 +84,11 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
       val resolve : t -> In.ExportId.t -> [`Cap of In.desc | `Exception] -> unit
       val release : t -> In.ImportId.t -> referenceCount:int -> unit
       val disembargo_request : t -> In.disembargo_request ->
-        [ `ReturnToSender of (C.struct_resolver * C.Path.t) * EmbargoId.t]
+        [ `ReturnToSender of (C.struct_resolver * Wire.Path.t) * EmbargoId.t]
       val disembargo_reply : t -> In.message_target -> EmbargoId.t -> unit
-      val provide : t -> In.QuestionId.t -> In.message_target -> N.recipient_id -> unit
-      val accept : t -> In.QuestionId.t -> N.provision_id -> embargo:bool -> unit
-      val join : t -> In.QuestionId.t -> In.message_target -> N.join_key_part -> unit
+      val provide : t -> In.QuestionId.t -> In.message_target -> C.recipient_id -> unit
+      val accept : t -> In.QuestionId.t -> C.provision_id -> embargo:bool -> unit
+      val join : t -> In.QuestionId.t -> In.message_target -> C.join_key_part -> unit
     end
 
     module Send : sig
@@ -183,7 +96,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
       val call : t -> C.struct_resolver -> message_target_cap -> [< cap] RO_array.t ->
         question * Out.QuestionId.t * Out.message_target * Out.desc RO_array.t
 
-      val return_results : t -> answer -> C.Response.t -> [< cap] RO_array.t -> Out.AnswerId.t * Out.return
+      val return_results : t -> answer -> Wire.Response.t -> [< cap] RO_array.t -> Out.AnswerId.t * Out.return
       val return_error : t -> answer -> string -> Out.AnswerId.t * Out.return
       val return_cancelled : t -> answer -> Out.AnswerId.t * Out.return
 
@@ -204,405 +117,395 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
     val pp_question : question Fmt.t
   end
 
-  module Make (T : S.TABLE_TYPES) : S with module T = T = struct
-    module T = T
+  module PathSet = Set.Make(Wire.Path)
+  module Embargoes = Table.Allocating(EmbargoId)
 
-    module Questions = Table.Allocating(T.QuestionId)
-    module Answers = Table.Tracking(T.AnswerId)
-    module Exports = Table.Allocating(T.ExportId)
-    module Imports = Table.Tracking(T.ImportId)
+  module Questions = Table.Allocating(QuestionId)
+  module Answers = Table.Tracking(AnswerId)
+  module Exports = Table.Allocating(ExportId)
+  module Imports = Table.Tracking(ImportId)
 
-    module Out = MessageTypes(T)
+  type question = {
+    question_id : QuestionId.t;
+    question_data : C.struct_resolver;
+    mutable question_flags : int;
+    mutable params_for_release : ExportId.t list;
+    mutable question_pipelined_fields : PathSet.t; (* Fields used while unresolved; will need embargoes *)
+  }
 
-    module In = MessageTypes(struct
-        module QuestionId = T.AnswerId
-        module AnswerId = T.QuestionId
-        module ImportId = T.ExportId
-        module ExportId = T.ImportId
-      end)
+  type answer = {
+    answer_id : AnswerId.t;
+    mutable exports_for_release : ExportId.t list;
+    answer_promise : C.struct_resolver;
+    mutable finished : bool;
+  }
 
-    type question = {
-      question_id : T.QuestionId.t;
-      question_data : C.struct_resolver;
-      mutable question_flags : int;
-      mutable params_for_release : T.ExportId.t list;
-      mutable question_pipelined_fields : PathSet.t; (* Fields used while unresolved; will need embargoes *)
+  let flag_returned = 1
+  let flag_finished = 2
+
+  type export = {
+    export_id : ExportId.t;
+    mutable export_count : int; (* Number of times sent to remote and not yet released *)
+    export_service : C.cap;
+  }
+
+  type import = {
+    import_id : ImportId.t;
+    mutable import_count : int; (* Number of times remote sent us this *)
+    mutable import_proxy : C.cap option;
+  }
+
+  type message_target_cap = [
+    | `ReceiverHosted of import
+    | `ReceiverAnswer of question * Wire.Path.t
+  ]
+
+  type cap = [
+    message_target_cap
+    | `None
+    | `SenderHosted of export
+    | `SenderPromise of export
+    | `ThirdPartyHosted of Out.third_party_desc
+    | `Local of C.cap
+  ]
+
+  type recv_cap = [
+    message_target_cap
+    | `None
+    | `ThirdPartyHosted of Out.third_party_desc
+    | `Local of C.cap
+    | `LocalPromise of C.struct_resolver * Wire.Path.t
+  ]
+
+  type recv_cap_with_embargo = [
+    recv_cap
+    | `LocalEmbargo of C.cap * Out.disembargo_request   (* Send a Disembargo, and queue messages until it returns *)
+  ]
+
+  let pp_cap : [< cap | recv_cap_with_embargo] Fmt.t = fun f -> function
+    | `None -> Fmt.pf f "null"
+    | `ReceiverHosted import -> Fmt.pf f "ReceiverHosted:%a" ImportId.pp import.import_id
+    | `ReceiverAnswer (question, p) -> Fmt.pf f "ReceiverAnswer:%a[%a]" QuestionId.pp question.question_id Wire.Path.pp p
+    | `ThirdPartyHosted _third_party_desc -> Fmt.pf f "ThirdPartyHosted"
+    | `SenderHosted export -> Fmt.pf f "SenderHosted:%a" ExportId.pp export.export_id
+    | `SenderPromise export -> Fmt.pf f "SenderPromise:%a" ExportId.pp export.export_id
+    | `Local local -> Fmt.pf f "Local:%t" local#pp
+    | `LocalPromise (_promise, path) -> Fmt.pf f "LocalPromise:<p>%a" Wire.Path.pp path
+    | `LocalEmbargo (local_service, req) -> Fmt.pf f "LocalEmbargo:%t:%a" local_service#pp Out.pp_disembargo_request req
+
+  type t = {
+    tags : Logs.Tag.set;
+    questions : question Questions.t;
+    answers : answer Answers.t;
+    exports : export Exports.t;
+    imports : import Imports.t;
+    embargoes : EmbargoId.t Embargoes.t;
+    wrapper : (C.cap, ExportId.t) Hashtbl.t;
+  }
+
+  let create ~tags () =
+    {
+      tags;
+      questions = Questions.make ();
+      answers = Answers.make ();
+      imports = Imports.make ();
+      exports = Exports.make ();
+      embargoes = Embargoes.make ();
+      wrapper = Hashtbl.create 30;
     }
 
-    type answer = {
-      answer_id : T.AnswerId.t;
-      mutable exports_for_release : T.ExportId.t list;
-      answer_promise : C.struct_resolver;
-      mutable finished : bool;
-    }
+  let pp_question f q =
+    Fmt.pf f "q%a" QuestionId.pp q.question_id
 
-    let flag_returned = 1
-    let flag_finished = 2
+  let dump_question f q =
+    Fmt.pf f "%t" q.question_data#pp
 
-    type export = {
-      export_id : T.ExportId.t;
-      mutable export_count : int; (* Number of times sent to remote and not yet released *)
-      export_service : C.cap;
-    }
+  let dump_answer f x =
+    Fmt.pf f "%t" x.answer_promise#pp
 
-    type import = {
-      import_id : T.ImportId.t;
-      mutable import_count : int; (* Number of times remote sent us this *)
-      mutable import_proxy : C.cap option;
-    }
+  let dump_export f x =
+    Fmt.pf f "%t" x.export_service#pp
 
-    type message_target_cap = [
-      | `ReceiverHosted of import
-      | `ReceiverAnswer of question * C.Path.t
-    ]
+  let dump_import f _x =
+    Fmt.pf f "import"
 
-    type cap = [
-      message_target_cap
-      | `None
-      | `SenderHosted of export
-      | `SenderPromise of export
-      | `ThirdPartyHosted of Out.third_party_desc
-      | `Local of C.cap
-    ]
+  let dump f t =
+    Fmt.pf f "@[<2>Questions:@,%a@]@,\
+              @[<2>Answers:@,%a@]@,\
+              @[<2>Exports:@,%a@]@,\
+              @[<2>Imports:@,%a@]"
+      (Questions.dump dump_question) t.questions
+      (Answers.dump dump_answer) t.answers
+      (Exports.dump dump_export) t.exports
+      (Imports.dump dump_import) t.imports
 
-    type recv_cap = [
-      message_target_cap
-      | `None
-      | `ThirdPartyHosted of Out.third_party_desc
-      | `Local of C.cap
-      | `LocalPromise of C.struct_resolver * C.Path.t
-    ]
+  let maybe_release_question t question =
+    if question.question_flags - flag_returned - flag_finished = 0 then (
+      Questions.release t.questions question.question_id
+    )
 
-    type recv_cap_with_embargo = [
-      recv_cap
-      | `LocalEmbargo of C.cap * Out.disembargo_request   (* Send a Disembargo, and queue messages until it returns *)
-    ]
+  (** [export t target] is a descriptor for [target], plus a list of exports that
+      should be freed if we get a request to free all capabilities associated with
+      the request. *)
+  let export t : [< cap] -> Out.desc * ExportId.t list = function
+    | `ReceiverHosted import ->
+      (* Any ref-counting needed here? *)
+      `ReceiverHosted import.import_id, []
+    | `ReceiverAnswer (question, i) ->
+      `ReceiverAnswer (question.question_id, i), []
+    | `ThirdPartyHosted _ |`None |`SenderHosted _|`SenderPromise _ -> failwith "TODO: export"
+    | `Local service ->
+      match Hashtbl.find t.wrapper service with
+      | id ->
+        let export = Exports.find_exn t.exports id in
+        export.export_count <- export.export_count + 1;
+        `SenderHosted id, [id]
+      | exception Not_found ->
+        let export = Exports.alloc t.exports (fun export_id ->
+            { export_count = 1; export_service = service; export_id }
+          )
+        in
+        let id = export.export_id in
+        Hashtbl.add t.wrapper service id;
+        `SenderHosted id, [id]
 
-    let pp_cap : [< cap | recv_cap_with_embargo] Fmt.t = fun f -> function
-      | `None -> Fmt.pf f "null"
-      | `ReceiverHosted import -> Fmt.pf f "ReceiverHosted:%a" T.ImportId.pp import.import_id
-      | `ReceiverAnswer (question, p) -> Fmt.pf f "ReceiverAnswer:%a[%a]" T.QuestionId.pp question.question_id C.Path.pp p
-      | `ThirdPartyHosted _third_party_desc -> Fmt.pf f "ThirdPartyHosted"
-      | `SenderHosted export -> Fmt.pf f "SenderHosted:%a" T.ExportId.pp export.export_id
-      | `SenderPromise export -> Fmt.pf f "SenderPromise:%a" T.ExportId.pp export.export_id
-      | `Local local -> Fmt.pf f "Local:%t" local#pp
-      | `LocalPromise (_promise, path) -> Fmt.pf f "LocalPromise:<p>%a" C.Path.pp path
-      | `LocalEmbargo (local_service, req) -> Fmt.pf f "LocalEmbargo:%t:%a" local_service#pp Out.pp_disembargo_request req
 
-    type t = {
-      tags : Logs.Tag.set;
-      questions : question Questions.t;
-      answers : answer Answers.t;
-      exports : export Exports.t;
-      imports : import Imports.t;
-      embargoes : EmbargoId.t Embargoes.t;
-      wrapper : (C.cap, T.ExportId.t) Hashtbl.t;
-    }
+  let import t = function
+    | `SenderHosted id ->
+      (* Spec says this is "newly exported", so how does the remote indicate an existing, settled export? *)
+      begin match Imports.find t.imports id with
+        | Some import ->
+          import.import_count <- import.import_count + 1;
+          `ReceiverHosted import
+        | None ->
+          let import = { import_count = 1; import_id = id; import_proxy = None } in
+          Imports.set t.imports id import;
+          `ReceiverHosted import
+      end
+    | `ReceiverHosted id ->
+      let export = Exports.find_exn t.exports id in
+      `Export export
+    | `ReceiverAnswer (id, path) ->
+      let answer = Answers.find_exn t.answers id in
+      `Answer (answer, path)
+    | _ -> failwith "TODO: import"
 
-    let create ~tags () =
-      {
-        tags;
-        questions = Questions.make ();
-        answers = Answers.make ();
-        imports = Imports.make ();
-        exports = Exports.make ();
-        embargoes = Embargoes.make ();
-        wrapper = Hashtbl.create 30;
-      }
+  let import_simple t desc : [> recv_cap] =
+    match import t desc with
+    | `Export e -> `Local e.export_service
+    | `Answer (answer, path) -> `Local (answer.answer_promise#cap path)
+    | #recv_cap as x -> x
 
-    let pp_question f q =
-      Fmt.pf f "q%a" T.QuestionId.pp q.question_id
+  let answer_promise answer = answer.answer_promise
 
-    let dump_question f q =
-      Fmt.pf f "%t" q.question_data#pp
+  let import_proxy import ~create ~inc_ref =
+    match import.import_proxy with
+    | Some p -> inc_ref p; p
+    | None ->
+      let p = create () in
+      import.import_proxy <- Some p;
+      p
 
-    let dump_answer f x =
-      Fmt.pf f "%t" x.answer_promise#pp
+  module Input = struct
+    let call t id (message_target : In.message_target) ~allowThirdPartyTailCall descrs sendResultsTo ~answer =
+      ignore allowThirdPartyTailCall; (* TODO *)
+      ignore sendResultsTo; (* TODO *)
+      let answer = {
+        answer_id = id;
+        exports_for_release = [];
+        answer_promise = answer;
+        finished = false;
+      } in
+      Answers.set t.answers id answer;
+      let target : recv_cap =
+        match message_target with
+        | `ReceiverHosted id ->
+          let export = Exports.find_exn t.exports id in
+          `Local export.export_service
+        | `ReceiverAnswer (id, path) ->
+          let answer = Answers.find_exn t.answers id in
+          `LocalPromise (answer.answer_promise, path)
+      in
+      let caps = RO_array.map (import_simple t) descrs in
+      answer, target, caps
 
-    let dump_export f x =
-      Fmt.pf f "%t" x.export_service#pp
+    let bootstrap t id ~answer =
+      let answer = {
+        answer_id = id;
+        exports_for_release = [];
+        answer_promise = answer;
+        finished = false;
+      } in
+      Answers.set t.answers id answer;
+      answer
 
-    let dump_import f _x =
-      Fmt.pf f "import"
+    let return_generic t id ~releaseParamCaps =
+      ignore releaseParamCaps; (* TODO *)
+      let question = Questions.find_exn t.questions id in
+      let flags = question.question_flags in
+      assert (flags land flag_returned = 0);
+      let flags = flags + flag_returned in
+      question.question_flags <- flags;
+      maybe_release_question t question;
+      question
 
-    let dump f t =
-      Fmt.pf f "@[<2>Questions:@,%a@]@,\
-                @[<2>Answers:@,%a@]@,\
-                @[<2>Exports:@,%a@]@,\
-                @[<2>Imports:@,%a@]"
-        (Questions.dump dump_question) t.questions
-        (Answers.dump dump_answer) t.answers
-        (Exports.dump dump_export) t.exports
-        (Imports.dump dump_import) t.imports
+    let return_cancelled t id ~releaseParamCaps =
+      let question = return_generic t id ~releaseParamCaps in
+      question.question_data
 
-    let maybe_release_question t question =
-      if question.question_flags - flag_returned - flag_finished = 0 then (
-        Questions.release t.questions question.question_id
+    let return_exception t id ~releaseParamCaps =
+      let question = return_generic t id ~releaseParamCaps in
+      question.question_data
+
+    let service = function
+      | `Export e -> e.export_service
+      | `Answer (answer, path) -> answer.answer_promise#cap path
+
+    let return_results t id ~releaseParamCaps msg descrs : C.struct_resolver * recv_cap_with_embargo RO_array.t =
+      let question = return_generic t id ~releaseParamCaps in
+      let caps_used = (* Maps used cap indexes to their paths *)
+        PathSet.elements question.question_pipelined_fields
+        |> filter_map (fun path ->
+            match Wire.Response.cap_index msg path with
+            | None -> None
+            | Some i -> Some (i, path)
+          )
+        |> IntMap.of_list
+      in
+      let import_with_embargo i d =
+        match import t d with
+        | #recv_cap as x -> x
+        | `Export _ | `Answer _ as x ->
+          match IntMap.find i caps_used with
+          | None -> `Local (service x)        (* Not used, so no embargo needed *)
+          | Some path ->
+            let cap = service x in
+            let embargo_id = Embargoes.alloc t.embargoes (fun id -> id) in
+            `LocalEmbargo (cap, `Loopback ((id, path), embargo_id))
+      in
+      let caps = RO_array.mapi import_with_embargo descrs in
+      question.question_data, caps
+
+    let resolve _t _export_id = function
+      | `Cap _desc -> ()
+      | `Exception -> ()
+
+    let release t export_id ~referenceCount =
+      assert (referenceCount > 0);
+      let export = Exports.find_exn t.exports export_id in
+      assert (export.export_count >= referenceCount);
+      let count = export.export_count - referenceCount in
+      export.export_count <- count;
+      if count = 0 then (
+        Log.info (fun f -> f ~tags:t.tags "Releasing export %a" ExportId.pp export_id);
+        Hashtbl.remove t.wrapper export.export_service;
+        Exports.release t.exports export_id
       )
 
-    (** [export t target] is a descriptor for [target], plus a list of exports that
-        should be freed if we get a request to free all capabilities associated with
-        the request. *)
-    let export t : [< cap] -> Out.desc * T.ExportId.t list = function
-      | `ReceiverHosted import ->
-        (* Any ref-counting needed here? *)
-        `ReceiverHosted import.import_id, []
-      | `ReceiverAnswer (question, i) ->
-        `ReceiverAnswer (question.question_id, i), []
-      | `ThirdPartyHosted _ |`None |`SenderHosted _|`SenderPromise _ -> failwith "TODO: export"
-      | `Local service ->
-        match Hashtbl.find t.wrapper service with
-        | id ->
-          let export = Exports.find_exn t.exports id in
-          export.export_count <- export.export_count + 1;
-          `SenderHosted id, [id]
-        | exception Not_found ->
-          let export = Exports.alloc t.exports (fun export_id ->
-              { export_count = 1; export_service = service; export_id }
-            )
-          in
-          let id = export.export_id in
-          Hashtbl.add t.wrapper service id;
-          `SenderHosted id, [id]
+    let finish t answer_id ~releaseResultCaps =
+      let answer = Answers.find_exn t.answers answer_id in
+      answer.finished <- true;
+      Answers.release t.answers answer_id;
+      if releaseResultCaps then (
+        (* This is very unclear. It says "all capabilities that were in the
+           results should be considered released". However, only imports can
+           be released, not capabilities in general.
+           Also, assuming we decrement the ref count by one in this case. *)
+        List.iter (release t ~referenceCount:1) answer.exports_for_release
+      );
+      answer.answer_promise
 
+    let disembargo_request t : In.disembargo_request -> _ = function
+      | `Loopback ((aid, i), id) ->
+        let answer = Answers.find_exn t.answers aid in
+        (* Check that [answer:i] points back at sender. *)
+        (* TODO: move the struct_ref logic here so we can do the check here? *)
+        `ReturnToSender ((answer.answer_promise, i), id)
 
-    let import t = function
-      | `SenderHosted id ->
-        (* Spec says this is "newly exported", so how does the remote indicate an existing, settled export? *)
-        begin match Imports.find t.imports id with
-          | Some import ->
-            import.import_count <- import.import_count + 1;
-            `ReceiverHosted import
-          | None ->
-            let import = { import_count = 1; import_id = id; import_proxy = None } in
-            Imports.set t.imports id import;
-            `ReceiverHosted import
-        end
-      | `ReceiverHosted id ->
-        let export = Exports.find_exn t.exports id in
-        `Export export
-      | `ReceiverAnswer (id, path) ->
-        let answer = Answers.find_exn t.answers id in
-        `Answer (answer, path)
-      | _ -> failwith "TODO: import"
+    let disembargo_reply t _target embargo_id =
+      Embargoes.release t.embargoes embargo_id
 
-    let import_simple t desc : [> recv_cap] =
-      match import t desc with
-      | `Export e -> `Local e.export_service
-      | `Answer (answer, path) -> `Local (answer.answer_promise#cap path)
-      | #recv_cap as x -> x
+    let provide _t _question_id _message_target _recipient_id = ()
+    let accept _t _question_id _provision_id ~embargo:_ = ()
+    let join _t _question_id _message_target _join_key_part = ()
+  end
 
-    let answer_promise answer = answer.answer_promise
-
-    let import_proxy import ~create ~inc_ref =
-      match import.import_proxy with
-      | Some p -> inc_ref p; p
-      | None ->
-        let p = create () in
-        import.import_proxy <- Some p;
-        p
-
-    module Input = struct
-      let call t id (message_target : In.message_target) ~allowThirdPartyTailCall descrs sendResultsTo ~answer =
-        ignore allowThirdPartyTailCall; (* TODO *)
-        ignore sendResultsTo; (* TODO *)
-        let answer = {
-          answer_id = id;
-          exports_for_release = [];
-          answer_promise = answer;
-          finished = false;
-        } in
-        Answers.set t.answers id answer;
-        let target : recv_cap =
-          match message_target with
-          | `ReceiverHosted id ->
-            let export = Exports.find_exn t.exports id in
-            `Local export.export_service
-          | `ReceiverAnswer (id, path) ->
-            let answer = Answers.find_exn t.answers id in
-            `LocalPromise (answer.answer_promise, path)
-        in
-        let caps = RO_array.map (import_simple t) descrs in
-        answer, target, caps
-
-      let bootstrap t id ~answer =
-        let answer = {
-          answer_id = id;
-          exports_for_release = [];
-          answer_promise = answer;
-          finished = false;
-        } in
-        Answers.set t.answers id answer;
-        answer
-
-      let return_generic t id ~releaseParamCaps =
-        ignore releaseParamCaps; (* TODO *)
-        let question = Questions.find_exn t.questions id in
-        let flags = question.question_flags in
-        assert (flags land flag_returned = 0);
-        let flags = flags + flag_returned in
-        question.question_flags <- flags;
-        maybe_release_question t question;
-        question
-
-      let return_cancelled t id ~releaseParamCaps =
-        let question = return_generic t id ~releaseParamCaps in
-        question.question_data
-
-      let return_exception t id ~releaseParamCaps =
-        let question = return_generic t id ~releaseParamCaps in
-        question.question_data
-
-      let service = function
-        | `Export e -> e.export_service
-        | `Answer (answer, path) -> answer.answer_promise#cap path
-
-      let return_results t id ~releaseParamCaps msg descrs : C.struct_resolver * recv_cap_with_embargo RO_array.t =
-        let question = return_generic t id ~releaseParamCaps in
-        let caps_used = (* Maps used cap indexes to their paths *)
-          PathSet.elements question.question_pipelined_fields
-          |> filter_map (fun path ->
-              match C.Response.cap_index msg path with
-              | None -> None
-              | Some i -> Some (i, path)
-            )
-          |> IntMap.of_list
-        in
-        let import_with_embargo i d =
-          match import t d with
-          | #recv_cap as x -> x
-          | `Export _ | `Answer _ as x ->
-            match IntMap.find i caps_used with
-            | None -> `Local (service x)        (* Not used, so no embargo needed *)
-            | Some path ->
-              let cap = service x in
-              let embargo_id = Embargoes.alloc t.embargoes (fun id -> id) in
-              `LocalEmbargo (cap, `Loopback ((id, path), embargo_id))
-        in
-        let caps = RO_array.mapi import_with_embargo descrs in
-        question.question_data, caps
-
-      let resolve _t _export_id = function
-        | `Cap _desc -> ()
-        | `Exception -> ()
-
-      let release t export_id ~referenceCount =
-        assert (referenceCount > 0);
-        let export = Exports.find_exn t.exports export_id in
-        assert (export.export_count >= referenceCount);
-        let count = export.export_count - referenceCount in
-        export.export_count <- count;
-        if count = 0 then (
-          Log.info (fun f -> f ~tags:t.tags "Releasing export %a" T.ExportId.pp export_id);
-          Hashtbl.remove t.wrapper export.export_service;
-          Exports.release t.exports export_id
-        )
-
-      let finish t answer_id ~releaseResultCaps =
-        let answer = Answers.find_exn t.answers answer_id in
-        answer.finished <- true;
-        Answers.release t.answers answer_id;
-        if releaseResultCaps then (
-          (* This is very unclear. It says "all capabilities that were in the
-             results should be considered released". However, only imports can
-             be released, not capabilities in general.
-             Also, assuming we decrement the ref count by one in this case. *)
-          List.iter (release t ~referenceCount:1) answer.exports_for_release
-        );
-        answer.answer_promise
-
-      let disembargo_request t : In.disembargo_request -> _ = function
-        | `Loopback ((aid, i), id) ->
-          let answer = Answers.find_exn t.answers aid in
-          (* Check that [answer:i] points back at sender. *)
-          (* TODO: move the struct_ref logic here so we can do the check here? *)
-          `ReturnToSender ((answer.answer_promise, i), id)
-
-      let disembargo_reply t _target embargo_id =
-        Embargoes.release t.embargoes embargo_id
-
-      let provide _t _question_id _message_target _recipient_id = ()
-      let accept _t _question_id _provision_id ~embargo:_ = ()
-      let join _t _question_id _message_target _join_key_part = ()
-    end
-
-    module Send = struct
-      let bootstrap t question_data =
-        let question =
-          Questions.alloc t.questions (fun question_id ->
-              {question_flags = 0; params_for_release = []; question_id; question_data; question_pipelined_fields = PathSet.empty}
-            )
-        in
-        question, question.question_id
-
-      let call t question_data (target : message_target_cap) caps =
-        let question = Questions.alloc t.questions (fun question_id ->
+  module Send = struct
+    let bootstrap t question_data =
+      let question =
+        Questions.alloc t.questions (fun question_id ->
             {question_flags = 0; params_for_release = []; question_id; question_data; question_pipelined_fields = PathSet.empty}
           )
-        in
-        let descrs =
-          caps |> RO_array.map (fun cap ->
-              let descr, to_release = export t cap in
-              question.params_for_release <- to_release @ question.params_for_release;
-              descr
-            )
-        in
-        let target =
-          match target with
-          | `ReceiverHosted import -> `ReceiverHosted import.import_id
-          | `ReceiverAnswer (question, i) ->
-            question.question_pipelined_fields <- PathSet.add i question.question_pipelined_fields;
-            `ReceiverAnswer (question.question_id, i)
-        in
-        question, question.question_id, target, descrs
+      in
+      question, question.question_id
 
-      let return_results t answer msg (caps : [< cap] RO_array.t) =
-        let result =
-          if answer.finished then `Cancelled
-          else (
-            let descrs =
-              caps |> RO_array.map (fun cap ->
-                  let descr, to_release = export t cap in
-                  answer.exports_for_release <- to_release @ answer.exports_for_release;
-                  descr
-                )
-            in
-            `Results (msg, descrs)
+    let call t question_data (target : message_target_cap) caps =
+      let question = Questions.alloc t.questions (fun question_id ->
+          {question_flags = 0; params_for_release = []; question_id; question_data; question_pipelined_fields = PathSet.empty}
+        )
+      in
+      let descrs =
+        caps |> RO_array.map (fun cap ->
+            let descr, to_release = export t cap in
+            question.params_for_release <- to_release @ question.params_for_release;
+            descr
           )
-        in
-        answer.answer_id, result
-
-      let return_error _t answer msg =
-        answer.answer_id, `Exception msg
-
-      let return_cancelled _t answer =
-        answer.answer_id, `Cancelled
-
-      let release t import =
-        Imports.release t.imports import.import_id;
-        let count = import.import_count in
-        import.import_count <- 0;       (* Just in case - mark as invalid *)
-        import.import_id, count
-
-      let finish t question =
-        let flags = question.question_flags in
-        assert (flags land flag_finished = 0);
-        let flags = flags + flag_finished in
-        question.question_flags <- flags;
-        maybe_release_question t question;
-        question.question_id
-
-      let disembargo_reply _t = function
+      in
+      let target =
+        match target with
         | `ReceiverHosted import -> `ReceiverHosted import.import_id
-        | `ReceiverAnswer (question, path) -> `ReceiverAnswer (question.question_id, path)
-    end
+        | `ReceiverAnswer (question, i) ->
+          question.question_pipelined_fields <- PathSet.add i question.question_pipelined_fields;
+          `ReceiverAnswer (question.question_id, i)
+      in
+      question, question.question_id, target, descrs
 
-    let stats t =
-      { Stats.
-        n_questions = Questions.active t.questions;
-        n_answers = Answers.active t.answers;
-        n_imports = Imports.active t.imports;
-        n_exports = Exports.active t.exports;
-      }
+    let return_results t answer msg (caps : [< cap] RO_array.t) =
+      let result =
+        if answer.finished then `Cancelled
+        else (
+          let descrs =
+            caps |> RO_array.map (fun cap ->
+                let descr, to_release = export t cap in
+                answer.exports_for_release <- to_release @ answer.exports_for_release;
+                descr
+              )
+          in
+          `Results (msg, descrs)
+        )
+      in
+      answer.answer_id, result
+
+    let return_error _t answer msg =
+      answer.answer_id, `Exception msg
+
+    let return_cancelled _t answer =
+      answer.answer_id, `Cancelled
+
+    let release t import =
+      Imports.release t.imports import.import_id;
+      let count = import.import_count in
+      import.import_count <- 0;       (* Just in case - mark as invalid *)
+      import.import_id, count
+
+    let finish t question =
+      let flags = question.question_flags in
+      assert (flags land flag_finished = 0);
+      let flags = flags + flag_finished in
+      question.question_flags <- flags;
+      maybe_release_question t question;
+      question.question_id
+
+    let disembargo_reply _t = function
+      | `ReceiverHosted import -> `ReceiverHosted import.import_id
+      | `ReceiverAnswer (question, path) -> `ReceiverAnswer (question.question_id, path)
   end
+
+  let stats t =
+    { Stats.
+      n_questions = Questions.active t.questions;
+      n_answers = Answers.active t.answers;
+      n_imports = Imports.active t.imports;
+      n_exports = Exports.active t.exports;
+    }
 end

--- a/capnp-rpc/protocol.ml
+++ b/capnp-rpc/protocol.ml
@@ -1,5 +1,3 @@
-[@@@ocaml.warning "-27"]        (* TODO *)
-
 module Log = Debug.Log
 
 open Asetmap
@@ -324,7 +322,7 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
     let dump_export f x =
       Fmt.pf f "%t" x.export_service#pp
 
-    let dump_import f x =
+    let dump_import f _x =
       Fmt.pf f "import"
 
     let dump f t =
@@ -484,8 +482,8 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
         let caps = RO_array.mapi import_with_embargo descrs in
         question.question_data, caps
 
-      let resolve t export_id = function
-        | `Cap desc -> ()
+      let resolve _t _export_id = function
+        | `Cap _desc -> ()
         | `Exception -> ()
 
       let release t export_id ~referenceCount =
@@ -520,12 +518,12 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
           (* TODO: move the struct_ref logic here so we can do the check here? *)
           `ReturnToSender ((answer.answer_promise, i), id)
 
-      let disembargo_reply t target embargo_id =
+      let disembargo_reply t _target embargo_id =
         Embargoes.release t.embargoes embargo_id
 
-      let provide t question_id message_target recipient_id = ()
-      let accept t question_id provision_id ~embargo = ()
-      let join t question_id message_target join_key_part = ()
+      let provide _t _question_id _message_target _recipient_id = ()
+      let accept _t _question_id _provision_id ~embargo:_ = ()
+      let join _t _question_id _message_target _join_key_part = ()
     end
 
     module Send = struct
@@ -574,10 +572,10 @@ module Make (C : S.CORE_TYPES) (N : S.NETWORK_TYPES) = struct
         in
         answer.answer_id, result
 
-      let return_error t answer msg =
+      let return_error _t answer msg =
         answer.answer_id, `Exception msg
 
-      let return_cancelled t answer =
+      let return_cancelled _t answer =
         answer.answer_id, `Cancelled
 
       let release t import =

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -15,12 +15,12 @@ module Make (C : S.CORE_TYPES) = struct
   class type struct_ref_internal = object
     inherit struct_resolver
 
-    method pipeline : Path.t -> Request.t -> cap RO_array.t -> struct_ref
-    method inc_ref : Path.t -> unit
-    method dec_ref : Path.t -> unit
+    method pipeline : Wire.Path.t -> Wire.Request.t -> cap RO_array.t -> struct_ref
+    method inc_ref : Wire.Path.t -> unit
+    method dec_ref : Wire.Path.t -> unit
   end
 
-  module Field_map = Map.Make(Path)
+  module Field_map = Map.Make(Wire.Path)
 
   class type field_cap = object
     inherit cap
@@ -44,7 +44,7 @@ module Make (C : S.CORE_TYPES) = struct
     | Forwarding of struct_ref
     | Finished
 
-  let pp_fields = Field_map.dump (fun f (k, v) -> Fmt.pf f "%a:rc=%d" Path.pp k v.ref_count)
+  let pp_fields = Field_map.dump (fun f (k, v) -> Fmt.pf f "%a:rc=%d" Wire.Path.pp k v.ref_count)
 
   let pp_state ~pp_promise f = function
     | Unresolved {target; cancelling = true; _} -> Fmt.pf f "%a (cancelling)" pp_promise target
@@ -60,7 +60,7 @@ module Make (C : S.CORE_TYPES) = struct
     | Forwarding x -> forwarding x
 
   type field_state =
-    | PromiseField of struct_ref_internal * C.Path.t
+    | PromiseField of struct_ref_internal * Wire.Path.t
     | ForwardingField of cap
 
   let field path (p:#struct_ref_internal) =
@@ -74,7 +74,7 @@ module Make (C : S.CORE_TYPES) = struct
 
       method pp f =
         match state with
-        | PromiseField (p, path) -> Fmt.pf f "field:%a -> %t" Path.pp path p#pp
+        | PromiseField (p, path) -> Fmt.pf f "field:%a -> %t" Wire.Path.pp path p#pp
         | ForwardingField c -> Fmt.pf f "field -> %t" c#pp
 
       method inc_ref =
@@ -116,7 +116,7 @@ module Make (C : S.CORE_TYPES) = struct
 
     val id = incr last_id; !last_id
 
-    method private virtual do_pipeline : 'promise -> Path.t -> Request.t -> cap RO_array.t -> struct_ref
+    method private virtual do_pipeline : 'promise -> Wire.Path.t -> Wire.Request.t -> cap RO_array.t -> struct_ref
 
     method private virtual on_resolve : 'promise -> struct_ref -> unit
     (* We have just started forwarding. Send any queued data onwards. *)

--- a/test/testbed/capnp_direct.ml
+++ b/test/testbed/capnp_direct.ml
@@ -25,7 +25,9 @@ module String_content = struct
   end
 end
 
-module Network_types = struct
+module Core_types = struct
+  include Capnp_rpc.Core_types(String_content)
+
   type sturdy_ref
   type provision_id
   type recipient_id
@@ -33,4 +35,8 @@ module Network_types = struct
   type join_key_part
 end
 
-include Capnp_rpc.Make(String_content)(Network_types)
+module type ENDPOINT = Capnp_rpc.Message_types.ENDPOINT with
+  module Core_types = Core_types
+
+module Local_struct_promise = Capnp_rpc.Local_struct_promise.Make(Core_types)
+module Cap_proxy = Capnp_rpc.Cap_proxy.Make(Core_types)


### PR DESCRIPTION
Moved RPC message definitions out of Protocol and into a new
Message_types module, which also defines NETWORK and ENDPOINT types.

NETWORK_TYPES now extends CORE_TYPES, so you don't have to pass both
everywhere.

The public Capnp_rpc signature is simpler, exposing the individual
modules directly rather than providing a big functor. CapTP in
particular is now parameterised by the endpoint message types, rather
than by a protocol handler.

There are fewer nested functors.

The plan is to allow removing Protocol from the public API, so that it
can be merged with CapTP at some point.