### PR TITLE
Fix handling of cycles

### DIFF
--- a/capnp-rpc-lwt/parse.ml
+++ b/capnp-rpc-lwt/parse.ml
@@ -93,7 +93,16 @@ module Make(T : Capnp_rpc.Message_types.TABLE_TYPES) = struct
     (* Get target *)
     let target = parse_target (Call.target_get call) in
     let msg = Rpc.Readonly call in
-    `Call (aid, target, msg, descs)
+    let results_to =
+      let r = Call.send_results_to_get call in
+      let open Call.SendResultsTo in
+      match get r with
+      | Caller -> `Caller
+      | Yourself -> `Yourself
+      | ThirdParty _ -> failwith "TODO: parse_call: ThirdParty"
+      | Undefined x -> Capnp_rpc.Debug.failf "Unknown SendResultsTo type %d" x
+    in
+    `Call (aid, target, msg, descs, results_to)
 
   let parse_bootstrap boot =
     let open Reader in

--- a/capnp-rpc-lwt/serialise.ml
+++ b/capnp-rpc-lwt/serialise.ml
@@ -69,12 +69,18 @@ let message ~tags : Endpoint_types.Out.t -> _ =
         f ~tags "Requesting bootstrap service"
       );
     Message.to_message b
-  | `Call (qid, target, request, descs) ->
+  | `Call (qid, target, request, descs, results_to) ->
     let c = Rpc.writable_req request in
     Call.question_id_set c (QuestionId.uint32 qid);
     set_target (Call.target_init c) target;
     let p = Call.params_get c in
     write_caps_array descs p;
+    let dest = Call.send_results_to_init c in
+    begin match results_to with
+      | `Caller -> Call.SendResultsTo.caller_set dest
+      | `Yourself -> Call.SendResultsTo.yourself_set dest
+      | `ThirdParty _ -> failwith "TODO: send_results_to ThirdParty"
+    end;
     Call.to_message c
   | `Finish (qid, release_result_caps) ->
     let b = Message.init_root () in

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -31,7 +31,7 @@ module Make (C : S.CORE_TYPES) = struct
     method private on_resolve q x =
       Queue.iter (fun fn -> fn x) q
 
-    method private do_finish _ = ()
+    method private send_cancel _ = ()
 
     method! blocker =
       match super#blocker, parent with

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -17,8 +17,8 @@ module Make (C : S.CORE_TYPES) = struct
     inherit struct_resolver
 
     method pipeline : Wire.Path.t -> Wire.Request.t -> cap RO_array.t -> struct_ref
-    method inc_ref : Wire.Path.t -> unit
-    method dec_ref : Wire.Path.t -> unit
+    method field_inc_ref : Wire.Path.t -> unit
+    method field_dec_ref : Wire.Path.t -> unit
 
     method field_blocker : Wire.Path.t -> base_ref option
 
@@ -85,7 +85,7 @@ module Make (C : S.CORE_TYPES) = struct
   let dispatch state ~cancelling_ok ~unresolved ~forwarding =
     match state with
     | Finished -> failwith "Already finished"
-    | Unresolved { cancelling = true; _ } when not cancelling_ok -> failwith "Cancelling"
+    | Unresolved { cancelling = true; _ } when not cancelling_ok -> failwith "Promise is cancelling!"
     | Unresolved x -> unresolved x
     | Forwarding x -> forwarding x
 
@@ -111,13 +111,13 @@ module Make (C : S.CORE_TYPES) = struct
 
       method inc_ref =
         match state with
-        | PromiseField (p, path) -> p#inc_ref path
+        | PromiseField (p, path) -> p#field_inc_ref path
         | ForwardingField c -> c#inc_ref
 
       method dec_ref =
         Log.info (fun f -> f "dec_ref %t" self#pp);
         match state with
-        | PromiseField (p, path) -> p#dec_ref path
+        | PromiseField (p, path) -> p#field_dec_ref path
         | ForwardingField c -> c#dec_ref
 
       method resolve cap =
@@ -254,8 +254,12 @@ module Make (C : S.CORE_TYPES) = struct
                     else c
                   in
                   let fixed_caps = RO_array.map break_cycles caps in
-                  if fixed_caps == caps then x
-                  else C.return (msg, fixed_caps)
+                  if RO_array.equal (=) fixed_caps caps then x
+                  else (
+                    RO_array.iter (fun c -> c#inc_ref) fixed_caps;
+                    x#finish;
+                    C.return (msg, fixed_caps)
+                  )
             in
             state <- Forwarding x;
             u.fields |> Field_map.iter (fun path f ->
@@ -340,7 +344,7 @@ module Make (C : S.CORE_TYPES) = struct
         ~unresolved:(fun u -> Queue.add (fun p -> p#when_resolved fn) u.when_resolved)
         ~forwarding:(fun x -> x#when_resolved fn)
 
-    method inc_ref path =
+    method field_inc_ref path =
       dispatch state
         ~cancelling_ok:true
         ~unresolved:(fun u ->
@@ -350,9 +354,9 @@ module Make (C : S.CORE_TYPES) = struct
             assert (f.ref_count > 1);   (* rc can't be one because that's our reference *)
             f.ref_count <- f.ref_count + 1
           )
-        ~forwarding:(fun x -> (x#cap path)#inc_ref)
+        ~forwarding:(fun x -> ignore (x#cap path))
 
-    method dec_ref path =
+    method field_dec_ref path =
       dispatch state
         ~cancelling_ok:true
         ~unresolved:(fun u ->
@@ -360,7 +364,11 @@ module Make (C : S.CORE_TYPES) = struct
             assert (f.ref_count > 1);   (* rc can't be one because that's our reference *)
             f.ref_count <- f.ref_count - 1
           )
-        ~forwarding:(fun x -> (x#cap path)#dec_ref)
+        ~forwarding:(fun x ->
+            let c = x#cap path in       (* Increases ref by one *)
+            c#dec_ref;
+            c#dec_ref
+          )
 
     method private update_target target =
       dispatch state

--- a/capnp-rpc/weak_ptr.ml
+++ b/capnp-rpc/weak_ptr.ml
@@ -1,8 +1,17 @@
 type 'a t = 'a Weak.t
 
+let empty () =
+  Weak.create 1
+
+let set t x =
+  Weak.set t 0 (Some x)
+
+let clear t =
+  Weak.set t 0 None
+
 let wrap x =
-  let t = Weak.create 1 in
-  Weak.set t 0 (Some x);
+  let t = empty () in
+  set t x;
   t
 
 let get t =

--- a/capnp-rpc/weak_ptr.mli
+++ b/capnp-rpc/weak_ptr.mli
@@ -1,8 +1,17 @@
 type 'a t
 (** An ['a t] is a weak pointer to an ['a]. *)
 
+val empty : unit -> 'a t
+(** [empty ()] is a fresh empty pointer. *)
+
 val wrap : 'a -> 'a t
 (** [wrap x] is a weak pointer to [x]. *)
 
 val get : 'a t -> 'a option
 (** [get t] is the target of [t], or [None] if it has been GC'd. *)
+
+val set : 'a t -> 'a -> unit
+(** [set t x] puts [x] in the pointer. *)
+
+val clear : 'a t -> unit
+(** [clear t] empties the pointer. *)

--- a/test/testbed/connection.mli
+++ b/test/testbed/connection.mli
@@ -2,7 +2,7 @@ open Capnp_direct.Core_types
 
 val summary_of_msg :
   [< `Bootstrap of _
-  | `Call of _ * _ * string * _
+  | `Call of _ * _ * string * _ * _
   | `Disembargo_reply of _
   | `Disembargo_request of _
   | `Finish of _
@@ -15,7 +15,7 @@ val summary_of_msg :
        | `Exception of Capnp_rpc.Exception.t
        | `Results of string * _
        | `ResultsSentElsewhere
-       | `TakeFromOtherQuestion ] *
+       | `TakeFromOtherQuestion of _] *
        _
   | `Unimplemented of _ ] ->
   string


### PR DESCRIPTION
- The optimisation of keeping the existing struct when there were no cycles was never triggered, due to a bad comparison, so we always made a copy.

- The code for making a copy would leak the caps which had cycles.

- Fixed some ref-counting bugs in the tests which this uncovered (we were trying to test the leaked caps, which only still existed due to the previous bug).

Also, log each incoming message in unit-tests and add missing send-results-to call field to message type (but it still isn't handled).