### PR TITLE
Add support for Resolve messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
-	#./_build/default/test/test.bc test core -ev 17
+	#./_build/default/test/test.bc test core -ev 8
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
-	#./_build/default/test/test.bc test core -ev 7
+	#./_build/default/test/test.bc test core -ev 17
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
-	#./_build/default/test/test.bc test core 7
+	#./_build/default/test/test.bc test core -ev 7
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -80,6 +80,7 @@ module Untyped = struct
       method finish = failwith "Can't use finish on a sub-struct"
       method pp f = Fmt.pf f "pointer %d in %t" i t#pp
       method blocker = failwith "struct_field: blocker"
+      method check_invariants = ()
     end
 
   let capability_field t f = t#cap [Xform.Field f]

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -102,7 +102,7 @@ module Service : sig
       If [fn ()] fails, the error is logged and an "Internal error" returned to the caller.
       Note that this does not support pipelining. *)
 
-  val fail : ('a, Format.formatter, unit, 'b StructRef.t) format4 -> 'a
+  val fail : ?ty:Capnp_rpc.Exception.ty -> ('a, Format.formatter, unit, 'b StructRef.t) format4 -> 'a
   (** [fail msg] is an exception with reason [msg]. *)
 end
 

--- a/capnp-rpc-lwt/request.ml
+++ b/capnp-rpc-lwt/request.ml
@@ -21,6 +21,7 @@ let create_no_args () =
   {msg; n_exports = 0; exports_rev = []}
 
 let export t cap =
+  cap#inc_ref;
   let i = t.n_exports in
   t.n_exports <- i + 1;
   t.exports_rev <- cap :: t.exports_rev;

--- a/capnp-rpc-lwt/response.ml
+++ b/capnp-rpc-lwt/response.ml
@@ -23,6 +23,7 @@ let create_empty () =
   {msg; n_exports = 0; exports_rev = []}
 
 let export t cap =
+  cap#inc_ref;
   let i = t.n_exports in
   t.n_exports <- i + 1;
   t.exports_rev <- cap :: t.exports_rev;

--- a/capnp-rpc-lwt/service.ml
+++ b/capnp-rpc-lwt/service.ml
@@ -59,7 +59,7 @@ let return_lwt fn =
         )
         (fun ex ->
            Log.warn (fun f -> f "Uncaught exception: %a" Fmt.exn ex);
-           result#resolve (Error (`Exception "Internal error"));
+           result#resolve (Error (Capnp_rpc.Error.exn "Internal error"));
            Lwt.return_unit
         );
     );

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -352,7 +352,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
         | None -> failwith "Not initialised!"
 
       method! pp f =
-        Fmt.pf f "remote-promise -> %a" (Struct_proxy.pp_state ~pp_promise) state
+        Fmt.pf f "remote-promise(%a) -> %a" Debug.OID.pp id (Struct_proxy.pp_state ~pp_promise) state
 
       method set_question q =
         let finish = lazy (
@@ -478,7 +478,9 @@ module Make (EP : Message_types.ENDPOINT) = struct
         object (self : #Core_types.cap)
           inherit Core_types.ref_counted
 
-          method call msg caps = send_call t message_target msg caps
+          method call msg caps =
+            if ref_count < 1 then Debug.failf "%t already released!" self#pp;
+            send_call t message_target msg caps
 
           method pp f =
             if settled then

--- a/capnp-rpc/capTP.mli
+++ b/capnp-rpc/capTP.mli
@@ -2,7 +2,7 @@ module Make (EP : Message_types.ENDPOINT) : sig
   type t
   (** A [t] is a connection to a remote vat. *)
 
-  val create : ?bootstrap:EP.Core_types.cap -> tags:Logs.Tag.set -> queue_send:(EP.Out.t -> unit) -> t
+  val create : ?bootstrap:#EP.Core_types.cap -> tags:Logs.Tag.set -> queue_send:(EP.Out.t -> unit) -> t
   (** [create ~bootstrap ~tags ~queue_send] is a handler for a connection to a remote peer.
       Messages will be sent to the peer by calling [queue_send] (which MUST deliver them in order).
       If the remote peer asks for the bootstrap object, it will be given a reference to [bootstrap].

--- a/capnp-rpc/capTP.mli
+++ b/capnp-rpc/capTP.mli
@@ -29,4 +29,8 @@ module Make (EP : Message_types.ENDPOINT) : sig
 
   val dump : t Fmt.t
   (** [dump] formats a dump of the current state of the connection. *)
+
+  val check : t -> unit
+  (** [check t] performs some sanity checks on the state of the tables and raises an exception
+      if it finds a problem. *)
 end

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -113,6 +113,7 @@ module Make(C : S.CORE_TYPES) = struct
           state <- Resolved released
 
         method disembargo =
+          assert (ref_count > 0);
           super#resolve underlying
 
         method! pp f =

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -23,7 +23,10 @@ module Make(C : S.CORE_TYPES) = struct
   class local_promise =
     object (self : #cap)
       inherit ref_counted as super
+
       val mutable state = Unresolved (Queue.create (), false)
+
+      val id = Debug.OID.next ()
 
       method call msg caps =
         match state with
@@ -90,8 +93,8 @@ module Make(C : S.CORE_TYPES) = struct
 
       method pp f =
         match state with
-        | Unresolved _ -> Fmt.pf f "local-cap-promise(rc=%d) -> (unresolved)" ref_count
-        | Resolved cap -> Fmt.pf f "local-cap-promise(rc=%d) -> %t" ref_count cap#pp
+        | Unresolved _ -> Fmt.pf f "local-cap-promise(%a, rc=%d) -> (unresolved)" Debug.OID.pp id ref_count
+        | Resolved cap -> Fmt.pf f "local-cap-promise(%a, rc=%d) -> %t" Debug.OID.pp id ref_count cap#pp
 
       method! check_invariants =
         super#check_invariants;
@@ -110,8 +113,8 @@ module Make(C : S.CORE_TYPES) = struct
 
         method! pp f =
           match state with
-          | Unresolved _ -> Fmt.pf f "embargoed -> %t" underlying#pp
-          | Resolved cap -> Fmt.pf f "disembargoed -> %t" cap#pp
+          | Unresolved _ -> Fmt.pf f "embargoed(%a, rc=%d) -> %t" Debug.OID.pp id ref_count underlying#pp
+          | Resolved cap -> Fmt.pf f "disembargoed(%a, rc=%d) -> %t" Debug.OID.pp id ref_count cap#pp
       end
     in
     (cap :> embargo_cap)

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -108,6 +108,10 @@ module Make(C : S.CORE_TYPES) = struct
       object
         inherit local_promise as super
 
+        method! release =
+          underlying#dec_ref;
+          state <- Resolved released
+
         method disembargo =
           super#resolve underlying
 
@@ -143,7 +147,7 @@ module Make(C : S.CORE_TYPES) = struct
         | `Unsettled (old, q) ->
           if is_settled cap then (
             state <- `Settled cap;
-            Queue.iter (fun f -> f cap) q
+            Queue.iter (fun f -> f (cap#inc_ref; cap)) q
           ) else (
             state <- `Unsettled (cap, q)
           );

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -9,26 +9,34 @@ module Make(C : S.CORE_TYPES) = struct
     method disembargo : unit
   end
 
+  (* Operations to perform when resolved. *)
+  type pending =
+    | Call of struct_resolver * Wire.Request.t * cap RO_array.t
+    | Watcher of (cap -> unit)
+
   type cap_promise_state =
-    | Unresolved of (struct_resolver * Wire.Request.t * cap RO_array.t) Queue.t
+    | Unresolved of pending Queue.t * bool      (* bool = release-pending *)
     | Resolved of cap
+
+  let released = C.broken_cap (Exception.v "(released)")
 
   class local_promise =
     object (self : #cap)
       inherit ref_counted
-      val mutable state = Unresolved (Queue.create ())
+      val mutable state = Unresolved (Queue.create (), false)
 
       method call msg caps =
         match state with
-        | Unresolved q ->
+        | Unresolved (q, release_pending) ->
+          assert (not release_pending);
           let result = Local_struct_promise.make () in
-          Queue.add (result, msg, caps) q;
+          Queue.add (Call (result, msg, caps)) q;
           (result :> struct_ref)
         | Resolved cap -> cap#call msg caps
 
       method resolve (cap:cap) =
         match state with
-        | Unresolved q ->
+        | Unresolved (q, release_pending) ->
           let cap =
             match cap#blocker with
             | Some blocker when blocker = (self :> base_ref) ->
@@ -36,18 +44,34 @@ module Make(C : S.CORE_TYPES) = struct
                                   Resolving %t with %t would create a cycle@]" self#pp cap#pp in
               Log.info (fun f -> f "%s" msg);
               cap#dec_ref;
-              C.broken_cap msg
+              C.broken_cap (Exception.v msg)
             | _ -> cap
           in
           state <- Resolved cap;
-          let forward (result, msg, caps) =
-            let r = cap#call msg caps in
-            result#connect r      (* Or should it be connect [r] to [result], for tail-recursion? *)
+          Log.info (fun f -> f "Resolved local cap promise: %t" self#pp);
+          let forward = function
+            | Watcher fn -> cap#inc_ref; fn cap
+            | Call (result, msg, caps) ->
+              let r = cap#call msg caps in
+              result#connect r      (* Or should it be connect [r] to [result], for tail-recursion? *)
           in
-          Queue.iter forward q
+          Queue.iter forward q;
+          if release_pending then (
+            Log.info (fun f -> f "Completing delayed release of %t" self#pp);
+            cap#dec_ref;
+            state <- Resolved released
+          )
         | Resolved _ -> failwith "Already resolved!"
 
-      method private release = ()
+      method private release =
+        match state with
+        | Unresolved (target, release_pending) ->
+          Log.info (fun f -> f "Delaying release of %t until resolved" self#pp);
+          assert (not release_pending);
+          state <- Unresolved (target, true)
+        | Resolved cap ->
+          cap#dec_ref;
+          state <- Resolved released
 
       method shortest =
         match state with
@@ -59,10 +83,15 @@ module Make(C : S.CORE_TYPES) = struct
         | Unresolved _ -> Some (self :> base_ref)
         | Resolved cap -> cap#blocker
 
+      method when_more_resolved fn =
+        match state with
+        | Unresolved (q, _) -> Queue.add (Watcher fn) q
+        | Resolved x -> x#when_more_resolved fn
+
       method pp f =
         match state with
-        | Unresolved _ -> Fmt.string f "local-cap-promise -> (unresolved)"
-        | Resolved cap -> Fmt.pf f "local-cap-promise -> %t" cap#pp
+        | Unresolved _ -> Fmt.pf f "local-cap-promise(rc=%d) -> (unresolved)" ref_count
+        | Resolved cap -> Fmt.pf f "local-cap-promise(rc=%d) -> %t" ref_count cap#pp
     end
 
   let embargo underlying : embargo_cap =
@@ -80,4 +109,61 @@ module Make(C : S.CORE_TYPES) = struct
       end
     in
     (cap :> embargo_cap)
+
+  class switchable init =
+    let is_settled x = (x#blocker = None) in
+    let pp_state f = function
+      | `Unsettled (x, _) -> Fmt.pf f "(unsettled) -> %t" x#pp
+      | `Settled x -> Fmt.pf f "(settled) -> %t" x#pp
+    in
+    object (self : #cap)
+      inherit ref_counted
+
+      val mutable state =
+        if is_settled init then `Settled init
+        else `Unsettled (init, Queue.create ())
+
+      method call msg caps =
+        match state with
+        | `Unsettled (x, _)
+        | `Settled x -> x#call msg caps
+
+      method resolve cap =
+        match state with
+        | `Settled _ -> failwith "Can't resolve settled switchable!"
+        | `Unsettled (old, q) ->
+          if is_settled cap then (
+            state <- `Settled cap;
+            Queue.iter (fun f -> f cap) q
+          ) else (
+            state <- `Unsettled (cap, q)
+          );
+          old#dec_ref
+
+      method private release =
+        begin
+          match state with
+          | `Unsettled (x, _)
+          | `Settled x -> x#dec_ref
+        end;
+        state <- `Settled released
+
+      method shortest =
+        match state with
+        | `Unsettled _ -> (self :> cap)     (* Can't shorten, as we may change later *)
+        | `Settled x -> x#shortest
+
+      method blocker =
+        match state with
+        | `Unsettled _ -> Some (self :> base_ref)
+        | `Settled x -> x#blocker
+
+      method when_more_resolved fn =
+        match state with
+        | `Unsettled (_, q) -> Queue.add fn q
+        | `Settled x -> x#when_more_resolved fn
+
+      method pp f =
+        Fmt.pf f "switchable %a" pp_state state
+    end
 end

--- a/capnp-rpc/cap_proxy.mli
+++ b/capnp-rpc/cap_proxy.mli
@@ -8,6 +8,13 @@ module Make(C : S.CORE_TYPES) : sig
     inherit C.cap
     method resolve : C.cap -> unit
   end
+  (** A [new local_promise] is a promise that buffers calls until it is resolved. *)
+
+  class switchable : C.cap -> object
+    inherit C.cap
+    method resolve : C.cap -> unit
+  end
+  (** A [new switchable init] forwards messages to [init], which can be changed by calling resolve. *)
 
   val embargo : C.cap -> embargo_cap
 end

--- a/capnp-rpc/capnp_rpc.ml
+++ b/capnp-rpc/capnp_rpc.ml
@@ -4,6 +4,7 @@ module Stats = Stats
 module Id = Id
 module Debug = Debug
 module Error = Error
+module Exception = Exception
 module Core_types(C : S.WIRE) = Core_types.Make(C)
 module Local_struct_promise = Local_struct_promise
 module Cap_proxy = Cap_proxy

--- a/capnp-rpc/capnp_rpc.mli
+++ b/capnp-rpc/capnp_rpc.mli
@@ -4,6 +4,7 @@ module Stats = Stats
 module Id = Id
 module Debug = Debug
 module Error = Error
+module Exception = Exception
 module Message_types = Message_types
 module Core_types (W : S.WIRE) : S.CORE_TYPES with module Wire = W
 module Local_struct_promise = Local_struct_promise

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -90,6 +90,7 @@ module Make(Wire : S.WIRE) = struct
   end
 
   let null = broken_cap {Exception.ty = `Failed; reason = "null"}
+  let cancelled = broken_cap Exception.cancelled
 
   let cap_failf ?(ty=`Failed) msg = msg |> Fmt.kstrf (fun reason -> broken_cap {Exception.ty; reason})
 
@@ -112,7 +113,7 @@ module Make(Wire : S.WIRE) = struct
 
   let cap_of_err = function
     | `Exception msg -> broken_cap msg
-    | `Cancelled -> broken_cap Exception.cancelled
+    | `Cancelled -> cancelled
 
   let cap_in_result i = function
     | Ok p -> cap_in_payload i p

--- a/capnp-rpc/debug.ml
+++ b/capnp-rpc/debug.ml
@@ -18,3 +18,19 @@ let () =
   Printexc.register_printer @@ function
   | Invariant_broken pp -> Some (Fmt.strf "%t" pp)
   | _ -> None
+
+module OID = struct
+  type t = int
+
+  let last_id = ref 0
+
+  let next () =
+    incr last_id;
+    !last_id
+
+  let pp f id =
+    Fmt.(styled `Bold (styled `Cyan int)) f id
+
+  let reset () =
+    last_id := 0
+end

--- a/capnp-rpc/debug.ml
+++ b/capnp-rpc/debug.ml
@@ -2,3 +2,19 @@ let src = Logs.Src.create "capnp-rpc" ~doc:"Cap'n Proto RPC"
 module Log = (val Logs.src_log src: Logs.LOG)
 
 let qid_tag = Logs.Tag.def "qid" Uint32.printer
+
+exception Invariant_broken of (Format.formatter -> unit)
+
+let pp_exn f = function
+  | Invariant_broken pp -> pp f
+  | Failure msg -> Fmt.string f msg
+  | ex -> Fmt.exn f ex
+
+let failf msg = Fmt.kstrf failwith msg
+
+let invariant_broken f = raise (Invariant_broken f)
+
+let () =
+  Printexc.register_printer @@ function
+  | Invariant_broken pp -> Some (Fmt.strf "%t" pp)
+  | _ -> None

--- a/capnp-rpc/debug.mli
+++ b/capnp-rpc/debug.mli
@@ -13,3 +13,16 @@ val failf : ('a, Format.formatter, unit, 'b) format4 -> 'a
 
 val invariant_broken : (Format.formatter -> unit) -> 'a
 (** [invariant_broken msg] raises [Invariant_broken msg]. *)
+
+module OID : sig
+  type t
+  (** A unique ID which can be attached to objects to aid debugging. *)
+
+  val next : unit -> t
+  (** [next ()] is a fresh ID, unique since the last [reset]. *)
+
+  val pp : t Fmt.t
+
+  val reset : unit -> unit
+  (** Reset the counter. Possibly useful in unit or fuzz tests. *)
+end

--- a/capnp-rpc/debug.mli
+++ b/capnp-rpc/debug.mli
@@ -2,3 +2,14 @@ module Log : Logs.LOG
 
 val qid_tag : Uint32.t Logs.Tag.def
 (** [qid_tag] is used in log reports to tag the question (or answer) ID in the call. *)
+
+exception Invariant_broken of (Format.formatter -> unit)
+
+val pp_exn : exn Fmt.t
+(** [pp_exn] is like [Fmt.exn], but pretty-prints [Invariant_broken]. *)
+
+val failf : ('a, Format.formatter, unit, 'b) format4 -> 'a
+(** [failf msg] raises [Failure msg]. *)
+
+val invariant_broken : (Format.formatter -> unit) -> 'a
+(** [invariant_broken msg] raises [Invariant_broken msg]. *)

--- a/capnp-rpc/error.ml
+++ b/capnp-rpc/error.ml
@@ -1,8 +1,12 @@
 type t = [
-  | `Exception of string
+  | `Exception of Exception.t
   | `Cancelled
 ]
 
 let pp f = function
-  | `Exception msg -> Fmt.pf f "exn:%s" msg
+  | `Exception ex -> Exception.pp f ex
   | `Cancelled -> Fmt.pf f "cancelled"
+
+let exn ?ty msg =
+  msg |> Fmt.kstrf @@ fun reason ->
+  `Exception (Exception.v ?ty reason)

--- a/capnp-rpc/exception.ml
+++ b/capnp-rpc/exception.ml
@@ -1,0 +1,28 @@
+type ty = [
+  | `Failed
+  | `Overloaded
+  | `Disconnected
+  | `Unimplemented
+  | `Undefined of int
+]
+
+type t = {
+  ty : ty;
+  reason : string;
+}
+
+let pp_ty f x =
+  Fmt.string f (match x with
+      | `Failed        -> "Failed"
+      | `Overloaded    -> "Overloaded"
+      | `Disconnected  -> "Disconnected"
+      | `Unimplemented -> "Unimplemented"
+      | `Undefined x   -> "Undefined:" ^ string_of_int x
+    )
+
+let pp f ex =
+  Fmt.pf f "%a: %s" pp_ty ex.ty ex.reason
+
+let v ?(ty = `Failed) reason = { ty; reason }
+
+let cancelled = v "Cancelled"

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -11,7 +11,7 @@ module Make (C : S.CORE_TYPES) = struct
     method private do_pipeline q i msg caps =
       let result = local_promise ~parent:self () in
       q |> Queue.add (fun p ->
-          Logs.info (fun f -> f "%d:%a forwarding %t" id Wire.Path.pp i p#pp);
+          Logs.info (fun f -> f "%a:%a forwarding %t" Debug.OID.pp id Wire.Path.pp i p#pp);
           result#connect ((p#cap i)#call msg caps)      (* XXX: dec_ref? *)
         );
       (result :> struct_ref)
@@ -23,7 +23,7 @@ module Make (C : S.CORE_TYPES) = struct
         | Some p -> Fmt.pf f "blocked on %t" p#pp
       in
       Fmt.pf f "local-struct-ref(%a) -> %a"
-        (Fmt.styled `Blue Fmt.int) id
+        Debug.OID.pp id
         (Struct_proxy.pp_state ~pp_promise) state
 
     method private on_resolve q x =

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -55,6 +55,10 @@ module type CORE_TYPES = sig
     method blocker : base_ref option
     (** [c#blocker] is the unresolved [cap] or [struct_ref] promise that must resolve for [c] to resolve.
         This is used to help detect cycles. *)
+
+    method check_invariants : unit
+    (** This is for debugging. Checks its own invariants and those of other base_refs it holds.
+        Raises [Invariant_broken] if there is a problem. *)
   end
 
   val pp : #base_ref Fmt.t
@@ -160,6 +164,7 @@ module type CORE_TYPES = sig
     method virtual pp : Format.formatter -> unit
     method inc_ref : unit
     method dec_ref : unit
+    method check_invariants : unit
   end
   (** A mix-in to help with writing reference-counted objects.
       It will call [self#release] when the ref-count reaches zero. *)

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -265,7 +265,10 @@ module Make (C : S.CORE_TYPES) = struct
       let fn : Response_payload.t or_error -> unit = function
         | Error (`Exception e) -> fn (C.broken_cap e)
         | Error `Cancelled -> fn (C.broken_cap Exception.cancelled)
-        | Ok payload -> fn (C.Response_payload.field_or_err payload i)
+        | Ok payload ->
+          let cap = C.Response_payload.field_or_err payload i in
+          cap#inc_ref;
+          fn cap
       in
       dispatch state
         ~cancelling_ok:true

--- a/capnp-rpc/table.ml
+++ b/capnp-rpc/table.ml
@@ -4,7 +4,7 @@ let pp_item ~check pp f (k, v) =
   match check v with
   | () -> pp f (k, v)
   | exception ex ->
-    Fmt.pf f "%a@,[%a] %a"
+    Fmt.pf f "%a@\n[%a] %a"
       pp (k, v)
       Fmt.(styled `Red string) "ERROR"
       Debug.pp_exn ex

--- a/fuzz/choose.ml
+++ b/fuzz/choose.ml
@@ -1,0 +1,15 @@
+exception End_of_fuzz_data
+
+let int limit =
+  try
+    let x = Char.code (input_char stdin) in
+    if limit < 0x100 then x mod limit
+    else (
+      let y = Char.code (input_char stdin) in
+      assert (limit < 0x10000);
+      (x lor (y lsl 8)) mod limit
+    )
+  with End_of_file -> raise End_of_fuzz_data
+
+let array options =
+  options.(int (Array.length options))

--- a/fuzz/dynArray.ml
+++ b/fuzz/dynArray.ml
@@ -1,0 +1,56 @@
+type 'a t = {
+  mutable items : 'a array;
+  mutable len : int;
+  default : 'a;
+}
+
+let create default = {
+  items = Array.make 10 default;
+  len = 0;
+  default;
+}
+
+let add t v =
+  if t.len = Array.length t.items then (
+    t.items <- Array.init (t.len * 2) (fun i ->
+        if i < t.len then t.items.(i)
+        else t.default
+      )
+  );
+  t.items.(t.len) <- v;
+  t.len <- t.len + 1
+
+let pick t =
+  if t.len = 0 then None
+  else Some (t.items.(Choose.int t.len))
+
+let iter fn t =
+  for i = 0 to t.len - 1 do
+    fn t.items.(i)
+  done
+
+let dump ~compare pp f t =
+  let items = Array.sub t.items 0 t.len in
+  Array.sort compare items;
+  Fmt.array ~sep:Fmt.cut pp f items
+let dump ~compare pp f = Fmt.fmt "[@[<v0>%a@]]" f (dump ~compare pp)
+
+let pop t =
+  if t.len = 0 then None
+  else (
+    let i = Choose.int t.len in
+    let v = t.items.(i) in
+    t.len <- t.len - 1;
+    t.items.(i) <- t.items.(t.len);
+    Some v
+  )
+
+let pop_first t =
+  if t.len = 0 then None
+  else (
+    let i = 0 in
+    let v = t.items.(i) in
+    t.len <- t.len - 1;
+    t.items.(i) <- t.items.(t.len);
+    Some v
+  )

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -1,10 +1,19 @@
 module RO_array = Capnp_rpc.RO_array
 module Test_utils = Testbed.Test_utils
 
-let three_vats = false
+let three_vats = false (* XXX *)
 
+let stop_after =
+  match Sys.getenv "FUZZ_STOP" with
+  | s -> int_of_string s
+  | exception Not_found -> -1
+(* If the ref-counting seems off after a while, try setting this to a low-ish number.
+   This will cause it to try to clean up early and hopefully discover the problem sooner. *)
+
+let dump_state_at_each_step = (stop_after >= 0)
+
+let sanity_checks = dump_state_at_each_step
 (* Check that the state is valid after every step (slow). *)
-let sanity_checks = true
 
 let failf msg = Fmt.kstrf failwith msg
 
@@ -38,6 +47,9 @@ module Direct : sig
   val make_struct : unit -> struct_ref
   val cap : struct_ref -> int -> cap
   val return : struct_ref -> cap RO_array.t -> unit
+
+  val compare_cap : cap -> cap -> int
+  val compare_sr : struct_ref -> struct_ref -> int
 
   val pp : cap Fmt.t
   val pp_struct : struct_ref Fmt.t
@@ -76,6 +88,12 @@ end = struct
     match x.target with
     | Id i -> i
     | See y -> target y
+
+  let compare_cap a b =
+    compare (target a) (target b)
+
+  let compare_sr a b =
+    compare a.struct_id b.struct_id
 
   let rec pp f t =
     match t.target with
@@ -209,65 +227,20 @@ module Endpoint = struct
     if Queue.length t.recv_queue > 0 then handle_msg t
 
   let bootstrap t = Conn.bootstrap t.conn
-end
 
-exception End_of_fuzz_data
+  let try_step t =
+    if Queue.length t.recv_queue > 0 then (
+      if dump_state_at_each_step then
+        Logs.info (fun f -> f ~tags:(Conn.tags t.conn) "%a" dump t);
+      handle_msg t;
+      if sanity_checks then Conn.check t.conn;
+      true
+    ) else false
+end
 
 let () =
   Format.pp_set_margin Fmt.stderr 120;
   Fmt.set_style_renderer Fmt.stderr `Ansi_tty
-
-let choose_int limit =
-  try
-    let x = Char.code (input_char stdin) in
-    if limit < 0x100 then x mod limit
-    else (
-      let y = Char.code (input_char stdin) in
-      assert (limit < 0x10000);
-      (x lor (y lsl 8)) mod limit
-    )
-  with End_of_file -> raise End_of_fuzz_data
-
-let choose options =
-  options.(choose_int (Array.length options))
-
-module DynArray = struct
-  type 'a t = {
-    mutable items : 'a array;
-    mutable len : int;
-    default : 'a;
-  }
-
-  let create default = {
-    items = Array.make 10 default;
-    len = 0;
-    default;
-  }
-
-  let add t v =
-    if t.len = Array.length t.items then (
-      t.items <- Array.init (t.len * 2) (fun i ->
-          if i < t.len then t.items.(i)
-          else t.default
-        )
-    );
-    t.items.(t.len) <- v;
-    t.len <- t.len + 1
-
-  let pick t =
-    if t.len = 0 then None
-    else Some (t.items.(choose_int t.len))
-
-  let pop t =
-    if t.len = 0 then None
-    else (
-      let i = choose_int t.len in
-      let v = t.items.(i) in
-      t.len <- t.len - 1;
-      t.items.(i) <- t.items.(t.len);
-      Some v
-    )
-end
 
 let dummy_answer = object (self : Core_types.struct_resolver)
   method cap _ = failwith "dummy_answer"
@@ -287,77 +260,6 @@ type cap_ref = {
   cr_counters : cap_ref_counters;
 }
 
-type vat = {
-  id : int;
-  mutable bootstrap : (Core_types.cap * Direct.cap) option;
-  caps : cap_ref DynArray.t;
-  structs : (Core_types.struct_ref * Direct.struct_ref) DynArray.t;
-  actions : (unit -> unit) DynArray.t;
-  mutable connections : (int * Endpoint.t) list;
-  answers_needed : (Core_types.struct_resolver * Direct.struct_ref) DynArray.t;
-}
-
-let tags v = tags_for_id v.id
-
-let pp_vat f t =
-  let pp_connection f (id, endpoint) =
-    Fmt.pf f "@[<v2>Connection to %d@,%a@]" id Endpoint.dump endpoint;
-  in
-  Fmt.Dump.list pp_connection f t.connections
-
-let do_action state =
-  match DynArray.pick state.actions with
-  | Some fn -> fn ()
-  | None -> assert false        (* There should always be some actions *)
-
-let n_caps state n =
-  let rec caps = function
-    | 0 -> []
-    | i ->
-      match DynArray.pick state.caps with
-      | Some c -> c :: caps (i - 1)
-      | None -> []
-  in
-  let cap_refs = caps n in
-  let args = RO_array.of_list @@ List.map (fun cr -> cr.cr_cap) cap_refs in
-  args, cap_refs
-
-(* Call a random cap, passing random arguments. *)
-let do_call state () =
-  match DynArray.pick state.caps with
-  | None -> ()
-  | Some cap_ref ->
-    let cap = cap_ref.cr_cap in
-    let counters = cap_ref.cr_counters in
-    let target = cap_ref.cr_target in
-    let n_args = choose_int 3 in
-    let args, arg_refs = n_caps state (n_args) in
-    let arg_ids = List.map (fun cr -> cr.cr_target) arg_refs |> RO_array.of_list in
-    RO_array.iter (fun c -> c#inc_ref) args;
-    let answer = Direct.make_struct () in
-    Logs.info (fun f -> f ~tags:(tags state) "Call %a=%t(%a) (answer %a)"
-                  Direct.pp target cap#pp
-                  (RO_array.pp Core_types.pp) args
-                  Direct.pp_struct answer);
-    let msg = { Msg.Request.target; counters; seq = counters.next_to_send; answer; arg_ids } in
-    counters.next_to_send <- succ counters.next_to_send;
-    DynArray.add state.structs (cap#call msg args, answer)
-
-(* Reply to a random question. *)
-let do_answer state () =
-  match DynArray.pop state.answers_needed with
-  | None -> ()
-  | Some (answer, answer_id) ->
-    let n_args = choose_int 3 in
-    let args, arg_refs = n_caps state (n_args) in
-    let arg_ids = List.map (fun cr -> cr.cr_target) arg_refs in
-    RO_array.iter (fun c -> c#inc_ref) args;
-    Logs.info (fun f -> f ~tags:(tags state)
-                  "Return %a (%a)" (RO_array.pp Core_types.pp) args Direct.pp_struct answer_id);
-    Direct.return answer_id (RO_array.of_list arg_ids);
-    answer#resolve (Ok ("reply", args))
-    (* TODO: reply with another promise or with an error *)
-
 let make_cap_ref ~target cap =
   {
     cr_cap = cap;
@@ -365,82 +267,258 @@ let make_cap_ref ~target cap =
     cr_counters = { next_to_send = 0; next_expected = 0 };
   }
 
-let test_service ~target:self_id vat =
-  object (_ : Core_types.cap)
-    inherit Core_types.service
+module Vat = struct
+  type t = {
+    id : int;
+    mutable bootstrap : (Core_types.cap * Direct.cap) option;
+    caps : cap_ref DynArray.t;
+    structs : (Core_types.struct_ref * Direct.struct_ref) DynArray.t;
+    actions : (unit -> unit) DynArray.t;
+    mutable connections : (int * Endpoint.t) list;
+    answers_needed : (Core_types.struct_resolver * Direct.struct_ref) DynArray.t;
+  }
 
-    method! pp f = Fmt.pf f "test-service(rc=%d) %a" ref_count Direct.pp self_id
+  let tags t = tags_for_id t.id
 
-    method call msg caps =
-      assert (ref_count > 0);
-      let {Msg.Request.target; counters; seq; arg_ids; answer} = msg in
-      if not (Direct.equal target self_id) then
-        failf "Call received by %a, but expected target was %a (answer %a)"
-          Direct.pp self_id
-          Direct.pp target
-          Direct.pp_struct answer;
-      if seq <> counters.next_expected then
-        failf "Expecting message number %d, but got %d (target %a)" counters.next_expected seq Direct.pp target;
-      counters.next_expected <- succ counters.next_expected;
-      caps |> RO_array.iteri (fun i c ->
-          let target = RO_array.get arg_ids i in
-          DynArray.add vat.caps (make_cap_ref ~target c)
-        );
-      let answer_promise = Local_struct_promise.make () in
-      DynArray.add vat.answers_needed (answer_promise, answer);
-      (answer_promise :> Core_types.struct_ref)
-  end
+  let pp_error f cap =
+    try cap#check_invariants
+    with ex ->
+      Fmt.pf f "@,[%a] %a"
+        Fmt.(styled `Red string) "ERROR"
+        Capnp_rpc.Debug.pp_exn ex
 
-(* Pick a random cap from an answer. *)
-let do_struct state () =
-  match DynArray.pick state.structs with
-  | None -> ()
-  | Some (s, s_id) ->
-    let i = choose_int 3 in
-    Logs.info (fun f -> f ~tags:(tags state) "Get %t/%d" s#pp i);
-    let cap = s#cap i in
-    let target = Direct.cap s_id i in
-    DynArray.add state.caps (make_cap_ref ~target cap)
+  let dump_cap f {cr_target; cr_cap; cr_counters} =
+    Fmt.pf f "%a : @[%t %a;%a@]"
+      Direct.pp cr_target
+      cr_cap#pp
+      pp_counters cr_counters
+      pp_error cr_cap
 
-(* Finish an answer *)
-let do_finish state () =
-  match DynArray.pop state.structs with
-  | None -> ()
-  | Some (s, _id) ->
-    Logs.info (fun f -> f ~tags:(tags state) "Finish %t" s#pp);
-    s#finish
+  let dump_sr f (sr, target) =
+    Fmt.pf f "%a : @[%t;%a@]"
+      Direct.pp_struct target
+      sr#pp
+      pp_error sr
 
-let do_release state () =
-  match DynArray.pop state.caps with
-  | None -> ()
-  | Some cr ->
-    let c = cr.cr_cap in
-    Logs.info (fun f -> f ~tags:(tags state) "Release %t" c#pp);
-    c#dec_ref
+  let dump_an f (sr, target) =
+    Fmt.pf f "%a : @[%t;%a@]"
+      Direct.pp_struct target
+      sr#pp
+      pp_error sr
 
-(* Create a new local service *)
-let do_create state () =
-  let target = Direct.make_cap () in
-  let ts = test_service ~target state in
-  Logs.info (fun f -> f ~tags:(tags state) "Created %t" ts#pp);
-  DynArray.add state.caps (make_cap_ref ~target ts)
+  let compare_cr a b =
+    Direct.compare_cap a.cr_target b.cr_target
 
-let add_actions v conn ~target =
-  DynArray.add v.actions (fun () ->
-      Logs.info (fun f -> f ~tags:(tags v) "Expecting bootstrap reply to be target %a" Direct.pp target);
-      DynArray.add v.caps (make_cap_ref ~target @@ Endpoint.bootstrap conn)
-    );
-  DynArray.add v.actions (fun () ->
-      Logs.info (fun f -> f ~tags:(tags_for_id v.id) "Handle next message");
-      Endpoint.maybe_handle_msg conn
-    )
+  let compare_sr (_, a) (_, b) =
+    Direct.compare_sr a b
+
+  let compare_an (_, a) (_, b) =
+    Direct.compare_sr a b
+
+  let pp f t =
+    let pp_connection f (id, endpoint) =
+      Fmt.pf f "@[<v2>Connection to %d@,%a\
+                @[<v2>Caps:@,%a@]@,\
+                @[<v2>Structs:@,%a@]@,\
+                @[<v2>Answers waiting:@,%a@]@,\
+                @]" id
+        Endpoint.dump endpoint
+        (DynArray.dump ~compare:compare_cr dump_cap) t.caps
+        (DynArray.dump ~compare:compare_sr dump_sr) t.structs
+        (DynArray.dump ~compare:compare_an dump_an) t.answers_needed
+      ;
+    in
+    Fmt.Dump.list pp_connection f t.connections
+
+  let check t =
+    try
+      t.connections |> List.iter (fun (_, conn) -> Endpoint.check conn);
+      t.caps |> DynArray.iter (fun c -> c.cr_cap#check_invariants);
+      t.structs |> DynArray.iter (fun (s, _) -> s#check_invariants);
+      t.answers_needed |> DynArray.iter (fun (s, _) -> s#check_invariants)
+    with ex ->
+      Logs.err (fun f -> f ~tags:(tags t) "Invariants check failed: %a" Capnp_rpc.Debug.pp_exn ex);
+      raise ex
+
+  let do_action state =
+    match DynArray.pick state.actions with
+    | Some fn -> fn ()
+    | None -> assert false        (* There should always be some actions *)
+
+  let n_caps state n =
+    let rec caps = function
+      | 0 -> []
+      | i ->
+        match DynArray.pick state.caps with
+        | Some c -> c :: caps (i - 1)
+        | None -> []
+    in
+    let cap_refs = caps n in
+    let args = RO_array.of_list @@ List.map (fun cr -> cr.cr_cap) cap_refs in
+    args, cap_refs
+
+  (* Call a random cap, passing random arguments. *)
+  let do_call state () =
+    match DynArray.pick state.caps with
+    | None -> ()
+    | Some cap_ref ->
+      let cap = cap_ref.cr_cap in
+      let counters = cap_ref.cr_counters in
+      let target = cap_ref.cr_target in
+      let n_args = Choose.int 3 in
+      let args, arg_refs = n_caps state (n_args) in
+      let arg_ids = List.map (fun cr -> cr.cr_target) arg_refs |> RO_array.of_list in
+      RO_array.iter (fun c -> c#inc_ref) args;
+      let answer = Direct.make_struct () in
+      Logs.info (fun f -> f ~tags:(tags state) "Call %a=%t(%a) (answer %a)"
+                    Direct.pp target cap#pp
+                    (RO_array.pp Core_types.pp) args
+                    Direct.pp_struct answer);
+      let msg = { Msg.Request.target; counters; seq = counters.next_to_send; answer; arg_ids } in
+      counters.next_to_send <- succ counters.next_to_send;
+      DynArray.add state.structs (cap#call msg args, answer)
+
+  (* Reply to a random question. *)
+  let do_answer state () =
+    match DynArray.pop state.answers_needed with
+    | None -> ()
+    | Some (answer, answer_id) ->
+      let n_args = Choose.int 3 in
+      let args, arg_refs = n_caps state (n_args) in
+      let arg_ids = List.map (fun cr -> cr.cr_target) arg_refs in
+      RO_array.iter (fun c -> c#inc_ref) args;
+      Logs.info (fun f -> f ~tags:(tags state)
+                    "Return %a (%a)" (RO_array.pp Core_types.pp) args Direct.pp_struct answer_id);
+      Direct.return answer_id (RO_array.of_list arg_ids);
+      answer#resolve (Ok ("reply", args))
+      (* TODO: reply with another promise or with an error *)
+
+  let test_service ~target:self_id vat =
+    object (_ : Core_types.cap)
+      inherit Core_types.service
+
+      method! pp f = Fmt.pf f "test-service(rc=%d) %a" ref_count Direct.pp self_id
+
+      method call msg caps =
+        assert (ref_count > 0);
+        let {Msg.Request.target; counters; seq; arg_ids; answer} = msg in
+        if not (Direct.equal target self_id) then
+          failf "Call received by %a, but expected target was %a (answer %a)"
+            Direct.pp self_id
+            Direct.pp target
+            Direct.pp_struct answer;
+        if seq <> counters.next_expected then
+          failf "Expecting message number %d, but got %d (target %a)" counters.next_expected seq Direct.pp target;
+        counters.next_expected <- succ counters.next_expected;
+        caps |> RO_array.iteri (fun i c ->
+            let target = RO_array.get arg_ids i in
+            DynArray.add vat.caps (make_cap_ref ~target c)
+          );
+        let answer_promise = Local_struct_promise.make () in
+        DynArray.add vat.answers_needed (answer_promise, answer);
+        (answer_promise :> Core_types.struct_ref)
+    end
+
+  (* Pick a random cap from an answer. *)
+  let do_struct state () =
+    match DynArray.pick state.structs with
+    | None -> ()
+    | Some (s, s_id) ->
+      let i = Choose.int 3 in
+      Logs.info (fun f -> f ~tags:(tags state) "Get %t/%d" s#pp i);
+      let cap = s#cap i in
+      let target = Direct.cap s_id i in
+      DynArray.add state.caps (make_cap_ref ~target cap)
+
+  (* Finish an answer *)
+  let do_finish state () =
+    match DynArray.pop state.structs with
+    | None -> ()
+    | Some (s, _id) ->
+      Logs.info (fun f -> f ~tags:(tags state) "Finish %t" s#pp);
+      s#finish
+
+  let do_release state () =
+    match DynArray.pop state.caps with
+    | None -> ()
+    | Some cr ->
+      let c = cr.cr_cap in
+      Logs.info (fun f -> f ~tags:(tags state) "Release %t (%a)" c#pp Direct.pp cr.cr_target);
+      c#dec_ref
+
+  (* Create a new local service *)
+  let do_create state () =
+    let target = Direct.make_cap () in
+    let ts = test_service ~target state in
+    Logs.info (fun f -> f ~tags:(tags state) "Created %t" ts#pp);
+    DynArray.add state.caps (make_cap_ref ~target ts)
+
+  let add_actions v conn ~target =
+    DynArray.add v.actions (fun () ->
+        Logs.info (fun f -> f ~tags:(tags v) "Expecting bootstrap reply to be target %a" Direct.pp target);
+        DynArray.add v.caps (make_cap_ref ~target @@ Endpoint.bootstrap conn)
+      );
+    DynArray.add v.actions (fun () ->
+        Logs.info (fun f -> f ~tags:(tags_for_id v.id) "Handle next message");
+        Endpoint.maybe_handle_msg conn
+      )
+
+  let free_all t =
+    let rec free_caps () =
+      match DynArray.pop_first t.caps with
+      | Some c -> c.cr_cap#dec_ref; free_caps ()
+      | None -> ()
+    in
+    let rec free_srs () =
+      match DynArray.pop_first t.structs with
+      | Some (q, _) -> q#finish; free_srs ()
+      | None -> ()
+    in
+    let rec free_ans () =
+      match DynArray.pop_first t.answers_needed with
+      | Some (a, _) -> a#resolve (Error (Capnp_rpc.Error.exn "Free all")); free_ans ()
+      | None -> ()
+    in
+    free_caps ();
+    free_srs ();
+    free_ans ()
+
+  let next_id = ref 0
+
+  let create () =
+    let id = !next_id in
+    next_id := succ !next_id;
+    let null = make_cap_ref ~target:Direct.null Core_types.null in
+    let t = {
+      id;
+      bootstrap = None;
+      caps = DynArray.create null;
+      structs = DynArray.create (Core_types.broken_struct `Cancelled, Direct.cancelled);
+      actions = DynArray.create ignore;
+      connections = [];
+      answers_needed = DynArray.create (dummy_answer, Direct.cancelled);
+    } in
+    let bs_id = Direct.make_cap () in
+    t.bootstrap <- Some (test_service ~target:bs_id t, bs_id);
+    DynArray.add t.actions (do_call t);
+    DynArray.add t.actions (do_struct t);
+    DynArray.add t.actions (do_finish t);
+    DynArray.add t.actions (do_create t);
+    DynArray.add t.actions (do_release t);
+    DynArray.add t.actions (do_answer t);
+    t
+
+  let try_step t =
+    List.fold_left (fun found (_, c) ->
+        Endpoint.try_step c || found
+      ) false t.connections
+end
 
 let make_connection v1 v2 =
   let q1 = Queue.create () in
   let q2 = Queue.create () in
-  let v1_tags = tags_for_id v1.id in
-  let v2_tags = tags_for_id v2.id in
-  let cap = function
+  let bootstrap x =
+    match x.Vat.bootstrap with
     | None -> None
     | Some (c, _) -> Some c
   in
@@ -448,51 +526,27 @@ let make_connection v1 v2 =
     | None -> Direct.null
     | Some (_, id) -> id
   in
-  let c = Endpoint.create ~tags:v1_tags q1 q2 ?bootstrap:(cap v1.bootstrap) in
-  let s = Endpoint.create ~tags:v2_tags q2 q1 ?bootstrap:(cap v2.bootstrap) in
+  let c = Endpoint.create ~tags:(Vat.tags v1) q1 q2 ?bootstrap:(bootstrap v1) in
+  let s = Endpoint.create ~tags:(Vat.tags v2) q2 q1 ?bootstrap:(bootstrap v2) in
+  let open Vat in
   add_actions v1 c ~target:(target v2.bootstrap);
   add_actions v2 s ~target:(target v1.bootstrap);
   v1.connections <- (v2.id, c) :: v1.connections;
   v2.connections <- (v1.id, s) :: v2.connections
-
-let next_id = ref 0
-
-let make_vat () =
-  let id = !next_id in
-  next_id := succ !next_id;
-  let null = make_cap_ref ~target:Direct.null Core_types.null in
-  let t = {
-    id;
-    bootstrap = None;
-    caps = DynArray.create null;
-    structs = DynArray.create (Core_types.broken_struct `Cancelled, Direct.cancelled);
-    actions = DynArray.create ignore;
-    connections = [];
-    answers_needed = DynArray.create (dummy_answer, Direct.cancelled);
-  } in
-  let bs_id = Direct.make_cap () in
-  t.bootstrap <- Some (test_service ~target:bs_id t, bs_id);
-  DynArray.add t.actions (do_call t);
-  DynArray.add t.actions (do_struct t);
-  DynArray.add t.actions (do_finish t);
-  DynArray.add t.actions (do_create t);
-  DynArray.add t.actions (do_release t);
-  DynArray.add t.actions (do_answer t);
-  t
 
 let () =
   (* Logs.set_level (Some Logs.Error); *)
   assert (Array.length (Sys.argv) = 1);
   AflPersistent.run @@ fun () ->
 
-  let v1 = make_vat () in
-  let v2 = make_vat () in
+  let v1 = Vat.create () in
+  let v2 = Vat.create () in
 
   make_connection v1 v2;
 
   let vats =
     if three_vats then (
-      let v3 = make_vat () in
+      let v3 = Vat.create () in
       make_connection v1 v3;
       [| v1; v2; v3 |]
     ) else (
@@ -500,22 +554,48 @@ let () =
     )
   in
 
+  let free_all () =
+    Logs.info (fun f -> f "Freeing everything (for debugging)");
+    vats |> Array.iter (fun v ->
+        Vat.free_all v;
+      );
+    let rec flush () =
+      let progress = Array.fold_left (fun found v ->
+          Vat.try_step v || found
+        ) false vats
+      in
+      Array.iter Vat.check vats;
+      if progress then flush ()
+    in
+    flush ();
+    if stop_after >= 0 then failwith "Everything freed!"
+  in
+
+  let step = ref 0 in
   try
     let rec loop () =
-      let v = choose vats in
-      if sanity_checks then
-        v.connections |> List.iter (fun (_, conn) -> Endpoint.check conn);
-      do_action v;
-      loop ()
+      let v = Choose.array vats in
+      if dump_state_at_each_step then
+        Logs.info (fun f -> f ~tags:(Vat.tags v) "Pre: %a" Vat.pp v);
+      Vat.do_action v;
+      if dump_state_at_each_step then
+        Logs.info (fun f -> f ~tags:(Vat.tags v) "Post: %a" Vat.pp v);
+      if sanity_checks then Vat.check v;
+      if !step <> stop_after then (
+        incr step;
+        loop ()
+      )
     in
-    try loop ()
-    with End_of_fuzz_data -> () (* TODO: try releasing everything *)
+    begin
+      try loop ()
+      with Choose.End_of_fuzz_data -> ()
+    end;
+    free_all ()
   with ex ->
     let bt = Printexc.get_raw_backtrace () in
     Logs.err (fun f -> f "%a" Fmt.exn_backtrace (ex, bt));
-    Logs.err (fun f -> f "Got error - dumping state:");
+    Logs.err (fun f -> f "Got error (at step %d) - dumping state:" !step);
     vats |> Array.iter (fun v ->
-        let tags = tags_for_id v.id in
-        Logs.info (fun f -> f ~tags "%a" pp_vat v);
+        Logs.info (fun f -> f ~tags:(Vat.tags v) "%a" Vat.pp v);
       );
     raise ex

--- a/test/test.ml
+++ b/test/test.ml
@@ -5,6 +5,8 @@ module Test_utils = Testbed.Test_utils
 module Services = Testbed.Services
 module CS = Testbed.Connection.Make ( )    (* A client-server pair *)
 module RO_array = Capnp_rpc.RO_array
+module Error = Capnp_rpc.Error
+module Exception = Capnp_rpc.Exception
 
 let empty = RO_array.empty
 
@@ -38,6 +40,10 @@ let init_pair ~bootstrap_service =
   S.handle_msg s ~expect:"finish";
   c, s, bs
 
+let call target msg caps =
+  List.iter (fun c -> c#inc_ref) caps;
+  target#call msg (RO_array.of_list caps)
+
 (* The server gets an object and then sends it back. When the object arrives back
    at the client, it must be the original (local) object, not a proxy. *)
 let test_return () =
@@ -46,7 +52,7 @@ let test_return () =
   (* Pass callback *)
   let slot = ref ("empty", empty) in
   let local = Services.swap_service slot in
-  let q = bs#call "c1" (RO_array.of_list [local]) in
+  let q = call bs "c1" [local] in
   (* Server echos args back *)
   S.handle_msg s ~expect:"call:c1";
   C.handle_msg c ~expect:"return:got:c1";
@@ -58,22 +64,18 @@ let test_return () =
   CS.check_finished c s
 
 let test_return_error () =
-  let c, s, bs = init_pair ~bootstrap_service:(Core_types.broken_cap "test-error") in
+  let c, s, bs = init_pair ~bootstrap_service:(Core_types.broken_cap (Exception.v "test-error")) in
   (* Pass callback *)
   let slot = ref ("empty", empty) in
   let local = Services.swap_service slot in
-  let q = bs#call "call" (RO_array.of_list [local]) in
+  let q = call bs "call" [local] in
   (* Server echos args back *)
   CS.flush c s;
-  Alcotest.(check response_promise) "Client got response" (Some (Error (`Exception "test-error"))) q#response;
+  Alcotest.(check response_promise) "Client got response" (Some (Error (Error.exn "test-error"))) q#response;
   q#finish;
   bs#dec_ref;
   CS.flush c s;
   CS.check_finished c s
-
-let call target msg caps =
-  List.iter (fun c -> c#inc_ref) caps;
-  target#call msg (RO_array.of_list caps)
 
 let test_share_cap () =
   let open CS in
@@ -161,6 +163,105 @@ let test_local_embargo_2 () =
   CS.flush c s;
   CS.check_finished c s
 
+(* Embargo on a resolve message *)
+let test_local_embargo_3 () =
+  let open CS in
+  let module Proxy = Testbed.Capnp_direct.Cap_proxy in
+  let service = Services.manual () in
+  let c, s, bs = init_pair ~bootstrap_service:service in
+  let local = Services.logger () in
+  let q1 = call bs "q1" [cap local] in
+  S.handle_msg s ~expect:"call:q1";
+  let (_, q1_args, a1) = service#pop in
+  let proxy_to_logger = RO_array.get q1_args 0 in
+  let promise = new Proxy.local_promise in
+  a1#resolve (Ok ("a1", RO_array.of_list [cap promise]));
+  C.handle_msg c ~expect:"return:a1";
+  let service = q1#cap 0 in
+  let _ = service#call "Message-1" empty in
+  promise#resolve proxy_to_logger;
+  C.handle_msg c ~expect:"resolve";
+  (* We've received the resolve message, so we know that [service] is local,
+     but the pipelined message we sent to it via [s] hasn't arrived yet. *)
+  let _ = service#call "Message-2" empty in
+  S.handle_msg s ~expect:"finish";
+  S.handle_msg s ~expect:"call:Message-1";
+  C.handle_msg c ~expect:"call:Message-1";            (* Gets pipelined message back *)
+  S.handle_msg s ~expect:"disembargo-request";
+  C.handle_msg c ~expect:"disembargo-reply";
+  Alcotest.(check string) "Pipelined arrived first" "Message-1" local#pop;
+  Alcotest.(check string) "Embargoed arrived second" "Message-2" local#pop;
+  (* Clean up *)
+  q1#finish;
+  bs#dec_ref;
+  service#dec_ref;
+  CS.flush c s;
+  CS.check_finished c s
+
+(* Embargo an local answer that doesn't have the specified cap. *)
+let test_local_embargo_4 () =
+  let open CS in
+  let service = Services.manual () in
+  let c, s, bs = init_pair ~bootstrap_service:service in
+  let local = Services.echo_service () in
+  let q1 = call bs "q1" [cap local] in
+  let broken = q1#cap 0 in
+  let _ = call broken "pipeline" [] in
+  S.handle_msg s ~expect:"call:q1";
+  let (_, q1_args, a1) = service#pop in
+  let proxy_to_local = RO_array.get q1_args 0 in
+  let q2 = call proxy_to_local "q2" [] in
+  a1#resolve (Ok ("a1", RO_array.of_list [q2#cap 0]));
+  C.handle_msg c ~expect:"call:q2";
+  C.handle_msg c ~expect:"return:a1";
+  (* At this point, the client knows that [broken] is its own answer to [q2], which is an error.
+     It therefore does not try to disembargo it. *)
+  Alcotest.(check string) "Error not embargoed"
+    "Failed: Invalid cap index 0 in []"
+   (Fmt.strf "%t" broken#shortest#pp);
+  (* Clean up *)
+  proxy_to_local#dec_ref;
+  q1#finish;
+  bs#dec_ref;
+  service#dec_ref;
+  CS.flush c s;
+  CS.check_finished c s
+
+(* A remote answer resolves to a remote promise, which doesn't require an embargo.
+   However, when that promise resolves to a local service, we *do* need an embargo
+   (because we pipelined over the answer), even though we didn't pipeline over the
+   import. *)
+let test_local_embargo_5 () =
+  let open CS in
+  let module Proxy = Testbed.Capnp_direct.Cap_proxy in
+  let service = Services.manual () in
+  let c, s, bs = init_pair ~bootstrap_service:service in
+  let local = Services.logger () in
+  let q1 = call bs "q1" [cap local] in
+  let test = q1#cap 0 in
+  let _ = call test "Message-1" [] in
+  S.handle_msg s ~expect:"call:q1";
+  let (_, q1_args, a1) = service#pop in
+  let proxy_to_local = RO_array.get q1_args 0 in
+  let server_promise = new Proxy.local_promise in
+  a1#resolve (Ok ("a1", RO_array.of_list [cap server_promise]));
+  C.handle_msg c ~expect:"return:a1";
+  (* [test] is now known to be at [service]; no embargo needed.
+     The server now resolves it to a client service. *)
+  server_promise#resolve proxy_to_local;
+  C.handle_msg c ~expect:"resolve";
+  let _ = call test "Message-2" [] in
+  CS.flush c s;
+  Alcotest.(check string) "Pipelined arrived first" "Message-1" local#pop;
+  Alcotest.(check string) "Embargoed arrived second" "Message-2" local#pop;
+
+  (* Clean up *)
+  q1#finish;
+  bs#dec_ref;
+  service#dec_ref;
+  CS.flush c s;
+  CS.check_finished c s
+
 (* The field must still be useable after the struct is released. *)
 let test_fields () =
   let open CS in
@@ -231,8 +332,8 @@ let test_duplicates () =
 
 let ensure_is_cycle_error (x:#Core_types.struct_ref) : unit =
   match x#response with
-  | Some (Error (`Exception msg))
-    when (String.is_prefix ~affix:"Attempt to create a cycle detected:" msg) -> ()
+  | Some (Error (`Exception ex))
+    when (String.is_prefix ~affix:"Attempt to create a cycle detected:" ex.Exception.reason) -> ()
   | _ -> Alcotest.fail (Fmt.strf "Not a cycle error: %t" x#pp)
 
 let test_cycle () =
@@ -263,18 +364,110 @@ let test_cycle_2 () =
   s1#resolve (Ok ("a7", RO_array.of_list [s2#cap 0]));
   ensure_is_cycle_error s1
 
+(* The server returns an answer containing a promise. Later, it resolves the promise
+   to a resource at the client. The client must be able to invoke the service locally. *)
+let test_resolve () =
+  let module Proxy = Testbed.Capnp_direct.Cap_proxy in
+  let open CS in
+  let service = Services.manual () in
+  let client_logger = Services.logger () in
+  let c, s, proxy_to_service = init_pair ~bootstrap_service:service in
+  (* The client makes a call and gets a reply, but the reply contains a promise. *)
+  let q1 = call proxy_to_service "q1" [cap client_logger] in
+  proxy_to_service#dec_ref;
+  S.handle_msg s ~expect:"call:q1";
+  let (_, q1_args, a1) = service#pop in
+  let proxy_to_logger = RO_array.get q1_args 0 in
+  let promise = new Proxy.local_promise in
+  a1#resolve (Ok ("a1", RO_array.of_list [cap promise]));
+  C.handle_msg c ~expect:"return:a1";
+  (* The server now resolves the promise *)
+  promise#resolve proxy_to_logger;
+  CS.flush c s;
+  (* The client can now use the logger directly *)
+  let x = q1#cap 0 in
+  let q2 = call x "test-message" [] in
+  Alcotest.(check string) "Got message directly" "test-message" client_logger#pop;
+  q2#finish;
+  CS.flush c s;
+  CS.check_finished c s
+
+(* The server resolves an export after the client has released it.
+   The client releases the new target. *)
+let test_resolve_2 () =
+  let module Proxy = Testbed.Capnp_direct.Cap_proxy in
+  let open CS in
+  let service = Services.manual () in
+  let client_logger = Services.logger () in
+  let c, s, proxy_to_service = init_pair ~bootstrap_service:service in
+  (* The client makes a call and gets a reply, but the reply contains a promise. *)
+  let q1 = call proxy_to_service "q1" [cap client_logger] in
+  proxy_to_service#dec_ref;
+  S.handle_msg s ~expect:"call:q1";
+  let (_, q1_args, a1) = service#pop in
+  let proxy_to_logger = RO_array.get q1_args 0 in
+  let promise = new Proxy.local_promise in
+  a1#resolve (Ok ("a1", RO_array.of_list [cap promise]));
+  C.handle_msg c ~expect:"return:a1";
+  (* The client doesn't care about the result and releases it *)
+  q1#finish;
+  (* The server now resolves the promise. The client must release the new target. *)
+  promise#resolve proxy_to_logger;
+  CS.flush c s;
+  CS.check_finished c s
+
+(* The server returns a promise, but by the time it resolves the server
+   has removed the export. It must not send a resolve message. *)
+let test_resolve_3 () =
+  let module Proxy = Testbed.Capnp_direct.Cap_proxy in
+  let open CS in
+  let service = Services.manual () in
+  let c, s, proxy_to_service = init_pair ~bootstrap_service:service in
+  (* Make a call, get a promise, and release it *)
+  let q1 = call proxy_to_service "q1" [] in
+  S.handle_msg s ~expect:"call:q1";
+  let (_, _q1_args, a1) = service#pop in
+  let a1_promise = new Proxy.local_promise in
+  a1#resolve (Ok ("a1", RO_array.of_list [cap a1_promise]));
+  C.handle_msg c ~expect:"return:a1";
+  q1#finish;
+  S.handle_msg s ~expect:"finish";
+  S.handle_msg s ~expect:"release";
+  (* Make another call, get a settled export this time. *)
+  let q2 = call proxy_to_service "q2" [] in
+  S.handle_msg s ~expect:"call:q2";
+  CS.flush c s;
+  let (_, _q2_args, a2) = service#pop in
+  let echo = Services.echo_service () in
+  echo#inc_ref;
+  a2#resolve (Ok ("a2", RO_array.of_list [cap echo]));
+  C.handle_msg c ~expect:"return:a2";
+  (* Service now resolves first answer *)
+  a1_promise#resolve echo;
+  proxy_to_service#dec_ref;
+  CS.flush c s;
+  q2#finish;
+  CS.flush c s;
+  CS.check_finished c s
+
 let tests = [
   "Return",     `Quick, test_return;
   "Return error", `Quick, test_return_error;
   "Connection", `Quick, test_simple_connection;
   "Local embargo", `Quick, test_local_embargo;
   "Local embargo 2", `Quick, test_local_embargo_2;
+  "Local embargo 3", `Quick, test_local_embargo_3;
+  "Local embargo 4", `Quick, test_local_embargo_4;
+  "Local embargo 5", `Quick, test_local_embargo_5;
   "Shared cap", `Quick, test_share_cap;
   "Fields", `Quick, test_fields;
   "Cancel", `Quick, test_cancel;
   "Duplicates", `Quick, test_duplicates;
   "Cycle", `Quick, test_cycle;
   "Cycle 2", `Quick, test_cycle_2;
+  "Resolve", `Quick, test_resolve;
+  "Resolve 2", `Quick, test_resolve_2;
+  "Resolve 3", `Quick, test_resolve_3;
 ]
 
 let () =

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -29,13 +29,14 @@ module Endpoint (EP : Capnp_direct.ENDPOINT) = struct
     | `Bootstrap _ -> "bootstrap"
     | `Call (_, _, msg, _) -> "call:" ^ msg
     | `Return (_, `Results (msg, _)) -> "return:" ^ msg
-    | `Return (_, `Exception msg) -> "return:" ^ msg
+    | `Return (_, `Exception ex) -> "return:" ^ ex.Capnp_rpc.Exception.reason
     | `Return (_, `Cancelled) -> "return:(cancelled)"
     | `Return (_, _) -> "return:(other)"
     | `Finish _ -> "finish"
     | `Release _ -> "release"
     | `Disembargo_request _ -> "disembargo-request"
     | `Disembargo_reply _ -> "disembargo-reply"
+    | `Resolve _ -> "resolve"
 
   let pop_msg ?expect t =
     match Queue.pop t.recv_queue, expect with

--- a/test/testbed/services.ml
+++ b/test/testbed/services.ml
@@ -23,6 +23,20 @@ let manual () = object
 
   method pop = Queue.pop queue  (* Caller takes ownership of caps *)
 
+  (* Expect a message with no caps *)
+  method pop0 msg =
+    let actual, args, answer = Queue.pop queue in
+    Alcotest.(check string) ("Expecting " ^ msg) msg actual;
+    Alcotest.(check int) "Has no args" 0 @@ RO_array.length args;
+    answer
+
+  (* Expect a message with one cap *)
+  method pop1 msg =
+    let actual, args, answer = Queue.pop queue in
+    Alcotest.(check string) ("Expecting " ^ msg) msg actual;
+    Alcotest.(check int) "Has one arg" 1 @@ RO_array.length args;
+    RO_array.get args 0, answer
+
   method! pp f = Fmt.string f "manual"
 end
 


### PR DESCRIPTION
Also, added Exception module to store full capnp exception information, sorted out some more ref-counting problems, and fixed a bug in the fuzz testing (bootstrap replies always got added the client's vat, even if the server made the call).

Closes #24.

Currently fails after fuzzing for about 1 minute, so not ready for merging.