### PR TITLE
Support Resolve and Release in Lwt bindings, and many ref-counting fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ocaml/opam@sha256:a469435632d0cacbceab799d7e48201b727d025fa1805cbbe210d9423
 RUN cd opam-repository && git fetch && git reset --hard f946b0ab58422e1f38b9bd3069a6c874d9df0129 && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
-RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces" && \
+RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces2" && \
     opam pin add -ny capnp-rpc . && \
     opam pin add -ny capnp-rpc-lwt . && \
     opam depext capnp-rpc-lwt

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
-	#./_build/default/test/test.bc test core -ev 14
+	#./_build/default/test/test.bc test core -ev 0
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
-	#./_build/default/test/test.bc test core -ev 0
+	#./_build/default/test-lwt/test.bc test lwt -ev 0
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some key features:
 
 This library should be used with the [capnp-ocaml][] schema compiler, which generates bindings from schema files.
 
-Currently, you need to pin the <https://github.com/talex5/capnp-ocaml/tree/interfaces> branch, which adds support for compiling interface definitions.
+Currently, you need to pin the <https://github.com/talex5/capnp-ocaml/tree/interfaces2> branch, which adds support for compiling interface definitions.
 
 
 ### Status
@@ -50,7 +50,7 @@ To build, you will need a platform with the capnproto package available (e.g. De
 
     git clone https://github.com/mirage/capnp-rpc.git
     cd capnp-rpc
-    opam pin add -n capnp "https://github.com/talex5/capnp-ocaml.git#interfaces"
+    opam pin add -n capnp "https://github.com/talex5/capnp-ocaml.git#interfaces2"
     opam pin add -nyk git capnp-rpc .
     opam pin add -nyk git capnp-rpc-lwt .
     opam depext capnp-rpc-lwt alcotest

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -11,3 +11,6 @@ val of_endpoint : ?offer:cap -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> End
 
 val bootstrap : t -> cap
 (** [bootstrap t] is the peer's public bootstrap object, if any. *)
+
+val dump : t Fmt.t
+(** [dump] dumps the state of the connection, for debugging. *)

--- a/capnp-rpc-lwt/capnp_core.ml
+++ b/capnp-rpc-lwt/capnp_core.ml
@@ -1,3 +1,5 @@
+open Lwt.Infix
+
 module Capnp_content = struct
   module Path = struct
     type t = Xform.t list
@@ -35,6 +37,13 @@ module Capnp_content = struct
       Payload.content_set_interface p (Some Uint32.zero);   (* Cap index 0 *)
       Rpc.Builder ret
   end
+
+  let ref_leak_detected fn =
+    Lwt.async (fun () ->
+        Lwt.pause () >|= fun () ->
+        fn ();
+        failwith "ref_leak_detected"
+      )
 end
 
 module Core_types = struct

--- a/capnp-rpc-lwt/request.ml
+++ b/capnp-rpc-lwt/request.ml
@@ -33,4 +33,12 @@ let get_call t =
   | _ -> failwith "Not a call!"
 
 let caps t =
-  List.rev t.exports_rev |> RO_array.of_list
+  let caps = List.rev t.exports_rev |> RO_array.of_list in
+  t.n_exports <- 0;
+  t.exports_rev <- [];
+  caps
+
+let release t =
+  List.iter (fun x -> x#dec_ref) t.exports_rev;
+  t.n_exports <- 0;
+  t.exports_rev <- []

--- a/capnp-rpc-lwt/request.mli
+++ b/capnp-rpc-lwt/request.mli
@@ -9,3 +9,4 @@ val create_no_args : unit -> 'a t
 val export : 'a t -> Core_types.cap -> Uint32.t
 val get_call : 'a t -> Schema.Builder.Call.t
 val caps : 'a t -> Core_types.cap RO_array.t
+val release : 'a t -> unit

--- a/capnp-rpc-lwt/response.ml
+++ b/capnp-rpc-lwt/response.ml
@@ -30,9 +30,17 @@ let export t cap =
   Uint32.of_int i
 
 let caps t =
-  List.rev t.exports_rev |> RO_array.of_list
+  let caps = List.rev t.exports_rev |> RO_array.of_list in
+  t.n_exports <- 0;
+  t.exports_rev <- [];
+  caps
 
 let finish t =
   match Message.get t.msg with
   | Message.Return r -> Rpc.Builder r, caps t
   | _ -> assert false
+
+let release t =
+  List.iter (fun x -> x#dec_ref) t.exports_rev;
+  t.n_exports <- 0;
+  t.exports_rev <- []

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -79,7 +79,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
     mutable import_proxy : [
       | `Uninitialised
       | `Settled of Core_types.cap
-      | `Unsettled of Cap_proxy.local_promise   (* Note: might be resolved to a settled value *)
+      | `Unsettled of Cap_proxy.resolver_cap   (* Note: might be resolved to a settled value *)
     ]
   }
 
@@ -555,7 +555,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
       if settled then
         import.import_proxy <- `Settled cap
       else
-        import.import_proxy <- `Unsettled (new Cap_proxy.switchable cap)
+        import.import_proxy <- `Unsettled (Cap_proxy.switchable cap)
 
     let import_sender t ~mark_dirty ~settled id =
       match Imports.find t.imports id with

--- a/capnp-rpc/capTP.mli
+++ b/capnp-rpc/capTP.mli
@@ -18,6 +18,9 @@ module Make (EP : Message_types.ENDPOINT) : sig
       It will call [queue_send] as necessary to handle the call.
       Messages MUST be fed to [handle_msg] in the order in which they arrive from the peer. *)
 
+  val disconnect : t -> Exception.t -> unit
+  (** [disconnect t reason] breaks all references with [reason] and releases the bootstrap object. *)
+
   (** {2 Debugging and diagnostics} *)
 
   val tags : ?qid:EP.Out.QuestionId.t -> ?aid:EP.Out.AnswerId.t -> t -> Logs.Tag.set

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -4,6 +4,11 @@ module Make(C : S.CORE_TYPES) = struct
   open C
   module Local_struct_promise = Local_struct_promise.Make(C)
 
+  class type resolver_cap = object
+    inherit C.cap
+    method resolve : C.cap -> unit
+  end
+
   class type embargo_cap = object
     inherit cap
     method disembargo : unit
@@ -185,4 +190,7 @@ module Make(C : S.CORE_TYPES) = struct
       method pp f =
         Fmt.pf f "switchable %a" pp_state state
     end
+
+  let local_promise () = (new local_promise :> resolver_cap)
+  let switchable init = (new switchable init :> resolver_cap)
 end

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -12,6 +12,7 @@ module Make(C : S.CORE_TYPES) = struct
   class type embargo_cap = object
     inherit cap
     method disembargo : unit
+    method break : Exception.t -> unit
   end
 
   (* Operations to perform when resolved. *)
@@ -71,6 +72,9 @@ module Make(C : S.CORE_TYPES) = struct
             state <- Resolved released
           )
         | Resolved _ -> failwith "Already resolved!"
+
+      method break ex =
+        self#resolve (broken_cap ex)
 
       method private release =
         match state with

--- a/capnp-rpc/cap_proxy.mli
+++ b/capnp-rpc/cap_proxy.mli
@@ -7,6 +7,7 @@ module Make(C : S.CORE_TYPES) : sig
   class type embargo_cap = object
     inherit C.cap
     method disembargo : unit
+    method break : Exception.t -> unit
   end
 
   val local_promise : unit -> resolver_cap

--- a/capnp-rpc/cap_proxy.mli
+++ b/capnp-rpc/cap_proxy.mli
@@ -1,20 +1,19 @@
 module Make(C : S.CORE_TYPES) : sig
+  class type resolver_cap = object
+    inherit C.cap
+    method resolve : C.cap -> unit
+  end
+
   class type embargo_cap = object
     inherit C.cap
     method disembargo : unit
   end
 
-  class local_promise : object
-    inherit C.cap
-    method resolve : C.cap -> unit
-  end
-  (** A [new local_promise] is a promise that buffers calls until it is resolved. *)
+  val local_promise : unit -> resolver_cap
+  (** A [local_promise ()] is a promise that buffers calls until it is resolved. *)
 
-  class switchable : C.cap -> object
-    inherit C.cap
-    method resolve : C.cap -> unit
-  end
-  (** A [new switchable init] forwards messages to [init], which can be changed by calling resolve. *)
+  val switchable : C.cap -> resolver_cap
+  (** A [switchable init] forwards messages to [init], which can be changed by calling resolve. *)
 
   val embargo : C.cap -> embargo_cap
 end

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -29,6 +29,7 @@ module Make(Wire : S.WIRE) = struct
     method dec_ref : unit
     method shortest : cap
     method when_more_resolved : (cap -> unit) -> unit
+    method sealed_dispatch : 'a. 'a S.brand -> 'a option
   end
 
   class type struct_resolver = object
@@ -39,32 +40,53 @@ module Make(Wire : S.WIRE) = struct
 
   let pp_cap_list f caps = RO_array.pp pp f caps
 
-  class virtual ref_counted = object (self)
-    val mutable ref_count = 1
+  type 'a S.brand += Gc : unit S.brand
 
-    method private virtual release : unit
-    method virtual pp : Format.formatter -> unit
+  class virtual ref_counted =
+    object (self : #cap)
+      val mutable ref_count = 1
+      method private virtual release : unit
+      method virtual pp : Format.formatter -> unit
 
-    method inc_ref =
-      if ref_count < 1 then (
-        failwith (Fmt.strf "inc_ref: already destroyed %t" self#pp)
-      );
-      ref_count <- ref_count + 1
+      method private pp_refcount f =
+        Fmt.pf f "rc=%d" ref_count
 
-    method dec_ref =
-      if ref_count < 1 then failwith (Fmt.strf "Already unref'd! %t" self#pp);
-      ref_count <- ref_count - 1;
-      if ref_count = 0 then
-        self#release
+      method private check_refcount =
+        if ref_count < 1 then
+          Debug.invariant_broken (fun f -> Fmt.pf f "Already unref'd! %t" self#pp)
 
-    method check_invariants =
-      if ref_count <= 0 then (
-        Debug.invariant_broken @@ fun f ->
-        Fmt.pf f "%a for %t"
-          (Fmt.styled `Red (Fmt.fmt "ref_count=%d")) ref_count
-          self#pp
-      )
-  end
+      method inc_ref =
+        self#check_refcount;
+        ref_count <- ref_count + 1
+
+      method dec_ref =
+        self#check_refcount;
+        ref_count <- ref_count - 1;
+        if ref_count = 0 then
+          self#release
+
+      method check_invariants = self#check_refcount
+
+      method sealed_dispatch : type a. a S.brand -> a option = function
+        | Gc ->
+          if ref_count <> 0 then (
+            Log.warn (fun f -> f "@[<v2>Capability reference GC'd with ref-count of %d!@,%t@]"
+                         ref_count self#pp);
+            ref_count <- 0;
+            self#release
+          );
+          Some ()
+        | _ ->
+          None
+
+      method virtual blocker : base_ref option
+      method virtual call : Request.t -> cap RO_array.t -> struct_ref
+      method virtual shortest : cap
+      method virtual when_more_resolved : (cap -> unit) -> unit
+
+      initializer
+        Gc.finalise (fun (self:#cap) -> ignore (self#sealed_dispatch Gc)) self
+    end
 
   let rec broken_cap ex = object (self : cap)
     method call _ caps =
@@ -77,6 +99,7 @@ module Make(Wire : S.WIRE) = struct
     method blocker = None
     method when_more_resolved _ = ()
     method check_invariants = ()
+    method sealed_dispatch _ = None
   end
   and broken_struct err = object (_ : struct_ref)
     method response = Some (Error err)

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -1,3 +1,5 @@
+module Log = Debug.Log
+
 module Make(Wire : S.WIRE) = struct
   module Wire = Wire
 

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -11,8 +11,10 @@ module Make (C : S.CORE_TYPES) = struct
     method private do_pipeline q i msg caps =
       let result = local_promise ~parent:self () in
       q |> Queue.add (fun p ->
-          Logs.info (fun f -> f "%a:%a forwarding %t" Debug.OID.pp id Wire.Path.pp i p#pp);
-          result#connect ((p#cap i)#call msg caps)      (* XXX: dec_ref? *)
+          let cap = p#cap i in
+          let r = result#connect (cap#call msg caps) in
+          cap#dec_ref;
+          r
         );
       (result :> struct_ref)
 

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -36,6 +36,8 @@ module Make (C : S.CORE_TYPES) = struct
       | None, _ -> None            (* Not blocked *)
       | Some _self, Some b -> b#blocker
       | Some _ as x, None -> x
+
+    method field_sealed_dispatch _ _ = None
   end
 
   let make () = (local_promise () :> struct_resolver)

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -39,6 +39,17 @@ module type WIRE = sig
     val cap_index : t -> Path.t -> int option
     (** [cap_index msg path] is the capability index at [path]. *)
   end
+
+  val ref_leak_detected : (unit -> unit) -> unit
+  (** [ref_leak_detected fn] is called when a promise or capability is GC'd while
+      its ref-count is non-zero, indicating that resources may have been leaked.
+      [fn ()] will log a warning about this and free the resources itself.
+      The reason for going via [ref_leak_detected] rather than calling [fn] directly
+      is because the OCaml GC may detect the problem at any point (e.g. while we're
+      sending another message). The implementation should arrange for [fn] to be
+      called at a safe point (e.g. when returning to the main loop).
+      Unit-tests may wish to call [fn] immediately to show the error and then
+      fail the test. *)
 end
 
 module type CORE_TYPES = sig

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -110,7 +110,7 @@ module Make (C : S.CORE_TYPES) = struct
         | ForwardingField c -> c#dec_ref
 
       method resolve cap =
-        Log.info (fun f -> f "Resolve field(%a) to %t" Debug.OID.pp id cap#pp);
+        Log.info (fun f -> f "Resolved field(%a) to %t" Debug.OID.pp id cap#pp);
         match state with
         | ForwardingField _ -> failwith "Field already resolved!"
         | PromiseField _ -> state <- ForwardingField cap
@@ -225,9 +225,9 @@ module Make (C : S.CORE_TYPES) = struct
                   match RO_array.find blocked_on_us caps with
                   | None -> x
                   | Some c ->
-                    let x = cycle_err "Resolving:@,  %t@,with:@,  %t@,due to:@,  %t@]" self#pp x#pp c#pp in
-                    RO_array.iter (fun c -> c#dec_ref) caps;
-                    x
+                    let err = cycle_err "Resolving:@,  %t@,with:@,  %t@,due to:@,  %t@]" self#pp x#pp c#pp in
+                    x#finish;
+                    err
             in
             state <- Forwarding x;
             u.fields |> Field_map.iter (fun path f ->

--- a/capnp-rpc/table.ml
+++ b/capnp-rpc/table.ml
@@ -54,6 +54,12 @@ module Allocating (Key : Id.S) = struct
     (Fmt.Dump.list (pp_item ~check (pp_kv pp))) f items
 
   let iter fn t = Hashtbl.iter fn t.used
+
+  let drop_all t fn =
+    Hashtbl.iter fn t.used;
+    t.free <- [];
+    t.next <- Key.zero;
+    Hashtbl.clear t.used
 end
 
 module Tracking (Key : Id.S) = struct
@@ -87,4 +93,8 @@ module Tracking (Key : Id.S) = struct
     (Fmt.Dump.list (pp_item ~check (pp_kv pp))) f items
 
   let iter fn t = Hashtbl.iter fn t
+
+  let drop_all t fn =
+    Hashtbl.iter fn t;
+    Hashtbl.clear t
 end

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -1,7 +1,7 @@
 module RO_array = Capnp_rpc.RO_array
 module Test_utils = Testbed.Test_utils
 
-let three_vats = true (* XXX *)
+let three_vats = true
 
 let stop_after =
   match Sys.getenv "FUZZ_STOP" with
@@ -169,6 +169,10 @@ module Msg = struct
     let cap_index _ i = Some i
     let bootstrap = "(boot)"
   end
+
+  let ref_leak_detected fn =
+    fn ();
+    failwith "ref_leak_detected"
 end
 
 module Core_types = struct

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -1,7 +1,7 @@
 module RO_array = Capnp_rpc.RO_array
 module Test_utils = Testbed.Test_utils
 
-let three_vats = false (* XXX *)
+let three_vats = true (* XXX *)
 
 let stop_after =
   match Sys.getenv "FUZZ_STOP" with

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -4,21 +4,41 @@ open Capnp_rpc_lwt
 
 module Test_utils = Testbed.Test_utils
 
+type cs = {
+  client : CapTP.t;
+  server : CapTP.t;
+}
+
+(* Have the client ask the server for its bootstrap object, and return the
+   resulting client-side proxy to it. *)
+let get_bootstrap cs =
+  CapTP.bootstrap cs.client
+
+module Utils = struct
+  [@@@ocaml.warning "-32"]
+
+  let dump cs =
+    Logs.info (fun f -> f ~tags:Test_utils.client_tags "%a" CapTP.dump cs.client);
+    Logs.info (fun f -> f ~tags:Test_utils.server_tags "%a" CapTP.dump cs.server)
+end
+
 (* Create a client/server pair, with the server providing [service].
    Return the client proxy to it.
    Everything gets shut down when the switch is turned off. *)
 let run_server ~switch ~service () =
   let server_socket, client_socket = Unix.(socketpair PF_UNIX SOCK_STREAM 0) in
-  let _server =
+  let server =
     CapTP.of_endpoint ~tags:Test_utils.server_tags ~switch ~offer:service (Endpoint.of_socket ~switch server_socket)
   in
   let client =
     CapTP.of_endpoint ~tags:Test_utils.client_tags ~switch (Endpoint.of_socket ~switch client_socket)
   in
-  CapTP.bootstrap client
+  Capability.dec_ref service;
+  { client; server }
 
 (* Generic Lwt running for Alcotest. *)
 let run_lwt fn () =
+  let warnings_at_start = Logs.(err_count () + warn_count ()) in
   Logs.info (fun f -> f "Start test-case");
   let async_ex, async_waker = Lwt.wait () in
   let handle_exn ex =
@@ -28,48 +48,63 @@ let run_lwt fn () =
   in
   Lwt.async_exception_hook := handle_exn;
   Lwt_main.run begin
-  Lwt_switch.with_switch (fun sw ->
+    Lwt_switch.with_switch (fun sw ->
         let finished = ref false in
         Lwt_switch.add_hook (Some sw) (fun () ->
-          if not !finished then handle_exn (Failure "Switch turned off early");
-          Lwt.return_unit
-        );
+            if not !finished then handle_exn (Failure "Switch turned off early");
+            Lwt.return_unit
+          );
         Lwt.pick [
           async_ex;
           fn sw >|= fun () -> finished := true;
-        ]
+        ] >|= fun () ->
+        Gc.full_major ()
       )
-  end
+  end;
+  Lwt.wakeup_paused ();
+  Gc.full_major ();
+  Lwt.wakeup_paused ();
+  Gc.full_major ();
+  let warnings_at_end = Logs.(err_count () + warn_count ()) in
+  Alcotest.(check int) "Check log for warnings" 0 (warnings_at_end - warnings_at_start)
 
 let test_simple switch =
-  let service = run_server ~switch ~service:(Echo.service ()) () in
+  let cs = run_server ~switch ~service:(Echo.service ()) () in
+  let service = get_bootstrap cs in
   Echo.Client.ping service "ping" >>= fun reply ->
   Alcotest.(check string) "Ping response" "got:0:ping" reply;
   Capability.dec_ref service;
   Lwt.return ()
 
 let test_parallel switch =
-  let service = run_server ~switch ~service:(Echo.service ()) () in
+  let cs = run_server ~switch ~service:(Echo.service ()) () in
+  let service = get_bootstrap cs in
   let reply1 = Echo.Client.ping service ~slow:true "ping1" in
   Echo.Client.ping service "ping2" >|= Alcotest.(check string) "Ping2 response" "got:1:ping2" >>= fun () ->
   assert (Lwt.state reply1 = Lwt.Sleep);
   Echo.Client.unblock service >>= fun () ->
   reply1 >|= Alcotest.(check string) "Ping1 response" "got:0:ping1" >>= fun () ->
+  Capability.dec_ref service;
   Lwt.return ()
 
 let test_registry switch =
   let registry_impl = Registry.service () in
-  let registry = run_server ~switch ~service:registry_impl () in
+  let cs = run_server ~switch ~service:registry_impl () in
+  let registry = get_bootstrap cs in
   let echo_service = Registry.Client.echo_service registry in
   Registry.Client.unblock registry >>= fun () ->
   Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
+  Capability.dec_ref registry;
+  Capability.dec_ref echo_service;
   Lwt.return ()
 
 let test_embargo switch =
   let registry_impl = Registry.service () in
   let local_echo = Echo.service () in
-  let registry = run_server ~switch ~service:registry_impl () in
+  let cs = run_server ~switch ~service:registry_impl () in
+  let registry = get_bootstrap cs in
   Registry.Client.set_echo_service registry local_echo >>= fun () ->
+  Capability.dec_ref local_echo;
   let echo_service = Registry.Client.echo_service registry in
   let reply1 = Echo.Client.ping echo_service "ping" in
   Registry.Client.unblock registry >>= fun () ->
@@ -78,10 +113,13 @@ let test_embargo switch =
   Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:1:ping" >>= fun () ->
   (* Test local connection. *)
   Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:2:ping" >>= fun () ->
+  Capability.dec_ref echo_service;
+  Capability.dec_ref registry;
   Lwt.return ()
 
 let test_cancel switch =
-  let service = run_server ~switch ~service:(Echo.service ()) () in
+  let cs = run_server ~switch ~service:(Echo.service ()) () in
+  let service = get_bootstrap cs in
   let reply1 = Echo.Client.ping service ~slow:true "ping1" in
   assert (Lwt.state reply1 = Lwt.Sleep);
   Lwt.cancel reply1;
@@ -93,27 +131,35 @@ let test_cancel switch =
       | ex -> Lwt.fail ex
     )
   >>= fun () ->
-  Echo.Client.unblock service
+  Echo.Client.unblock service >|= fun () ->
+  Capability.dec_ref service
 
 let test_calculator switch =
   let open Calc in
-  let c = run_server ~switch ~service:Calc.service () in
-  Client.evaluate c (Float 1.) |> Client.read >|= Alcotest.(check float) "Simple calc" 1. >>= fun () ->
+  let cs = run_server ~switch ~service:Calc.service () in
+  let c = get_bootstrap cs in
+  Client.evaluate c (Float 1.) |> Client.final_read >|= Alcotest.(check float) "Simple calc" 1. >>= fun () ->
   let local_add = Calc.add in
   let expr = Call (local_add, [Float 1.; Float 2.]) in
-  Client.evaluate c expr |> Client.read >|= Alcotest.(check float) "Complex with local fn" 3. >>= fun () ->
+  Client.evaluate c expr |> Client.final_read >|= Alcotest.(check float) "Complex with local fn" 3. >>= fun () ->
   let remote_add = Calc.Client.getOperator c `Add in
   Calc.Client.call remote_add [5.; 3.] >|= Alcotest.(check float) "Check fn" 8. >>= fun () ->
   let expr = Call (remote_add, [Float 1.; Float 2.]) in
-  Client.evaluate c expr |> Client.read >|= Alcotest.(check float) "Complex with remote fn" 3. >>= fun () ->
+  Client.evaluate c expr |> Client.final_read >|= Alcotest.(check float) "Complex with remote fn" 3. >>= fun () ->
+  Capability.dec_ref remote_add;
+  Capability.dec_ref c;
   Lwt.return ()
 
 let test_indexing switch =
   let registry_impl = Registry.service () in
-  let registry = run_server ~switch ~service:registry_impl () in
+  let cs = run_server ~switch ~service:registry_impl () in
+  let registry = get_bootstrap cs in
   let echo_service, version = Registry.Client.complex registry in
   Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
   Registry.Version.read version >|= Alcotest.(check string) "Version response" "0.1" >>= fun () ->
+  Capability.dec_ref registry;
+  Capability.dec_ref echo_service;
+  Capability.dec_ref version;
   Lwt.return ()
 
 let rpc_tests = [

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,10 +3,13 @@ open Astring
 module Core_types = Testbed.Capnp_direct.Core_types
 module Test_utils = Testbed.Test_utils
 module Services = Testbed.Services
-module CS = Testbed.Connection.Make ( )    (* A client-server pair *)
+module CS = Testbed.Connection.Pair ( )    (* A client-server pair *)
 module RO_array = Capnp_rpc.RO_array
 module Error = Capnp_rpc.Error
 module Exception = Capnp_rpc.Exception
+
+module C = CS.C
+module S = CS.S
 
 let empty = RO_array.empty
 
@@ -24,8 +27,7 @@ let resolve_ok (ans:#Core_types.struct_resolver) msg caps =
   ans#resolve (Ok (msg, RO_array.of_list caps))
 
 let test_simple_connection () =
-  let open CS in
-  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags (Services.echo_service ()) in
+  let c, s = CS.create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags (Services.echo_service ()) in
   let servce_promise = C.bootstrap c in
   S.handle_msg s ~expect:"bootstrap";
   C.handle_msg c ~expect:"return:(boot)";
@@ -39,8 +41,7 @@ let test_simple_connection () =
   CS.check_finished c s
 
 let init_pair ~bootstrap_service =
-  let open CS in
-  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags bootstrap_service in
+  let c, s = CS.create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags bootstrap_service in
   let bs = C.bootstrap c in
   S.handle_msg s ~expect:"bootstrap";
   C.handle_msg c ~expect:"return:(boot)";
@@ -55,12 +56,12 @@ let call target msg caps =
 (* The server gets an object and then sends it back. When the object arrives back
    at the client, it must be the original (local) object, not a proxy. *)
 let test_return () =
-  let open CS in
   let c, s, bs = init_pair ~bootstrap_service:(Services.echo_service ()) in
   (* Pass callback *)
   let slot = ref ("empty", empty) in
   let local = Services.swap_service slot in
   let q = call bs "c1" [local] in
+  local#dec_ref;
   (* Server echos args back *)
   S.handle_msg s ~expect:"call:c1";
   C.handle_msg c ~expect:"return:got:c1";
@@ -69,6 +70,7 @@ let test_return () =
   S.handle_msg s ~expect:"finish";
   S.handle_msg s ~expect:"release";
   C.handle_msg c ~expect:"release";
+  q#finish;
   CS.check_finished c s
 
 let test_return_error () =
@@ -77,6 +79,7 @@ let test_return_error () =
   let slot = ref ("empty", empty) in
   let local = Services.swap_service slot in
   let q = call bs "call" [local] in
+  local#dec_ref;
   (* Server echos args back *)
   CS.flush c s;
   Alcotest.(check response_promise) "Client got response" (Some (Error (Error.exn "test-error"))) q#response;
@@ -86,7 +89,6 @@ let test_return_error () =
   CS.check_finished c s
 
 let test_share_cap () =
-  let open CS in
   let c, s, bs = init_pair ~bootstrap_service:(Services.echo_service ()) in
   let q = call bs "msg" [bs; bs] in
   bs#dec_ref;
@@ -101,7 +103,6 @@ let test_share_cap () =
 (* The server gets an object and then sends it back. Messages pipelined to
    the object must arrive before ones sent directly. *)
 let test_local_embargo () =
-  let open CS in
   let c, s, bs = init_pair ~bootstrap_service:(Services.echo_service ()) in
   let local = Services.logger () in
   let q = call bs "Get service" [(local :> Core_types.cap)] in
@@ -109,6 +110,7 @@ let test_local_embargo () =
   let _ = service#call "Message-1" empty in
   S.handle_msg s ~expect:"call:Get service";
   C.handle_msg c ~expect:"return:got:Get service";
+  q#finish;
   (* We've received the bootstrap reply, so we know that [service] is local,
      but the pipelined message we sent to it via [s] hasn't arrived yet. *)
   let _ = service#call "Message-2" empty in
@@ -119,17 +121,15 @@ let test_local_embargo () =
   Alcotest.(check string) "Pipelined arrived first" "Message-1" local#pop;
   Alcotest.(check string) "Embargoed arrived second" "Message-2" local#pop;
   (* Clean up *)
-  q#finish;
+  CS.dump c s;
+  local#dec_ref;
   bs#dec_ref;
   service#dec_ref;
   CS.flush c s;
   CS.check_finished c s
 
-let cap x = (x :> Core_types.cap)
-
 (* As above, but this time it resolves to a promised answer. *)
 let test_local_embargo_2 () =
-  let open CS in
   let server_main = Services.manual () in
   let c, s, bs = init_pair ~bootstrap_service:server_main in
   let local = Services.logger () in
@@ -168,12 +168,12 @@ let test_local_embargo_2 () =
   (* Clean up *)
   bs#dec_ref;
   service#dec_ref;
+  local_reg#dec_ref;
   CS.flush c s;
   CS.check_finished c s
 
 (* Embargo on a resolve message *)
 let test_local_embargo_3 () =
-  let open CS in
   let module Proxy = Testbed.Capnp_direct.Cap_proxy in
   let service = Services.manual () in
   let c, s, bs = init_pair ~bootstrap_service:service in
@@ -200,6 +200,7 @@ let test_local_embargo_3 () =
   Alcotest.(check string) "Pipelined arrived first" "Message-1" local#pop;
   Alcotest.(check string) "Embargoed arrived second" "Message-2" local#pop;
   (* Clean up *)
+  local#dec_ref;
   q1#finish;
   bs#dec_ref;
   service#dec_ref;
@@ -208,7 +209,6 @@ let test_local_embargo_3 () =
 
 (* Embargo an local answer that doesn't have the specified cap. *)
 let test_local_embargo_4 () =
-  let open CS in
   let service = Services.manual () in
   let c, s, bs = init_pair ~bootstrap_service:service in
   let local = Services.echo_service () in
@@ -228,10 +228,10 @@ let test_local_embargo_4 () =
     "Failed: Invalid cap index 0 in []"
    (Fmt.strf "%t" broken#shortest#pp);
   (* Clean up *)
+  local#dec_ref;
   proxy_to_local#dec_ref;
   q1#finish;
   bs#dec_ref;
-  service#dec_ref;
   CS.flush c s;
   CS.check_finished c s
 
@@ -240,7 +240,6 @@ let test_local_embargo_4 () =
    (because we pipelined over the answer), even though we didn't pipeline over the
    import. *)
 let test_local_embargo_5 () =
-  let open CS in
   let module Proxy = Testbed.Capnp_direct.Cap_proxy in
   let service = Services.manual () in
   let c, s, bs = init_pair ~bootstrap_service:service in
@@ -262,10 +261,12 @@ let test_local_embargo_5 () =
   CS.flush c s;
   Alcotest.(check string) "Pipelined arrived first" "Message-1" local#pop;
   Alcotest.(check string) "Embargoed arrived second" "Message-2" local#pop;
+  CS.flush c s;
   (* Clean up *)
+  local#dec_ref;
+  test#dec_ref;
   q1#finish;
   bs#dec_ref;
-  service#dec_ref;
   CS.flush c s;
   CS.check_finished c s
 
@@ -274,7 +275,6 @@ let test_local_embargo_5 () =
    is already bouncing the pipelined message back to us, we need to embargo
    the new cap until the server's question is finished. *)
 let test_local_embargo_6 () =
-  let open CS in
   let service = Services.manual () in
   let c, s, bs = init_pair ~bootstrap_service:service in
   let local = Services.manual () in
@@ -311,14 +311,15 @@ let test_local_embargo_6 () =
   let m2 = service#pop0 "Message-2" in
   resolve_ok m1 "m1" [];
   resolve_ok m2 "m2" [];
+  q2#finish;
   proxy_to_local#dec_ref;
+  local#dec_ref;
   CS.flush c s;
   CS.check_finished c s
 
 (* The field must still be useable after the struct is released. *)
 let test_fields () =
-  let open CS in
-  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags (Services.echo_service ()) in
+  let c, s = CS.create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags (Services.echo_service ()) in
   let f0 = C.bootstrap c in
   let q1 = call f0 "c1" [] in
   S.handle_msg s ~expect:"bootstrap";
@@ -336,9 +337,8 @@ let test_fields () =
   CS.check_finished c s
 
 let test_cancel () =
-  let open CS in
   let service = Services.manual () in
-  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags
+  let c, s = CS.create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags
       (service :> Core_types.cap) in
   let f0 = C.bootstrap c in
   let q1 = call f0 "c1" [] in
@@ -360,9 +360,8 @@ let test_cancel () =
 
 (* Asking for the same field twice gives the same object. *)
 let test_duplicates () =
-  let open CS in
   let service = Services.manual () in
-  let c, s = create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags
+  let c, s = CS.create ~client_tags:Test_utils.client_tags ~server_tags:Test_utils.server_tags
       (service :> Core_types.cap) in
   let f0 = C.bootstrap c in
   let q1 = call f0 "c1" [] in
@@ -386,13 +385,12 @@ let test_duplicates () =
 
 (* Exporting a cap twice reuses the existing export. *)
 let test_single_export () =
-  let open CS in
   let service = Services.manual () in
   let c, s, bs = init_pair ~bootstrap_service:service in
   let local = Services.echo_service () in
   let q1 = call bs "q1" [local; local] in
   let q2 = call bs "q2" [local] in
-  Alcotest.(check int) "One export" 1 (C.Conn.stats c.C.conn).n_exports;
+  Alcotest.(check int) "One export" 1 (C.stats c).n_exports;
   S.handle_msg s ~expect:"call:q1";
   S.handle_msg s ~expect:"call:q2";
   q1#finish;
@@ -405,13 +403,13 @@ let test_single_export () =
   in
   ignore "q1";
   ignore "q2";
+  local#dec_ref;
   bs#dec_ref;
   CS.flush c s;
   CS.check_finished c s
 
 (* Exporting a field of a remote promise sends a promised answer desc. *)
 let test_shorten_field () =
-  let open CS in
   let service = Services.manual () in
   let logger = Services.logger () in
   let c, s, bs = init_pair ~bootstrap_service:service in
@@ -425,6 +423,7 @@ let test_shorten_field () =
   let direct_to_logger, a2 = service#pop1 "q2" in
   assert (direct_to_logger#shortest = (logger :> Core_types.cap));
   resolve_ok a2 "a2" [];
+  direct_to_logger#dec_ref;
   bs#dec_ref;
   proxy_to_logger#dec_ref;
   q1#finish;
@@ -470,7 +469,6 @@ let test_cycle_2 () =
    to a resource at the client. The client must be able to invoke the service locally. *)
 let test_resolve () =
   let module Proxy = Testbed.Capnp_direct.Cap_proxy in
-  let open CS in
   let service = Services.manual () in
   let client_logger = Services.logger () in
   let c, s, proxy_to_service = init_pair ~bootstrap_service:service in
@@ -478,19 +476,23 @@ let test_resolve () =
   let q1 = call proxy_to_service "q1" [client_logger] in
   proxy_to_service#dec_ref;
   S.handle_msg s ~expect:"call:q1";
-  let (_, q1_args, a1) = service#pop in
-  let proxy_to_logger = RO_array.get q1_args 0 in
+  let proxy_to_logger, a1 = service#pop1 "q1" in
   let promise = Proxy.local_promise () in
+  promise#inc_ref;
   resolve_ok a1 "a1" [promise];
   C.handle_msg c ~expect:"return:a1";
   (* The server now resolves the promise *)
   promise#resolve proxy_to_logger;
+  promise#dec_ref;
   CS.flush c s;
   (* The client can now use the logger directly *)
   let x = q1#cap 0 in
   let q2 = call x "test-message" [] in
   Alcotest.(check string) "Got message directly" "test-message" client_logger#pop;
+  x#dec_ref;
+  q1#finish;
   q2#finish;
+  client_logger#dec_ref;
   CS.flush c s;
   CS.check_finished c s
 
@@ -498,16 +500,15 @@ let test_resolve () =
    The client releases the new target. *)
 let test_resolve_2 () =
   let module Proxy = Testbed.Capnp_direct.Cap_proxy in
-  let open CS in
   let service = Services.manual () in
   let client_logger = Services.logger () in
   let c, s, proxy_to_service = init_pair ~bootstrap_service:service in
   (* The client makes a call and gets a reply, but the reply contains a promise. *)
   let q1 = call proxy_to_service "q1" [client_logger] in
+  client_logger#dec_ref;
   proxy_to_service#dec_ref;
   S.handle_msg s ~expect:"call:q1";
-  let (_, q1_args, a1) = service#pop in
-  let proxy_to_logger = RO_array.get q1_args 0 in
+  let proxy_to_logger, a1 = service#pop1 "q1" in
   let promise = Proxy.local_promise () in
   resolve_ok a1 "a1" [promise];
   C.handle_msg c ~expect:"return:a1";
@@ -522,14 +523,14 @@ let test_resolve_2 () =
    has removed the export. It must not send a resolve message. *)
 let test_resolve_3 () =
   let module Proxy = Testbed.Capnp_direct.Cap_proxy in
-  let open CS in
   let service = Services.manual () in
   let c, s, proxy_to_service = init_pair ~bootstrap_service:service in
   (* Make a call, get a promise, and release it *)
   let q1 = call proxy_to_service "q1" [] in
   S.handle_msg s ~expect:"call:q1";
-  let (_, _q1_args, a1) = service#pop in
+  let a1 = service#pop0 "q1" in
   let a1_promise = Proxy.local_promise () in
+  a1_promise#inc_ref;
   resolve_ok a1 "a1" [a1_promise];
   C.handle_msg c ~expect:"return:a1";
   q1#finish;
@@ -539,13 +540,14 @@ let test_resolve_3 () =
   let q2 = call proxy_to_service "q2" [] in
   S.handle_msg s ~expect:"call:q2";
   CS.flush c s;
-  let (_, _q2_args, a2) = service#pop in
+  let a2 = service#pop0 "q2" in
   let echo = Services.echo_service () in
   echo#inc_ref;
   resolve_ok a2 "a2" [echo];
   C.handle_msg c ~expect:"return:a2";
   (* Service now resolves first answer *)
   a1_promise#resolve echo;
+  a1_promise#dec_ref;
   proxy_to_service#dec_ref;
   CS.flush c s;
   q2#finish;
@@ -561,7 +563,7 @@ let test_ref_counts () =
       val id = Capnp_rpc.Debug.OID.next ()
       method call _ _  = failwith "call"
       method! private release = Hashtbl.remove objects self
-      method! pp f = Fmt.pf f "Service(%a, rc=%d)" Capnp_rpc.Debug.OID.pp id ref_count
+      method! pp f = Fmt.pf f "Service(%a, %t)" Capnp_rpc.Debug.OID.pp id self#pp_refcount
     end in
     Hashtbl.add objects o true;
     o
@@ -572,7 +574,7 @@ let test_ref_counts () =
       val id = Capnp_rpc.Debug.OID.next ()
       method call _ _  = failwith "call"
       method private release = Hashtbl.remove objects self
-      method pp f = Fmt.pf f "remote-promise(%a, rc=%d)" Capnp_rpc.Debug.OID.pp id ref_count
+      method pp f = Fmt.pf f "remote-promise(%a, %t)" Capnp_rpc.Debug.OID.pp id self#pp_refcount
       method blocker = Some (self :> Core_types.base_ref)
       method shortest = (self :> Core_types.cap)
       method when_more_resolved _ = ()
@@ -599,7 +601,7 @@ let test_ref_counts () =
   promise#dec_ref;
   Alcotest.(check int) "Local promise released" 0 (Hashtbl.length objects);
   (* Test switchable promise *)
-  let promise = new Proxy.switchable (remote_promise ()) in
+  let promise = Proxy.switchable (remote_promise ()) in
   promise#when_more_resolved dec_ref;
   promise#resolve (make ());
   promise#dec_ref;
@@ -615,7 +617,7 @@ let test_ref_counts () =
   embargo#when_more_resolved dec_ref;
   embargo#dec_ref;
   Alcotest.(check int) "Embargo released" 0 (Hashtbl.length objects);
-  ()
+  Gc.full_major ()
 
 let tests = [
   "Return",     `Quick, test_return;
@@ -639,7 +641,9 @@ let tests = [
   "Resolve 2", `Quick, test_resolve_2;
   "Resolve 3", `Quick, test_resolve_3;
   "Ref-counts", `Quick, test_ref_counts;
-]
+] |> List.map (fun (name, speed, test) ->
+    name, speed, (fun () -> test (); Gc.full_major ())
+  )
 
 let () =
   Printexc.record_backtrace true;

--- a/test/test.ml
+++ b/test/test.ml
@@ -131,7 +131,7 @@ let cap x = (x :> Core_types.cap)
 let test_local_embargo_2 () =
   let open CS in
   let server_main = Services.manual () in
-  let c, s, bs = init_pair ~bootstrap_service:(cap server_main) in
+  let c, s, bs = init_pair ~bootstrap_service:server_main in
   let local = Services.logger () in
   let local_reg = Services.manual () in    (* A registry that provides access to [local]. *)
   let q1 = call bs "q1" [local_reg] in (* Give the server our registry and get back [local]. *)
@@ -182,7 +182,7 @@ let test_local_embargo_3 () =
   S.handle_msg s ~expect:"call:q1";
   let (_, q1_args, a1) = service#pop in
   let proxy_to_logger = RO_array.get q1_args 0 in
-  let promise = new Proxy.local_promise in
+  let promise = Proxy.local_promise () in
   resolve_ok a1 "a1" [promise];
   C.handle_msg c ~expect:"return:a1";
   let service = q1#cap 0 in
@@ -251,7 +251,7 @@ let test_local_embargo_5 () =
   S.handle_msg s ~expect:"call:q1";
   let (_, q1_args, a1) = service#pop in
   let proxy_to_local = RO_array.get q1_args 0 in
-  let server_promise = new Proxy.local_promise in
+  let server_promise = Proxy.local_promise () in
   resolve_ok a1 "a1" [server_promise];
   C.handle_msg c ~expect:"return:a1";
   (* [test] is now known to be at [service]; no embargo needed.
@@ -441,8 +441,8 @@ let ensure_is_cycle_error (x:#Core_types.struct_ref) : unit =
 let test_cycle () =
   (* Cap cycles *)
   let module P = Testbed.Capnp_direct.Cap_proxy in
-  let p1 = new P.local_promise in
-  let p2 = new P.local_promise in
+  let p1 = P.local_promise () in
+  let p2 = P.local_promise () in
   p1#resolve (p2 :> Core_types.cap);
   p2#resolve (p1 :> Core_types.cap);
   ensure_is_cycle_error (call p2 "test" []);
@@ -480,7 +480,7 @@ let test_resolve () =
   S.handle_msg s ~expect:"call:q1";
   let (_, q1_args, a1) = service#pop in
   let proxy_to_logger = RO_array.get q1_args 0 in
-  let promise = new Proxy.local_promise in
+  let promise = Proxy.local_promise () in
   resolve_ok a1 "a1" [promise];
   C.handle_msg c ~expect:"return:a1";
   (* The server now resolves the promise *)
@@ -508,7 +508,7 @@ let test_resolve_2 () =
   S.handle_msg s ~expect:"call:q1";
   let (_, q1_args, a1) = service#pop in
   let proxy_to_logger = RO_array.get q1_args 0 in
-  let promise = new Proxy.local_promise in
+  let promise = Proxy.local_promise () in
   resolve_ok a1 "a1" [promise];
   C.handle_msg c ~expect:"return:a1";
   (* The client doesn't care about the result and releases it *)
@@ -529,7 +529,7 @@ let test_resolve_3 () =
   let q1 = call proxy_to_service "q1" [] in
   S.handle_msg s ~expect:"call:q1";
   let (_, _q1_args, a1) = service#pop in
-  let a1_promise = new Proxy.local_promise in
+  let a1_promise = Proxy.local_promise () in
   resolve_ok a1 "a1" [a1_promise];
   C.handle_msg c ~expect:"return:a1";
   q1#finish;
@@ -593,7 +593,7 @@ let test_ref_counts () =
   Alcotest.(check int) "Fields released" 0 (Hashtbl.length objects);
   (* Test local promise *)
   let module Proxy = Testbed.Capnp_direct.Cap_proxy in
-  let promise = new Proxy.local_promise in
+  let promise = Proxy.local_promise () in
   promise#when_more_resolved dec_ref;
   promise#resolve (make ());
   promise#dec_ref;

--- a/test/testbed/capnp_direct.ml
+++ b/test/testbed/capnp_direct.ml
@@ -23,6 +23,10 @@ module String_content = struct
     let cap_index _ i = Some i
     let bootstrap = "(boot)"
   end
+
+  let ref_leak_detected fn =
+    fn ();
+    failwith "ref_leak_detected"
 end
 
 module Core_types = struct

--- a/test/testbed/connection.mli
+++ b/test/testbed/connection.mli
@@ -1,0 +1,37 @@
+open Capnp_direct.Core_types
+
+module type ENDPOINT = sig
+  type t
+
+  module EP : Capnp_direct.ENDPOINT
+
+  val dump : t Fmt.t
+
+  val create : ?bootstrap:#cap -> tags:Logs.Tag.set -> EP.Out.t Queue.t -> EP.In.t Queue.t -> t
+
+  val handle_msg : ?expect:string -> t -> unit
+
+  val maybe_handle_msg : t -> unit
+
+  val step : t -> bool
+
+  val bootstrap : t -> cap
+
+  val stats : t -> Capnp_rpc.Stats.t
+end
+
+module Endpoint (EP : Capnp_direct.ENDPOINT) : ENDPOINT
+
+module Pair ( ) : sig
+  module C : ENDPOINT
+  module S : ENDPOINT
+
+  val create : client_tags:Logs.Tag.set -> server_tags:Logs.Tag.set -> #cap -> C.t * S.t
+
+  val flush : C.t -> S.t -> unit
+
+  val dump : C.t -> S.t -> unit
+
+  val check_finished : C.t -> S.t -> unit
+end
+


### PR DESCRIPTION
- Log warnings if caps or structs containing caps are leaked.
- Fix various ref-counting bugs discovered by the above warning.
- Replace `proxy_caps` with a `sealed_dispatch` system. Removes the need for ephemerons and will make implementing level 3 easier.
- Implement deserialisers for release and resolve messages.
- Extend CapTP.disconnect to free the resources.
- Export CapTP dump function in Lwt API.
- Add Capability.call_for_caps to make it easier to finish questions.
- Update to new capnp-ocaml API - allows overriding release and pp
  methods in local services.
- Added Request and Response.release methods in case you need to abort.
- Still finish when an attempt is made to create a cycle.
- Updated examples to do ref-counting correctly.