### PR TITLE
Fix cycle detector

### DIFF
--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -537,6 +537,11 @@ module Make (EP : Message_types.ENDPOINT) = struct
         | `Unsettled _ -> Some (self :> Core_types.base_ref)
         | `Set x -> x#blocker
 
+      method problem =
+        match state with
+        | `Unsettled _ -> None
+        | `Set x -> x#problem
+
       method when_more_resolved fn =
         match state with
         | `Unsettled (_, q) -> Queue.add fn q
@@ -613,6 +618,8 @@ module Make (EP : Message_types.ENDPOINT) = struct
           method blocker =
             if settled then None
             else Some (self :> Core_types.base_ref)
+
+          method problem = None
 
           method when_more_resolved _ =
             assert settled      (* Otherwise, our switchable should have intercepted this *)

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -91,6 +91,11 @@ module Make(C : S.CORE_TYPES) = struct
         | Unresolved _ -> (self :> cap)
         | Resolved cap -> cap#shortest
 
+      method problem =
+        match state with
+        | Unresolved _ -> None
+        | Resolved cap -> cap#problem
+
       method blocker =
         match state with
         | Unresolved _ -> Some (self :> base_ref)

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -30,6 +30,7 @@ module Make(Wire : S.WIRE) = struct
     method shortest : cap
     method when_more_resolved : (cap -> unit) -> unit
     method sealed_dispatch : 'a. 'a S.brand -> 'a option
+    method problem : Exception.t option
   end
 
   class type struct_resolver = object
@@ -112,6 +113,7 @@ module Make(Wire : S.WIRE) = struct
     method when_more_resolved _ = ()
     method check_invariants = ()
     method sealed_dispatch _ = None
+    method problem = Some ex
   end
   and broken_struct err = object (_ : struct_ref)
     method response = Some (Error err)
@@ -225,6 +227,7 @@ module Make(Wire : S.WIRE) = struct
     method shortest = (self :> cap)
     method blocker = None
     method when_more_resolved _ = ()
+    method problem = None
   end
 
   let fail ?(ty=`Failed) msg =

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -131,6 +131,9 @@ module type CORE_TYPES = sig
 
       method sealed_dispatch : 'a. 'a brand -> 'a option
       (** [c#sealed_dispatch brand] extracts some private data of the given type. *)
+
+      method problem : Exception.t option
+      (** [c#problem] is the exception for a broken reference, or [None] if it is not known to be broken. *)
           
     end
   (** A capability reference to an object that can handle calls.
@@ -193,6 +196,7 @@ module type CORE_TYPES = sig
     method virtual call : Wire.Request.t -> cap RO_array.t -> struct_ref
     method virtual shortest : cap
     method virtual when_more_resolved : (cap -> unit) -> unit
+    method virtual problem : Exception.t option
     method sealed_dispatch : 'a. 'a brand -> 'a option
   end
   (** A mix-in to help with writing reference-counted objects.
@@ -205,6 +209,7 @@ module type CORE_TYPES = sig
     method shortest : cap
     method private release : unit
     method when_more_resolved : (cap -> unit) -> unit
+    method problem : Exception.t option
   end
   (** A convenience base class for creating local services.
       The capability is always resolved, and the default [release] method does nothing. *)

--- a/test/testbed/services.ml
+++ b/test/testbed/services.ml
@@ -15,7 +15,7 @@ let echo_service () = object
   method call x caps =
     super#check_refcount;
     return ("got:" ^ x, caps)
-  method! pp f = Fmt.string f "echo-service"
+  method! pp f = Fmt.pf f "echo-service(%t)" super#pp_refcount
 end
 
 (* A service which just queues incoming messages and lets the test driver handle them. *)


### PR DESCRIPTION
Previously, attempting to resolve a promise to a set of fields that contained a cycle would resolve the promise itself to a cycle error.

Now, we only break the individual fields that contain cycles.

One reason for doing this is because unnecessarily breaking the other caps may affect some network paths and not others, leading to messages being delivered along one path and not along another.

Also, add a `#problem` method to caps to test if they're broken.

Detected by the fuzz tests.