### PR TITLE
Resolve broken caps to exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc
-	#./_build/default/test/test.bc test core -ev 10
+	#./_build/default/test/test.bc test core -ev 28
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -124,9 +124,10 @@ module type CORE_TYPES = sig
 
       method when_more_resolved : (cap -> unit) -> unit
       (** [c#when_more_resolved fn] calls [fn x] when this cap becomes more resolved.
-          [fn c] gets a reference to [c] and needs to [dec_ref] it.
+          [fn x] gets a reference to [x] and needs to [dec_ref] it.
           Note that the new capability can be another promise.
-          If [c] is already resolved to a value, this does nothing.
+          If [c] is already resolved to its final value, this does nothing.
+          If [c] is a far-ref, [fn x] will be called when it breaks.
           If [c] is forwarding to another cap, it will forward this call. *)
 
       method sealed_dispatch : 'a. 'a brand -> 'a option

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -47,6 +47,8 @@ module type ENDPOINT = sig
   val stats : t -> Capnp_rpc.Stats.t
 
   val check_finished : t -> name:string -> unit
+
+  val disconnect : t -> Capnp_rpc.Exception.t -> unit
 end
 
 module Endpoint (EP : Capnp_direct.ENDPOINT) = struct
@@ -95,9 +97,11 @@ module Endpoint (EP : Capnp_direct.ENDPOINT) = struct
   let finished = Capnp_rpc.Exception.v "Tests finished"
 
   let check_finished t ~name =
-      Alcotest.(check stats_t) (name ^ " finished") Stats.zero @@ stats t;
-      Conn.check t.conn;
-      Conn.disconnect t.conn finished
+    Alcotest.(check stats_t) (name ^ " finished") Stats.zero @@ stats t;
+    Conn.check t.conn;
+    Conn.disconnect t.conn finished
+
+  let disconnect t = Conn.disconnect t.conn
 end
 
 module Pair ( ) = struct

--- a/test/testbed/connection.mli
+++ b/test/testbed/connection.mli
@@ -43,6 +43,8 @@ module type ENDPOINT = sig
   val stats : t -> Capnp_rpc.Stats.t
 
   val check_finished : t -> name:string -> unit
+
+  val disconnect : t -> Capnp_rpc.Exception.t -> unit
 end
 
 module Endpoint (EP : Capnp_direct.ENDPOINT) : ENDPOINT


### PR DESCRIPTION
For some reason, we can't include broken capabilities in payloads. Instead, export a proxy to the broken cap and then immediately send a resolve for it that resolves it to an exception.

Also, resolve imports to broken references when the connection is lost.

Closes #38.