### PR TITLE
Clean up CapTP questions code

### DIFF
--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -274,7 +274,10 @@ module Make (C : S.CORE_TYPES) = struct
               );
             self#on_resolve u.target x;
             Queue.iter (fun fn -> fn x) u.when_resolved;
-            if u.cancelling then self#finish
+            if u.cancelling then (
+              self#do_finish u.target;
+              self#finish
+            )
           )
         ~forwarding:(fun t ->
             failwith (Fmt.strf "Already forwarding (to %t)!" t#pp)

--- a/capnp-rpc/weak_ptr.ml
+++ b/capnp-rpc/weak_ptr.ml
@@ -1,0 +1,9 @@
+type 'a t = 'a Weak.t
+
+let wrap x =
+  let t = Weak.create 1 in
+  Weak.set t 0 (Some x);
+  t
+
+let get t =
+  Weak.get t 0

--- a/capnp-rpc/weak_ptr.mli
+++ b/capnp-rpc/weak_ptr.mli
@@ -1,0 +1,8 @@
+type 'a t
+(** An ['a t] is a weak pointer to an ['a]. *)
+
+val wrap : 'a -> 'a t
+(** [wrap x] is a weak pointer to [x]. *)
+
+val get : 'a t -> 'a option
+(** [get t] is the target of [t], or [None] if it has been GC'd. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -487,11 +487,11 @@ let test_duplicates () =
   S.handle_msg s ~expect:"bootstrap";
   C.handle_msg c ~expect:"return:(boot)";       (* [bs] resolves *)
   S.handle_msg s ~expect:"call:c1";
-  S.handle_msg s ~expect:"finish";              (* bootstrap *)
+  S.handle_msg s ~expect:"finish";              (* bootstrap question *)
+  S.handle_msg s ~expect:"release";             (* bootstrap cap *)
   let (_, _, a1) = service#pop in
   a1#resolve (Ok ("a1", empty));
   C.handle_msg c ~expect:"return:a1";
-  S.handle_msg s ~expect:"release";             (* bootstrap *)
   S.handle_msg s ~expect:"finish";              (* c1 *)
   CS.check_finished c s
 


### PR DESCRIPTION
- Move question-related functions to a submodule.
- Add and document a proper state model for questions.