### PR TITLE
Ensure embargo targets don't get released

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
-	#./_build/default/test/test.bc test core -ev 8
+	#./_build/default/test/test.bc test core -ev 10
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/capnp-rpc-lwt/endpoint.ml
+++ b/capnp-rpc-lwt/endpoint.ml
@@ -60,6 +60,7 @@ let send t msg =
 
 let rec recv t =
   match Capnp.Codecs.FramedStream.get_next_frame t.decoder with
+  | _ when not (Lwt_switch.is_on t.switch) -> Lwt.return @@ Error `Closed
   | Ok msg -> Lwt.return (Ok (Capnp.BytesMessage.Message.readonly msg))
   | Error Capnp.Codecs.FramingError.Unsupported -> failwith "Unsupported Cap'n'Proto frame received"
   | Error Capnp.Codecs.FramingError.Incomplete ->


### PR DESCRIPTION
We only looked at the embargo ID, and so didn't notice that the target was sometimes invalid. Although this worked fine, it might cause interoperability problems with other implementations.

Now, we keep alive targets to which we might still want to route disembargo replies.