### PR TITLE
Support Unimplemented messages

### DIFF
--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -1,20 +1,16 @@
 open Lwt.Infix
-open Capnp_core
 
-module EmbargoId = Capnp_rpc.Message_types.EmbargoId
-
-module Log = Rpc.Log
+module Log = Capnp_rpc.Debug.Log
 
 module Builder = Schema.Builder
 module Reader = Schema.Reader
-module RO_array = Capnp_rpc.RO_array
 
 module Conn = Capnp_rpc.CapTP.Make(Capnp_core.Endpoint_types)
-include Capnp_core.Endpoint_types.Table
 
 type t = {
   endpoint : Endpoint.t;
   conn : Conn.t;
+  xmit_queue : Capnp.Message.rw Capnp.BytesMessage.Message.t Queue.t;
 }
 
 let bootstrap t = Conn.bootstrap t.conn
@@ -29,175 +25,42 @@ let async_tagged label fn =
         )
     )
 
-let pp_call f call =
+let pp_msg f call =
   let open Reader in
+  let call = Rpc.readable_req call in
   let interface_id = Call.interface_id_get call in
   let method_id = Call.method_id_get call in
   Capnp.RPC.Registry.pp_method f (interface_id, method_id)
 
-let tags ?qid ?aid t = Conn.tags ?qid ?aid t.conn
+let tags t = Conn.tags t.conn
 
-let write_promised_answer pa (qid, xforms) =
+(* [flush ~xmit_queue endpoint] writes each message in the queue until it is empty.
+   Invariant:
+     Whenever Lwt blocks or switches threads, a flush thread is running iff the
+     queue is non-empty. *)
+let rec flush ~xmit_queue endpoint =
+  (* We keep the item on the queue until it is transmitted, as the queue state
+     tells us whether there is a [flush] currently running. *)
+  let next = Queue.peek xmit_queue in
+  Endpoint.send endpoint next >>= fun () ->
+  ignore (Queue.pop xmit_queue);
+  if not (Queue.is_empty xmit_queue) then
+    flush ~xmit_queue endpoint
+  else (* queue is empty and flush thread is done *)
+    Lwt.return_unit
+
+(* Enqueue [message] in [xmit_queue] and ensure the flush thread is running. *)
+let queue_send ~xmit_queue endpoint message =
+  let was_idle = Queue.is_empty xmit_queue in
+  Queue.add message xmit_queue;
+  if was_idle then async_tagged "Message sender thread" (fun () -> flush ~xmit_queue endpoint)
+
+let return_not_implemented t x =
+  Log.info (fun f -> f ~tags:(tags t) "Returning Unimplemented");
   let open Builder in
-  PromisedAnswer.question_id_set pa (QuestionId.uint32 qid);
-  let xforms_builder = PromisedAnswer.transform_init pa (List.length xforms) in
-  xforms |> List.iteri (fun i (Xform.Field f) ->
-      let b = Capnp.Array.get xforms_builder i in
-      PromisedAnswer.Op.get_pointer_field_set_exn b f
-    )
-
-let write_cap slot =
-  let open Builder in function
-  | `ReceiverHosted id -> CapDescriptor.receiver_hosted_set slot (ImportId.uint32 id)
-  | `ReceiverAnswer x -> write_promised_answer (CapDescriptor.receiver_answer_init slot) x
-  | `SenderHosted id -> CapDescriptor.sender_hosted_set slot (ExportId.uint32 id)
-  | `SenderPromise id -> CapDescriptor.sender_promise_set slot (ExportId.uint32 id)
-  | `ThirdPartyHosted _ -> failwith "TODO: write_caps_array"
-  | `None -> CapDescriptor.none_set slot
-
-let write_caps_array caps payload =
-  let open Builder in
-  let builder = Payload.cap_table_init payload (RO_array.length caps) in
-  caps |> RO_array.iteri (fun i -> write_cap (Capnp.Array.get builder i))
-
-let parse_xform x =
-  let open Reader.PromisedAnswer.Op in
-  match get x with
-  | Noop -> []
-  | GetPointerField y -> [Xform.Field y]
-  | Undefined _ -> failwith "Unknown transform type"
-
-let parse_promised_answer pa =
-  let open Reader in
-  let qid = PromisedAnswer.question_id_get pa |> AnswerId.of_uint32 in
-  let trans = PromisedAnswer.transform_get_list pa |> List.map parse_xform |> List.concat in
-  `ReceiverAnswer (qid, trans)
-
-let parse_desc d =
-  let open Reader in
-  match CapDescriptor.get d with
-  | CapDescriptor.None -> `None
-  | CapDescriptor.SenderHosted id -> `SenderHosted (ImportId.of_uint32 id)
-  | CapDescriptor.SenderPromise id -> `SenderPromise (ImportId.of_uint32 id)
-  | CapDescriptor.ReceiverHosted id -> `ReceiverHosted (ExportId.of_uint32 id)
-  | CapDescriptor.ReceiverAnswer p -> parse_promised_answer p
-  | CapDescriptor.ThirdPartyHosted tp ->
-    let vine_id = ThirdPartyCapDescriptor.vine_id_get tp |> ImportId.of_uint32 in
-    (* todo: for level 3, we should establish a direct connection rather than proxying
-       through the vine *)
-    `ThirdPartyHosted (`TODO_3rd_party, vine_id)
-  | CapDescriptor.Undefined _ -> failwith "Unknown cap descriptor type"
-
-let parse_descs = RO_array.map parse_desc
-
-let read_exn ex =
-  let open Reader.Exception in
-  let reason = reason_get ex in
-  let ty =
-    match type_get ex with
-    | Failed        -> `Failed
-    | Overloaded    -> `Overloaded
-    | Disconnected  -> `Disconnected
-    | Unimplemented -> `Unimplemented
-    | Undefined x   -> `Undefined x
-  in
-  { Capnp_rpc.Exception.ty; reason }
-
-let handle_return t return =
-  let open Reader in
-  let qid = Return.answer_id_get return |> QuestionId.of_uint32 in
-  let release_param_caps = Return.release_param_caps_get return in
-  match Return.get return with
-  | Return.Results results ->
-    let descs = parse_descs (Payload.cap_table_get_list results |> RO_array.of_list) in
-    Conn.handle_msg t.conn (`Return (qid, `Results (Rpc.Readonly return, descs), release_param_caps))
-  | Return.Exception ex ->
-    let ex = read_exn ex in
-    Log.info (fun f -> f ~tags:(tags ~qid t) "Got exception %a" Capnp_rpc.Exception.pp ex);
-    Conn.handle_msg t.conn (`Return (qid, `Exception ex, release_param_caps))
-  | Return.Canceled ->
-    Conn.handle_msg t.conn (`Return (qid, `Cancelled, release_param_caps))
-  | _ ->
-    Log.warn (fun f -> f ~tags:(tags ~qid t) "Got unknown return type");
-    failwith "Unexpected return type received"
-
-let handle_finish t finish =
-  let open Reader in
-  let aid = Finish.question_id_get finish |> AnswerId.of_uint32 in
-  let release = Finish.release_result_caps_get finish in
-  Conn.handle_msg t.conn (`Finish (aid, release))
-
-let results_of_return ret =
-  let open Builder in
-  match Return.get ret with
-  | Return.Results r -> r
-  | _ -> failwith "results_of_return: not results!"
-
-let parse_target msg_target =
-  let open Reader in
-  match MessageTarget.get msg_target with
-  | MessageTarget.Undefined _ -> failwith "Bad MessageTarget"
-  | MessageTarget.ImportedCap id -> `ReceiverHosted (ExportId.of_uint32 id)
-  | MessageTarget.PromisedAnswer x -> parse_promised_answer x
-
-(* We have received a question from our peer. *)
-let handle_call t call =
-  let open Reader in
-  let aid = Call.question_id_get call |> AnswerId.of_uint32 in
-  Log.info (fun f -> f ~tags:(tags ~aid t) "Received call %a" pp_call call);
-  (* Resolve capabilities *)
-  let p = Call.params_get call in
-  let descs = parse_descs (Payload.cap_table_get_list p |> RO_array.of_list) in
-  (* Get target *)
-  let target = parse_target (Call.target_get call) in
-  let msg = Rpc.Readonly call in
-  Conn.handle_msg t.conn (`Call (aid, target, msg, descs))
-
-let handle_bootstrap t boot =
-  let open Reader in
-  let qid = Bootstrap.question_id_get boot |> AnswerId.of_uint32 in
-  Conn.handle_msg t.conn (`Bootstrap qid)
-
-let handle_disembargo t x =
-  let open Reader in
-  let target = parse_target (Disembargo.target_get x) in
-  let ctx = Disembargo.context_get x in
-  match Disembargo.Context.get ctx with
-  | Disembargo.Context.SenderLoopback embargo_id ->
-    let embargo_id = EmbargoId.of_uint32 embargo_id in
-    begin match target with
-    | `ReceiverAnswer (aid, path) ->
-      let req = `Loopback (`ReceiverAnswer (aid, path), embargo_id) in
-      Conn.handle_msg t.conn (`Disembargo_request req)
-    | `ReceiverHosted _ -> failwith "TODO: handle_disembargo: ReceiverHosted"   (* Can this happen? *)
-    end
-  | Disembargo.Context.ReceiverLoopback embargo_id ->
-    let embargo_id = EmbargoId.of_uint32 embargo_id in
-    begin match target with
-    | `ReceiverHosted id ->
-      Conn.handle_msg t.conn (`Disembargo_reply ((`ReceiverHosted id), embargo_id))
-    | `ReceiverAnswer _ -> failwith "TODO: handle_disembargo: ReceiverAnswer"        (* Can this happen? *)
-    end
-  | _ -> failwith "TODO: handle_disembargo"
-
-let handle_resolve t x =
-  let open Reader in
-  let new_target =
-    match Resolve.get x with
-    | Resolve.Cap d -> Ok (parse_desc d)
-    | Resolve.Exception e -> Error (read_exn e)
-    | Resolve.Undefined x -> Capnp_rpc.Debug.failf "Resolved to Undefined(%d)!" x
-  in
-  let import_id = Resolve.promise_id_get x |> ImportId.of_uint32 in
-  Conn.handle_msg t.conn (`Resolve (import_id, new_target))
-
-let handle_release t x =
-  let open Reader in
-  let export_id = Release.id_get x |> ExportId.of_uint32 in
-  let ref_count = Release.reference_count_get x |> Uint32.to_int in
-  Conn.handle_msg t.conn (`Release (export_id, ref_count))
-
-let return_not_implemented _t _x = failwith "TODO: return_not_implemented"
+  let m = Message.init_root () in
+  let _ : Builder.Message.t = Message.unimplemented_set_reader m x in
+  queue_send ~xmit_queue:t.xmit_queue t.endpoint (Message.to_message m)
 
 let listen t =
   let rec loop () =
@@ -207,137 +70,29 @@ let listen t =
       begin
         let open Reader.Message in
         let msg = of_message msg in
-        match get msg with
-        | Call x       -> handle_call t x
-        | Bootstrap x  -> handle_bootstrap t x
-        | Return x     -> handle_return t x
-        | Finish x     -> handle_finish t x
-        | Disembargo x -> handle_disembargo t x
-        | Resolve x    -> handle_resolve t x
-        | Release x    -> handle_release t x
-        | Unimplemented _  -> failwith "TODO: listen: Unimplemented"
-        | Abort _          -> failwith "Received Abort" (* TODO: handle this better *)
-        | Provide _
-        | Accept _
-        | Join _           -> return_not_implemented t msg
-        | ObsoleteSave _   -> failwith "Received ObsoleteSave!"
-        | ObsoleteDelete _ -> failwith "Received ObsoleteDelete!"
-        | Undefined x      -> Capnp_rpc.Debug.failf "Received Undefined message (%d)!" x
+        match Parse.message msg with
+        | #Capnp_core.Endpoint_types.In.t as msg ->
+          Log.info (fun f ->
+              let tags = Capnp_core.Endpoint_types.In.with_qid_tag (Conn.tags t.conn) msg in
+              f ~tags "<- %a" (Capnp_core.Endpoint_types.In.pp_recv pp_msg) msg);
+          Conn.handle_msg t.conn msg
+        | `Unimplemented x as msg ->
+          Log.info (fun f ->
+              let tags = Capnp_core.Endpoint_types.Out.with_qid_tag (Conn.tags t.conn) x in
+              f ~tags "<- Unimplemented(%a)" (Capnp_core.Endpoint_types.Out.pp_recv pp_msg) x);
+          Conn.handle_msg t.conn msg
+        | `Not_implemented ->
+          Log.info (fun f -> f "<- unsupported message type");
+          return_not_implemented t msg
       end;
       loop ()
   in
   loop ()
 
-let set_target b target =
-  let open Builder in
-  match target with
-  | `ReceiverAnswer (id, i) ->
-    let builder = MessageTarget.promised_answer_init b in
-    write_promised_answer builder (id, i)
-  | `ReceiverHosted id ->
-    MessageTarget.imported_cap_set b (ImportId.uint32 id)
-
-let write_exn b ex =
-  let open Builder.Exception in
-  let ty =
-    match ex.Capnp_rpc.Exception.ty with
-    | `Failed        -> Type.Failed
-    | `Overloaded    -> Type.Overloaded
-    | `Disconnected  -> Type.Disconnected
-    | `Unimplemented -> Type.Unimplemented
-    | `Undefined x   -> Type.Undefined x
-  in
-  type_set b ty;
-  reason_set b ex.Capnp_rpc.Exception.reason
-
-let serialise ~tags : Endpoint_types.Out.t -> _ =
-  let open Builder in
-  function
-  | `Bootstrap qid ->
-    let b = Message.init_root () in
-    let boot = Message.bootstrap_init b in
-    Bootstrap.question_id_set boot (QuestionId.uint32 qid);
-    Log.info (fun f ->
-        let tags = Logs.Tag.add Capnp_rpc.Debug.qid_tag (QuestionId.uint32 qid) tags in
-        f ~tags "Requesting bootstrap service"
-      );
-    Message.to_message b
-  | `Call (qid, target, request, descs) ->
-    let c = Rpc.writable_req request in
-    Call.question_id_set c (QuestionId.uint32 qid);
-    set_target (Call.target_init c) target;
-    let p = Call.params_get c in
-    write_caps_array descs p;
-    Call.to_message c
-  | `Finish (qid, release_result_caps) ->
-    let b = Message.init_root () in
-    let fin = Message.finish_init b in
-    Finish.question_id_set fin (QuestionId.uint32 qid);
-    Finish.release_result_caps_set fin release_result_caps;
-    Message.to_message b
-  | `Release (id, count) ->
-    let m = Message.init_root () in
-    let rel = Message.release_init m in
-    Release.id_set rel (ImportId.uint32 id);
-    Release.reference_count_set_int_exn rel count;
-    Message.to_message m
-  | `Disembargo_request disembargo_request ->
-    let m = Message.init_root () in
-    let dis = Message.disembargo_init m in
-    let ctx = Disembargo.context_init dis in
-    begin match disembargo_request with
-      | `Loopback (old_path, embargo_id) ->
-        set_target (Disembargo.target_init dis) old_path;
-        Disembargo.Context.sender_loopback_set ctx (EmbargoId.uint32 embargo_id)
-    end;
-    Message.to_message m
-  | `Disembargo_reply (target, embargo_id) ->
-    let m = Message.init_root () in
-    let dis = Message.disembargo_init m in
-    let ctx = Disembargo.context_init dis in
-    set_target (Disembargo.target_init dis) target;
-    Disembargo.Context.receiver_loopback_set ctx (EmbargoId.uint32 embargo_id);
-    Message.to_message m
-  | `Return (aid, return, release) ->
-    let ret =
-      match return with
-        | `Results (msg, descs) ->
-          (* [msg] has payload filled in, but nothing else. *)
-          let ret = Rpc.writable_resp msg in
-          write_caps_array descs (results_of_return ret);
-          ret
-        | `Exception ex ->
-          let m = Message.init_root () in
-          let ret = Message.return_init m in
-          write_exn (Return.exception_init ret) ex;
-          ret
-        | `Cancelled ->
-          let m = Message.init_root () in
-          let ret = Message.return_init m in
-          Return.canceled_set ret;
-          ret
-        | _ -> failwith "TODO: other return type"
-    in
-    Return.answer_id_set ret (AnswerId.uint32 aid);
-    Return.release_param_caps_set ret release;
-    Return.to_message ret
-  | `Resolve (id, new_target) ->
-    let m = Message.init_root () in
-    let r = Message.resolve_init m in
-    begin match new_target with
-      | Ok cap -> write_cap (Resolve.cap_init r) cap
-      | Error e -> write_exn (Resolve.exception_init r) e
-    end;
-    Resolve.promise_id_set r (ExportId.uint32 id);
-    Message.to_message m
-
-let queue_send ~tags endpoint x =
-  let message = serialise ~tags x in
-  async_tagged "Transmit message"
-    (fun () -> Endpoint.send endpoint message)
-
-let of_endpoint ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
-  let conn = Conn.create ?bootstrap:offer ~tags ~queue_send:(queue_send ~tags endpoint) in
+let connect ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
+  let xmit_queue = Queue.create () in
+  let queue_send msg = queue_send ~xmit_queue endpoint (Serialise.message ~tags msg) in
+  let conn = Conn.create ?bootstrap:offer ~tags ~queue_send in
   Lwt_switch.add_hook (Some switch) (fun () ->
       Conn.disconnect conn (Capnp_rpc.Exception.v "CapTP switch turned off");
       Lwt.return_unit
@@ -345,6 +100,7 @@ let of_endpoint ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
   let t = {
     conn;
     endpoint;
+    xmit_queue;
   } in
   Lwt.async (fun () ->
       Lwt.catch

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -3,11 +3,14 @@
 open Capnp_core.Core_types
 
 type t
+(** A Cap'n Proto RPC protocol handler. *)
 
-val of_endpoint : ?offer:cap -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
-(** [of_endpoint ?offer ~switch endpoint] is fresh CapTP state for communicating with [endpoint].
+val connect : ?offer:cap -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+(** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
+    receives messages using [endpoint].
     If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
-    If the connection fails then [switch] will be turned off. *)
+    If the connection fails then [switch] will be turned off, and turning off the switch
+    will release all resources used by the connection. *)
 
 val bootstrap : t -> cap
 (** [bootstrap t] is the peer's public bootstrap object, if any. *)

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -168,10 +168,12 @@ module CapTP : sig
   type t
   (** A CapTP connection to a remote peer. *)
 
-  val of_endpoint : ?offer:'a Capability.t -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
-  (** [of_endpoint ?offer ~switch endpoint] is fresh CapTP connection wrapping [endpoint].
+  val connect : ?offer:'a Capability.t -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+  (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
+      receives messages using [endpoint].
       If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
-      If the connection fails then [switch] will be turned off. *)
+      If the connection fails then [switch] will be turned off, and turning off the switch
+      will release all resources used by the connection. *)
 
   val bootstrap : t -> 'a Capability.t
   (** [bootstrap t] is the peer's public bootstrap object, if any. *)

--- a/capnp-rpc-lwt/parse.ml
+++ b/capnp-rpc-lwt/parse.ml
@@ -1,0 +1,176 @@
+open Capnp_core
+
+module EmbargoId = Capnp_rpc.Message_types.EmbargoId
+module RO_array = Capnp_rpc.RO_array
+module Reader = Schema.Reader
+module Log = Capnp_rpc.Debug.Log
+
+module Make(T : Capnp_rpc.Message_types.TABLE_TYPES) = struct
+  module Msg = Capnp_rpc.Message_types.Make(Core_types)(T)
+  open Msg
+
+  let parse_xform x =
+    let open Reader.PromisedAnswer.Op in
+    match get x with
+    | Noop -> []
+    | GetPointerField y -> [Xform.Field y]
+    | Undefined _ -> failwith "Unknown transform type"
+
+  let parse_promised_answer pa =
+    let open Reader in
+    let qid = PromisedAnswer.question_id_get pa |> AnswerId.of_uint32 in
+    let trans = PromisedAnswer.transform_get_list pa |> List.map parse_xform |> List.concat in
+    `ReceiverAnswer (qid, trans)
+
+  let parse_desc d =
+    let open Reader in
+    match CapDescriptor.get d with
+    | CapDescriptor.None -> `None
+    | CapDescriptor.SenderHosted id -> `SenderHosted (ImportId.of_uint32 id)
+    | CapDescriptor.SenderPromise id -> `SenderPromise (ImportId.of_uint32 id)
+    | CapDescriptor.ReceiverHosted id -> `ReceiverHosted (ExportId.of_uint32 id)
+    | CapDescriptor.ReceiverAnswer p -> parse_promised_answer p
+    | CapDescriptor.ThirdPartyHosted tp ->
+      let vine_id = ThirdPartyCapDescriptor.vine_id_get tp |> ImportId.of_uint32 in
+      (* todo: for level 3, we should establish a direct connection rather than proxying
+         through the vine *)
+      `ThirdPartyHosted (`TODO_3rd_party, vine_id)
+    | CapDescriptor.Undefined _ -> failwith "Unknown cap descriptor type"
+
+  let parse_descs = RO_array.map parse_desc
+
+  let parse_exn ex =
+    let open Reader.Exception in
+    let reason = reason_get ex in
+    let ty =
+      match type_get ex with
+      | Failed        -> `Failed
+      | Overloaded    -> `Overloaded
+      | Disconnected  -> `Disconnected
+      | Unimplemented -> `Unimplemented
+      | Undefined x   -> `Undefined x
+    in
+    { Capnp_rpc.Exception.ty; reason }
+
+  let parse_return return =
+    let open Reader in
+    let qid = Return.answer_id_get return |> QuestionId.of_uint32 in
+    let release_param_caps = Return.release_param_caps_get return in
+    match Return.get return with
+    | Return.Results results ->
+      let descs = parse_descs (Payload.cap_table_get_list results |> RO_array.of_list) in
+      `Return (qid, `Results (Rpc.Readonly return, descs), release_param_caps)
+    | Return.Exception ex ->
+      let ex = parse_exn ex in
+      `Return (qid, `Exception ex, release_param_caps)
+    | Return.Canceled ->
+      `Return (qid, `Cancelled, release_param_caps)
+    | Return.ResultsSentElsewhere -> failwith "TODO: ResultsSentElsewhere"
+    | Return.TakeFromOtherQuestion _ -> failwith "TODO: TakeFromOtherQuestion"
+    | Return.AcceptFromThirdParty _ -> failwith "TODO: AcceptFromThirdParty"
+    | Return.Undefined x -> failwith (Fmt.strf "Unexpected return type received: %d" x)
+
+  let parse_finish finish =
+    let open Reader in
+    let aid = Finish.question_id_get finish |> AnswerId.of_uint32 in
+    let release = Finish.release_result_caps_get finish in
+    `Finish (aid, release)
+
+  let parse_target msg_target =
+    let open Reader in
+    match MessageTarget.get msg_target with
+    | MessageTarget.Undefined _ -> failwith "Bad MessageTarget"
+    | MessageTarget.ImportedCap id -> `ReceiverHosted (ExportId.of_uint32 id)
+    | MessageTarget.PromisedAnswer x -> parse_promised_answer x
+
+  (* We have received a question from our peer. *)
+  let parse_call call =
+    let open Reader in
+    let aid = Call.question_id_get call |> AnswerId.of_uint32 in
+    (* Resolve capabilities *)
+    let p = Call.params_get call in
+    let descs = parse_descs (Payload.cap_table_get_list p |> RO_array.of_list) in
+    (* Get target *)
+    let target = parse_target (Call.target_get call) in
+    let msg = Rpc.Readonly call in
+    `Call (aid, target, msg, descs)
+
+  let parse_bootstrap boot =
+    let open Reader in
+    let qid = Bootstrap.question_id_get boot |> AnswerId.of_uint32 in
+    `Bootstrap qid
+
+  let parse_disembargo x =
+    let open Reader in
+    let target = parse_target (Disembargo.target_get x) in
+    let ctx = Disembargo.context_get x in
+    match Disembargo.Context.get ctx with
+    | Disembargo.Context.SenderLoopback embargo_id ->
+      let embargo_id = EmbargoId.of_uint32 embargo_id in
+      begin match target with
+      | `ReceiverAnswer (aid, path) ->
+        let req = `Loopback (`ReceiverAnswer (aid, path), embargo_id) in
+        `Disembargo_request req
+      | `ReceiverHosted _ -> failwith "TODO: handle_disembargo: ReceiverHosted"   (* Can this happen? *)
+      end
+    | Disembargo.Context.ReceiverLoopback embargo_id ->
+      let embargo_id = EmbargoId.of_uint32 embargo_id in
+      begin match target with
+      | `ReceiverHosted id ->
+        `Disembargo_reply ((`ReceiverHosted id), embargo_id)
+      | `ReceiverAnswer _ -> failwith "TODO: handle_disembargo: ReceiverAnswer"        (* Can this happen? *)
+      end
+    | _ -> failwith "TODO: handle_disembargo"
+
+  let parse_resolve x =
+    let open Reader in
+    let new_target =
+      match Resolve.get x with
+      | Resolve.Cap d -> Ok (parse_desc d)
+      | Resolve.Exception e -> Error (parse_exn e)
+      | Resolve.Undefined x -> Capnp_rpc.Debug.failf "Resolved to Undefined(%d)!" x
+    in
+    let import_id = Resolve.promise_id_get x |> ImportId.of_uint32 in
+    `Resolve (import_id, new_target)
+
+  let parse_release x =
+    let open Reader in
+    let export_id = Release.id_get x |> ExportId.of_uint32 in
+    let ref_count = Release.reference_count_get x |> Uint32.to_int in
+    `Release (export_id, ref_count)
+
+  (* Parse a message received from our peer. Returns [`Not_implemented`] if we couldn't understand it. *)
+  let parse_msg msg =
+    let open Reader.Message in
+    match get msg with
+    | Call x           -> parse_call x
+    | Bootstrap x      -> parse_bootstrap x
+    | Return x         -> parse_return x
+    | Finish x         -> parse_finish x
+    | Disembargo x     -> parse_disembargo x
+    | Resolve x        -> parse_resolve x
+    | Release x        -> parse_release x
+    | Abort _          -> failwith "Received Abort" (* TODO: handle this better *)
+    | Provide _
+    | Accept _
+    | Join _           -> `Not_implemented        (* TODO *)
+    | ObsoleteSave _
+    | ObsoleteDelete _ -> `Not_implemented
+    | Undefined x      ->
+      Log.warn (fun f -> f "Received Undefined message (%d)!" x);
+      `Not_implemented
+    | Unimplemented x  -> `Unimplemented x
+end
+
+module Parse_in = Make(Capnp_core.Endpoint_types.Table)
+module Parse_out = Make(Capnp_rpc.Message_types.Flip(Capnp_core.Endpoint_types.Table))
+
+let message msg =
+  match Parse_in.parse_msg msg with
+  | #Capnp_core.Endpoint_types.In.t as msg -> msg
+  | `Not_implemented -> `Not_implemented        (* We don't understand [msg] *)
+  | `Unimplemented x ->                         (* The remote peer didn't understand [x] *)
+    match Parse_out.parse_msg x with
+    | #Capnp_core.Endpoint_types.Out.t as msg -> `Unimplemented msg
+    | `Not_implemented -> failwith "Can't read copy of our own message in Unimplemented reply!"
+    | `Unimplemented _ -> failwith "Peer doesn't implement support for unimplemented message!"

--- a/capnp-rpc-lwt/parse.mli
+++ b/capnp-rpc-lwt/parse.mli
@@ -1,0 +1,9 @@
+(** Parsing of Cap'n Proto RPC messages received from a remote peer. *)
+
+val message :
+  Schema.Reader.Message.t ->
+  [ Capnp_core.Endpoint_types.In.t
+  | `Unimplemented of Capnp_core.Endpoint_types.Out.t
+  | `Not_implemented ]
+(** Parse a message received from a peer.
+    Returns [`Not_implemented] if we don't understand it. *)

--- a/capnp-rpc-lwt/rpc.ml
+++ b/capnp-rpc-lwt/rpc.ml
@@ -1,5 +1,4 @@
-let src = Logs.Src.create "capnp-rpc" ~doc:"Cap'n Proto RPC"
-module Log = (val Logs.src_log src: Logs.LOG)
+module Log = Capnp_rpc.Debug.Log
 
 module RO_array = Capnp_rpc.RO_array
 

--- a/capnp-rpc-lwt/serialise.ml
+++ b/capnp-rpc-lwt/serialise.ml
@@ -1,0 +1,139 @@
+open Capnp_core
+open Capnp_core.Endpoint_types.Table
+
+module EmbargoId = Capnp_rpc.Message_types.EmbargoId
+module Log = Capnp_rpc.Debug.Log
+module Builder = Schema.Builder
+module RO_array = Capnp_rpc.RO_array
+
+let results_of_return ret =
+  let open Builder in
+  match Return.get ret with
+  | Return.Results r -> r
+  | _ -> failwith "results_of_return: not results!"
+
+let write_promised_answer pa (qid, xforms) =
+  let open Builder in
+  PromisedAnswer.question_id_set pa (QuestionId.uint32 qid);
+  let xforms_builder = PromisedAnswer.transform_init pa (List.length xforms) in
+  xforms |> List.iteri (fun i (Xform.Field f) ->
+      let b = Capnp.Array.get xforms_builder i in
+      PromisedAnswer.Op.get_pointer_field_set_exn b f
+    )
+
+let write_cap slot =
+  let open Builder in function
+    | `ReceiverHosted id -> CapDescriptor.receiver_hosted_set slot (ImportId.uint32 id)
+    | `ReceiverAnswer x -> write_promised_answer (CapDescriptor.receiver_answer_init slot) x
+    | `SenderHosted id -> CapDescriptor.sender_hosted_set slot (ExportId.uint32 id)
+    | `SenderPromise id -> CapDescriptor.sender_promise_set slot (ExportId.uint32 id)
+    | `ThirdPartyHosted _ -> failwith "TODO: write_caps_array"
+    | `None -> CapDescriptor.none_set slot
+
+let write_caps_array caps payload =
+  let open Builder in
+  let builder = Payload.cap_table_init payload (RO_array.length caps) in
+  caps |> RO_array.iteri (fun i -> write_cap (Capnp.Array.get builder i))
+
+let set_target b target =
+  let open Builder in
+  match target with
+  | `ReceiverAnswer (id, i) ->
+    let builder = MessageTarget.promised_answer_init b in
+    write_promised_answer builder (id, i)
+  | `ReceiverHosted id ->
+    MessageTarget.imported_cap_set b (ImportId.uint32 id)
+
+let write_exn b ex =
+  let open Builder.Exception in
+  let ty =
+    match ex.Capnp_rpc.Exception.ty with
+    | `Failed        -> Type.Failed
+    | `Overloaded    -> Type.Overloaded
+    | `Disconnected  -> Type.Disconnected
+    | `Unimplemented -> Type.Unimplemented
+    | `Undefined x   -> Type.Undefined x
+  in
+  type_set b ty;
+  reason_set b ex.Capnp_rpc.Exception.reason
+
+let message ~tags : Endpoint_types.Out.t -> _ =
+  let open Builder in
+  function
+  | `Bootstrap qid ->
+    let b = Message.init_root () in
+    let boot = Message.bootstrap_init b in
+    Bootstrap.question_id_set boot (QuestionId.uint32 qid);
+    Log.info (fun f ->
+        let tags = Logs.Tag.add Capnp_rpc.Debug.qid_tag (QuestionId.uint32 qid) tags in
+        f ~tags "Requesting bootstrap service"
+      );
+    Message.to_message b
+  | `Call (qid, target, request, descs) ->
+    let c = Rpc.writable_req request in
+    Call.question_id_set c (QuestionId.uint32 qid);
+    set_target (Call.target_init c) target;
+    let p = Call.params_get c in
+    write_caps_array descs p;
+    Call.to_message c
+  | `Finish (qid, release_result_caps) ->
+    let b = Message.init_root () in
+    let fin = Message.finish_init b in
+    Finish.question_id_set fin (QuestionId.uint32 qid);
+    Finish.release_result_caps_set fin release_result_caps;
+    Message.to_message b
+  | `Release (id, count) ->
+    let m = Message.init_root () in
+    let rel = Message.release_init m in
+    Release.id_set rel (ImportId.uint32 id);
+    Release.reference_count_set_int_exn rel count;
+    Message.to_message m
+  | `Disembargo_request disembargo_request ->
+    let m = Message.init_root () in
+    let dis = Message.disembargo_init m in
+    let ctx = Disembargo.context_init dis in
+    begin match disembargo_request with
+      | `Loopback (old_path, embargo_id) ->
+        set_target (Disembargo.target_init dis) old_path;
+        Disembargo.Context.sender_loopback_set ctx (EmbargoId.uint32 embargo_id)
+    end;
+    Message.to_message m
+  | `Disembargo_reply (target, embargo_id) ->
+    let m = Message.init_root () in
+    let dis = Message.disembargo_init m in
+    let ctx = Disembargo.context_init dis in
+    set_target (Disembargo.target_init dis) target;
+    Disembargo.Context.receiver_loopback_set ctx (EmbargoId.uint32 embargo_id);
+    Message.to_message m
+  | `Return (aid, return, release) ->
+    let ret =
+      match return with
+      | `Results (msg, descs) ->
+        (* [msg] has payload filled in, but nothing else. *)
+        let ret = Rpc.writable_resp msg in
+        write_caps_array descs (results_of_return ret);
+        ret
+      | `Exception ex ->
+        let m = Message.init_root () in
+        let ret = Message.return_init m in
+        write_exn (Return.exception_init ret) ex;
+        ret
+      | `Cancelled ->
+        let m = Message.init_root () in
+        let ret = Message.return_init m in
+        Return.canceled_set ret;
+        ret
+      | _ -> failwith "TODO: other return type"
+    in
+    Return.answer_id_set ret (AnswerId.uint32 aid);
+    Return.release_param_caps_set ret release;
+    Return.to_message ret
+  | `Resolve (id, new_target) ->
+    let m = Message.init_root () in
+    let r = Message.resolve_init m in
+    begin match new_target with
+      | Ok cap -> write_cap (Resolve.cap_init r) cap
+      | Error e -> write_exn (Resolve.exception_init r) e
+    end;
+    Resolve.promise_id_set r (ExportId.uint32 id);
+    Message.to_message m

--- a/capnp-rpc-lwt/serialise.mli
+++ b/capnp-rpc-lwt/serialise.mli
@@ -1,0 +1,1 @@
+val message : tags:Logs.Tag.set -> Capnp_core.Endpoint_types.Out.t -> Rpc_schema.rw Schema.message_t

--- a/capnp-rpc/capTP.mli
+++ b/capnp-rpc/capTP.mli
@@ -2,7 +2,8 @@ module Make (EP : Message_types.ENDPOINT) : sig
   type t
   (** A [t] is a connection to a remote vat. *)
 
-  val create : ?bootstrap:#EP.Core_types.cap -> tags:Logs.Tag.set -> queue_send:(EP.Out.t -> unit) -> t
+  val create : ?bootstrap:#EP.Core_types.cap -> tags:Logs.Tag.set ->
+    queue_send:([> EP.Out.t] -> unit) -> t
   (** [create ~bootstrap ~tags ~queue_send] is a handler for a connection to a remote peer.
       Messages will be sent to the peer by calling [queue_send] (which MUST deliver them in order).
       If the remote peer asks for the bootstrap object, it will be given a reference to [bootstrap].
@@ -13,7 +14,7 @@ module Make (EP : Message_types.ENDPOINT) : sig
       This call does not block; the result is a promise for the object, on which further
       messages may be pipelined. *)
 
-  val handle_msg : t -> EP.In.t -> unit
+  val handle_msg : t -> [< EP.In.t | `Unimplemented of EP.Out.t] -> unit
   (** [handle_msg t] feeds one message received from the remote peer into [t].
       It will call [queue_send] as necessary to handle the call.
       Messages MUST be fed to [handle_msg] in the order in which they arrive from the peer. *)
@@ -23,9 +24,8 @@ module Make (EP : Message_types.ENDPOINT) : sig
 
   (** {2 Debugging and diagnostics} *)
 
-  val tags : ?qid:EP.Out.QuestionId.t -> ?aid:EP.Out.AnswerId.t -> t -> Logs.Tag.set
-  (** [tags t] is a set of logging tags suitable for logging a message about this connection.
-      [qid] or [aid] (but not both) may be given to add a tag with the question ID. *)
+  val tags : t -> Logs.Tag.set
+  (** [tags t] is a set of logging tags suitable for logging a message about this connection. *)
 
   val stats : t -> Stats.t
   (** [stats t] returns statistics about the state of the connection. *)

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -28,10 +28,10 @@ end
 let run_server ~switch ~service () =
   let server_socket, client_socket = Unix.(socketpair PF_UNIX SOCK_STREAM 0) in
   let server =
-    CapTP.of_endpoint ~tags:Test_utils.server_tags ~switch ~offer:service (Endpoint.of_socket ~switch server_socket)
+    CapTP.connect ~tags:Test_utils.server_tags ~switch ~offer:service (Endpoint.of_socket ~switch server_socket)
   in
   let client =
-    CapTP.of_endpoint ~tags:Test_utils.client_tags ~switch (Endpoint.of_socket ~switch client_socket)
+    CapTP.connect ~tags:Test_utils.client_tags ~switch (Endpoint.of_socket ~switch client_socket)
   in
   Capability.dec_ref service;
   { client; server }

--- a/test/testbed/connection.mli
+++ b/test/testbed/connection.mli
@@ -1,5 +1,25 @@
 open Capnp_direct.Core_types
 
+val summary_of_msg :
+  [< `Bootstrap of _
+  | `Call of _ * _ * string * _
+  | `Disembargo_reply of _
+  | `Disembargo_request of _
+  | `Finish of _
+  | `Release of _
+  | `Resolve of _
+  | `Return of
+       _ *
+       [< `AcceptFromThirdParty
+       | `Cancelled
+       | `Exception of Capnp_rpc.Exception.t
+       | `Results of string * _
+       | `ResultsSentElsewhere
+       | `TakeFromOtherQuestion ] *
+       _
+  | `Unimplemented of _ ] ->
+  string
+
 module type ENDPOINT = sig
   type t
 
@@ -7,7 +27,10 @@ module type ENDPOINT = sig
 
   val dump : t Fmt.t
 
-  val create : ?bootstrap:#cap -> tags:Logs.Tag.set -> EP.Out.t Queue.t -> EP.In.t Queue.t -> t
+  val create : ?bootstrap:#cap -> tags:Logs.Tag.set ->
+    [EP.Out.t | `Unimplemented of EP.In.t] Queue.t ->
+    [EP.In.t | `Unimplemented of EP.Out.t] Queue.t ->
+    t
 
   val handle_msg : ?expect:string -> t -> unit
 


### PR DESCRIPTION
- If the peer doesn't understand call or bootstrap, pretend it answered the question with an error.
- If the peer doesn't understand resolve, release the target.

Also, ensure messages are sent in the correct order and split out parsing and serialising of Cap'n Proto RPC messages into their own modules.

Note that `CapTP.of_endpoint` is now called `CapTP.connect`.

Closes #26.