### PR TITLE
Simplify state model for questions

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -12,11 +12,11 @@ module Payload = struct
 
   let import (t:'a t) i =
     let cap = RO_array.get (snd t) (Uint32.to_int i) in       (* TODO: out-of-bounds *)
-    cap#inc_ref;
+    Core_types.inc_ref cap;
     cap
 
   let release (_, caps) =
-    RO_array.iter (fun x -> x#dec_ref) caps
+    RO_array.iter Core_types.dec_ref caps
 end
 
 module Capability = struct
@@ -27,8 +27,8 @@ module Capability = struct
   module Request = Request
   module Response = Payload
 
-  let inc_ref x = x#inc_ref
-  let dec_ref x = x#dec_ref
+  let inc_ref = Core_types.inc_ref
+  let dec_ref = Core_types.dec_ref
   let pp f x = x#pp f
 
   let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) req =

--- a/capnp-rpc-lwt/request.ml
+++ b/capnp-rpc-lwt/request.ml
@@ -21,7 +21,7 @@ let create_no_args () =
   {msg; n_exports = 0; exports_rev = []}
 
 let export t cap =
-  cap#inc_ref;
+  Core_types.inc_ref cap;
   let i = t.n_exports in
   t.n_exports <- i + 1;
   t.exports_rev <- cap :: t.exports_rev;
@@ -39,6 +39,6 @@ let caps t =
   caps
 
 let release t =
-  List.iter (fun x -> x#dec_ref) t.exports_rev;
+  List.iter Core_types.dec_ref t.exports_rev;
   t.n_exports <- 0;
   t.exports_rev <- []

--- a/capnp-rpc-lwt/response.ml
+++ b/capnp-rpc-lwt/response.ml
@@ -23,7 +23,7 @@ let create_empty () =
   {msg; n_exports = 0; exports_rev = []}
 
 let export t cap =
-  cap#inc_ref;
+  Core_types.inc_ref cap;
   let i = t.n_exports in
   t.n_exports <- i + 1;
   t.exports_rev <- cap :: t.exports_rev;
@@ -41,6 +41,6 @@ let finish t =
   | _ -> assert false
 
 let release t =
-  List.iter (fun x -> x#dec_ref) t.exports_rev;
+  List.iter Core_types.dec_ref t.exports_rev;
   t.n_exports <- 0;
   t.exports_rev <- []

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -10,8 +10,6 @@ let rec filter_map f = function
     | None -> filter_map f xs
     | Some y -> y :: filter_map f xs
 
-let dec_ref x = x#dec_ref
-
 let pp_check check f (k, v) =
   try check k v
   with ex ->
@@ -39,6 +37,13 @@ module Make (EP : Message_types.ENDPOINT) = struct
   module Local_struct_promise = Local_struct_promise.Make(Core_types)
   module Out = EP.Out
   module In = EP.In
+
+  let inc_ref = Core_types.inc_ref
+  let dec_ref = Core_types.dec_ref
+
+  let with_inc_ref x =
+    Core_types.inc_ref x;
+    x
 
   open EP.Table
 
@@ -204,7 +209,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
       | `Promise p -> p#resolve payload
       | `Released ->
         match payload with
-        | Ok (_, caps) -> RO_array.iter (fun x -> x#dec_ref) caps
+        | Ok (_, caps) -> RO_array.iter Core_types.dec_ref caps
         | Error _ -> ()
 
     let v ~params_for_release ~remote_promise id =
@@ -405,7 +410,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
   let create ?bootstrap ~tags ~queue_send =
     begin match bootstrap with
       | None -> ()
-      | Some x -> x#inc_ref
+      | Some x -> Core_types.inc_ref x
     end;
     {
       queue_send = (queue_send :> EP.Out.t -> unit);
@@ -495,7 +500,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
             ex.export_count <- ex.export_count + 1;
             ex
           | exception Not_found ->
-            cap#inc_ref;
+            Core_types.inc_ref cap;
             let ex = Exports.alloc t.exports (fun export_id ->
                 { export_count = 1; export_service = cap; export_id; export_resolve_target = `None }
               )
@@ -528,7 +533,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
                       ex.export_resolve_target <- get_resolve_target t x;
                       t.queue_send (`Resolve (ex.export_id, Ok new_export));
                   ); (* else: no longer an export *)
-                  x#dec_ref
+                  Core_types.dec_ref x
                 )
             end;
             ex
@@ -586,7 +591,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
       let caps = RO_array.map (fun c -> c#shortest) caps in
       Log.info (fun f -> f ~tags:(with_aid aid t) "Returning results: %a"
                    Core_types.Response_payload.pp (msg, caps));
-      RO_array.iter (fun c -> c#inc_ref) caps;        (* Copy everything stored in [answer]. *)
+      RO_array.iter Core_types.inc_ref caps;        (* Copy everything stored in [answer]. *)
       let broken_caps = Queue.create () in
       let descs = RO_array.map (export ~broken_caps t) caps in
       answer.exports_for_release <- exports_of descs;
@@ -715,7 +720,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
       let promise = answer_promise answer in
       begin match t.bootstrap with
         | Some service ->
-          service#inc_ref;
+          Core_types.inc_ref service;
           promise#resolve (Ok (Wire.Response.bootstrap, RO_array.of_list [service]));
         | None ->
           promise#resolve (Error (Error.exn "No bootstrap service available"));
@@ -724,7 +729,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
     | `Call (answer, target, msg, caps) ->
       Log.info (fun f -> f ~tags:t.tags "Handling call: (%t).call %a" target#pp Core_types.Request_payload.pp (msg, caps));
       let resp = target#call msg caps in  (* Takes ownership of [caps]. *)
-      target#dec_ref;
+      dec_ref target;
       (answer_promise answer)#connect resp;
       resp#when_resolved (fun _ -> Send.return t answer)
 
@@ -757,12 +762,12 @@ module Make (EP : Message_types.ENDPOINT) = struct
         | `Set _ -> Debug.failf "Can't resolve already-set switchable %t to %t!" self#pp cap#pp
         | `Unsettled (old, q) ->
           state <- `Set cap;
-          Queue.iter (fun f -> f (cap#inc_ref; cap)) q;
-          old#dec_ref;
+          Queue.iter (fun f -> f (with_inc_ref cap)) q;
+          dec_ref old;
           Lazy.force release
 
       method private release =
-        (target state)#dec_ref;
+        dec_ref (target state);
         Lazy.force release;
         state <- `Set released
 
@@ -822,10 +827,6 @@ module Make (EP : Message_types.ENDPOINT) = struct
     val join : t -> In.QuestionId.t -> In.message_target -> join_key_part -> unit
 *)
   end = struct
-    let with_inc_ref x =
-      x#inc_ref;
-      x
-
     let set_import_proxy t ~settled import =
       let message_target = `Import import in
       let cap =
@@ -884,7 +885,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
         if mark_dirty then Import.mark_used import;
         match Import.get_proxy import with
         | Some proxy ->
-          proxy#inc_ref;
+          Core_types.inc_ref proxy;
           (proxy :> Core_types.cap)
         | None ->
           (* The switchable got GC'd. It may have already dec-ref'd the import, or
@@ -895,7 +896,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
     let local_embargo t ~old_path x =
       let embargo = Cap_proxy.embargo x in
       (* Store in table *)
-      embargo#inc_ref;
+      inc_ref embargo;
       let (embargo_id, _) = Embargoes.alloc t.embargoes (fun id -> (id, embargo)) in
       (* Send disembargo request *)
       let disembargo_request = `Loopback (old_path, embargo_id) in
@@ -1008,7 +1009,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
         Log.info (fun f -> f ~tags:t.tags "Releasing export %a" ExportId.pp export_id);
         Hashtbl.remove t.exported_caps export.export_service;
         Exports.release t.exports export_id;
-        export.export_service#dec_ref;
+        dec_ref export.export_service;
         release_resolve_target t export.export_resolve_target
       )
 
@@ -1102,7 +1103,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
         );
       Embargoes.release t.embargoes embargo_id;
       embargo#disembargo;
-      embargo#dec_ref
+      dec_ref embargo
 
     let resolve t import_id new_target =
       Log.info (fun f -> f ~tags:t.tags "Received resolve of import %a to %a"
@@ -1119,14 +1120,14 @@ module Make (EP : Message_types.ENDPOINT) = struct
         let new_target = import_new_target ~embargo_path:None in
         Log.info (fun f -> f ~tags:t.tags "Import %a no longer used - releasing new resolve target %t"
                      ImportId.pp import_id new_target#pp);
-        new_target#dec_ref
+        dec_ref new_target
       | Some im ->
         (* Check we're not resolving a settled import. *)
         begin match new_target with
           | Ok _ when im.Import.settled ->
             let new_target = import_new_target ~embargo_path:None in
             let msg = Fmt.strf "Got a Resolve (to %t) for settled import %a!" new_target#pp Import.dump im in
-            new_target#dec_ref;
+            dec_ref new_target;
             failwith msg
           | _ -> ()
         end;
@@ -1141,7 +1142,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
           let new_target = import_new_target ~embargo_path:None in
           Log.info (fun f -> f ~tags:t.tags "Ignoring resolve of import %a, which we no longer need (to %t)"
                        ImportId.pp import_id new_target#pp);
-          new_target#dec_ref
+          dec_ref new_target
 
 (* TODO:
     let provide _t _question_id _message_target _recipient_id = ()
@@ -1243,16 +1244,16 @@ module Make (EP : Message_types.ENDPOINT) = struct
     t.disconnected <- Some ex;
     begin match t.bootstrap with
     | None -> ()
-    | Some b -> t.bootstrap <- None; b#dec_ref
+    | Some b -> t.bootstrap <- None; dec_ref b
     end;
     t.queue_send <- ignore;
-    Exports.drop_all t.exports (fun _ e -> e.export_service#dec_ref);
+    Exports.drop_all t.exports (fun _ e -> dec_ref e.export_service);
     Hashtbl.clear t.exported_caps;
     Questions.drop_all t.questions (fun _ -> Question.lost_connection ~ex);
     Answers.drop_all t.answers (fun _ a -> a.answer_promise#finish);
     let broken_cap = Core_types.broken_cap ex in
     Imports.drop_all t.imports (fun _ -> Import.lost_connection ~broken_cap);
-    Embargoes.drop_all t.embargoes (fun _ (_, e) -> e#break ex; e#dec_ref);
+    Embargoes.drop_all t.embargoes (fun _ (_, e) -> e#break ex; dec_ref e);
     (* TODO: break existing caps *)
     ()
 end

--- a/capnp-rpc/capnp_rpc.ml
+++ b/capnp-rpc/capnp_rpc.ml
@@ -11,3 +11,4 @@ module Cap_proxy = Cap_proxy
 
 module Message_types = Message_types
 module CapTP = CapTP
+module RC = RC

--- a/capnp-rpc/capnp_rpc.mli
+++ b/capnp-rpc/capnp_rpc.mli
@@ -10,3 +10,4 @@ module Core_types (W : S.WIRE) : S.CORE_TYPES with module Wire = W
 module Local_struct_promise = Local_struct_promise
 module Cap_proxy = Cap_proxy
 module CapTP = CapTP
+module RC = RC

--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -1,11 +1,9 @@
 module Make (C : S.CORE_TYPES) = struct
-  open C
-
   module Struct_proxy = Struct_proxy.Make(C)
 
-  type target = (struct_ref -> unit) Queue.t
+  type target = (C.struct_ref -> unit) Queue.t
 
-  let rec local_promise ?parent () = object (self : #struct_resolver)
+  let rec local_promise ?parent () = object (self : #C.struct_resolver)
     inherit [target] Struct_proxy.t (Queue.create ()) as super
 
     method private do_pipeline q i msg caps =
@@ -13,10 +11,10 @@ module Make (C : S.CORE_TYPES) = struct
       q |> Queue.add (fun p ->
           let cap = p#cap i in
           let r = result#connect (cap#call msg caps) in
-          cap#dec_ref;
+          C.dec_ref cap;
           r
         );
-      (result :> struct_ref)
+      (result :> C.struct_ref)
 
     method! pp f =
       let pp_promise f _ =
@@ -42,5 +40,5 @@ module Make (C : S.CORE_TYPES) = struct
     method field_sealed_dispatch _ _ = None
   end
 
-  let make () = (local_promise () :> struct_resolver)
+  let make () = (local_promise () :> C.struct_resolver)
 end

--- a/capnp-rpc/message_types.ml
+++ b/capnp-rpc/message_types.ml
@@ -100,15 +100,20 @@ module Make (Network : S.NETWORK_TYPES) (T : TABLE_TYPES) = struct
   ]
   (** A message sent over the network. *)
 
-  let with_qid_tag tags = function
+  let with_qid_tag tags : t -> _ = function
     | `Finish (qid, _)
     | `Bootstrap qid
-    | `Call (qid, _, _, _, _) -> Logs.Tag.add Debug.qid_tag (QuestionId.uint32 qid) tags
-    | `Return (aid, _, _) -> Logs.Tag.add Debug.qid_tag (AnswerId.uint32 aid) tags
-    | `Release _
-    | `Disembargo_request _
+    | `Call (qid, _, _, _, _)
+    | `Disembargo_request (`Loopback (`ReceiverAnswer (qid, _), _))
+    | `Disembargo_reply (`ReceiverAnswer (qid, _), _) ->
+      Logs.Tag.add Debug.qid_tag (QuestionId.uint32 qid) tags
+    | `Return (aid, _, _) ->
+      Logs.Tag.add Debug.qid_tag (AnswerId.uint32 aid) tags
     | `Disembargo_reply _
-    | `Resolve _ -> tags
+    | `Disembargo_request _
+    | `Release _
+    | `Resolve _ ->
+      tags
 
   let pp_results_to f = function
     | `Caller -> ()

--- a/capnp-rpc/rC.ml
+++ b/capnp-rpc/rC.ml
@@ -1,0 +1,34 @@
+type t = int
+
+let leaked  = -1
+let zero    =  0
+let one     =  1
+
+let pp f = function
+  | -1 -> Fmt.pf f "rc=%a" Fmt.(styled `Red string) "LEAKED"
+  | 0  -> Fmt.pf f "rc=%a" Fmt.(styled `Red int) 0
+  | t  -> Fmt.pf f "rc=%d" t
+
+let succ ~pp:pp_obj t =
+  if t > 0 then (
+    let t' = t + 1 in
+    if t' < 0 then Debug.failf "Ref-count %a on %t would wrap if incremented further!" pp t pp_obj;
+    t'
+  ) else (
+    Debug.failf "Attempt to inc-ref on freed resource %t" pp_obj
+  )
+
+let pred ~pp t =
+  if t > 0 then t - 1
+  else if t = 0 then Debug.failf "Attempt to free already-freed resource %t" pp
+  else leaked
+
+let is_zero = function
+  | 0 -> true
+  | _ -> false
+
+let check ~pp t =
+  if t < 1 then
+    Debug.invariant_broken (fun f -> Fmt.pf f "Already unref'd! %t" pp)
+
+let to_int t = t

--- a/capnp-rpc/rC.mli
+++ b/capnp-rpc/rC.mli
@@ -1,0 +1,32 @@
+(* A ref-count type that raises an exception on overflow. *)
+
+type t
+(** A number used as a reference count. *)
+
+val zero : t
+
+val one : t
+
+val leaked : t
+(** [leaked] is used to represent a ref-count that is invalid because we detected a GC leak.
+    Has the value [-1] (for [to_int] or polymorphic compare). *)
+
+val succ : pp:(Format.formatter -> unit) -> t -> t
+(** [succ ~pp t] is t plus one.
+    Raises an exception (including [pp]) if this overflows, or if [t] is [zero] or [leaked]. *)
+
+val pred : pp:(Format.formatter -> unit) -> t -> t
+(** [pred ~pp t] is t minus one. Raises an exception (including [pp]) if [t] is [zero].
+    [pred ~pp leaked = leaked], so that one leaked resource freeing another doesn't generate further errors. *)
+
+val is_zero : t -> bool
+(** [is_zero t] is [true] if the ref-count is zero (the resource should be released).
+    [is_zero leaked = false], since whatever detected the leak should free it. *)
+
+val pp : t Fmt.t
+
+val check : pp:(Format.formatter -> unit) -> t -> unit
+(** [check ~pp t] raises an exception (including [pp]) if [t] is zero or leaked.
+    Useful in sanity checks. *)
+
+val to_int : t -> int

--- a/capnp-rpc/rC.mli
+++ b/capnp-rpc/rC.mli
@@ -8,16 +8,17 @@ val zero : t
 val one : t
 
 val leaked : t
-(** [leaked] is used to represent a ref-count that is invalid because we detected a GC leak.
-    Has the value [-1] (for [to_int] or polymorphic compare). *)
+(** [leaked] is used to represent a ref-count that is invalid because we detected a GC leak. *)
+
+val sum : pp:(Format.formatter -> unit) -> t -> int -> t
+(** [sum ~pp t d] is [t + d].
+    Raises an exception (including [pp]) if this would overflow or become negative, or if [t] is [zero] or [leaked]. *)
 
 val succ : pp:(Format.formatter -> unit) -> t -> t
-(** [succ ~pp t] is t plus one.
-    Raises an exception (including [pp]) if this overflows, or if [t] is [zero] or [leaked]. *)
+(** [succ ~pp t] is [add ~pp t 1]. *)
 
 val pred : pp:(Format.formatter -> unit) -> t -> t
-(** [pred ~pp t] is t minus one. Raises an exception (including [pp]) if [t] is [zero].
-    [pred ~pp leaked = leaked], so that one leaked resource freeing another doesn't generate further errors. *)
+(** [pred ~pp t] is [add ~pp t (-1)]. *)
 
 val is_zero : t -> bool
 (** [is_zero t] is [true] if the ref-count is zero (the resource should be released).
@@ -29,4 +30,5 @@ val check : pp:(Format.formatter -> unit) -> t -> unit
 (** [check ~pp t] raises an exception (including [pp]) if [t] is zero or leaked.
     Useful in sanity checks. *)
 
-val to_int : t -> int
+val to_int : t -> int option
+(** [to_int t] is the non-negative integer ref-count, or [None] if [t = leaked]. *)

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -17,8 +17,7 @@ module Make (C : S.CORE_TYPES) = struct
     inherit struct_resolver
 
     method pipeline : Wire.Path.t -> Wire.Request.t -> cap RO_array.t -> struct_ref
-    method field_inc_ref : Wire.Path.t -> unit
-    method field_dec_ref : Wire.Path.t -> unit
+    method field_update_rc : Wire.Path.t -> int -> unit
 
     method field_blocker : Wire.Path.t -> base_ref option
 
@@ -34,8 +33,7 @@ module Make (C : S.CORE_TYPES) = struct
 
   let invalid_cap = object (_ : C.cap)
     method call _ _ = failwith "invalid_cap"
-    method inc_ref = failwith "invalid_cap"
-    method dec_ref = failwith "invalid_cap"
+    method update_rc = failwith "invalid_cap"
     method shortest = failwith "invalid_cap"
     method when_more_resolved _ = failwith "invalid_cap"
     method pp f = Fmt.string f "(invalid cap)"
@@ -109,16 +107,10 @@ module Make (C : S.CORE_TYPES) = struct
         | PromiseField (p, path) -> Fmt.pf f "field(%a)%t" Debug.OID.pp id (p#field_pp path)
         | ForwardingField c -> Fmt.pf f "field(%a) -> %t" Debug.OID.pp id c#pp
 
-      method inc_ref =
+      method update_rc d =
         match state with
-        | PromiseField (p, path) -> p#field_inc_ref path
-        | ForwardingField c -> c#inc_ref
-
-      method dec_ref =
-        Log.info (fun f -> f "dec_ref %t" self#pp);
-        match state with
-        | PromiseField (p, path) -> p#field_dec_ref path
-        | ForwardingField c -> c#dec_ref
+        | PromiseField (p, path) -> p#field_update_rc path d
+        | ForwardingField c -> c#update_rc d
 
       method resolve cap =
         Log.info (fun f -> f "Resolved field(%a) to %t" Debug.OID.pp id cap#pp);
@@ -257,7 +249,7 @@ module Make (C : S.CORE_TYPES) = struct
                   let fixed_caps = RO_array.map break_cycles caps in
                   if RO_array.equal (=) fixed_caps caps then x
                   else (
-                    RO_array.iter (fun c -> c#inc_ref) fixed_caps;
+                    RO_array.iter C.inc_ref fixed_caps;
                     x#finish;
                     C.return (msg, fixed_caps)
                   )
@@ -267,15 +259,15 @@ module Make (C : S.CORE_TYPES) = struct
                 let pp = self#field_pp path in
                 let ref_count = RC.pred f.ref_count ~pp in (* Count excluding our ref *)
                 f.ref_count <- RC.zero;
-                let ref_count = RC.to_int ref_count in
-                if ref_count > 0 then (   (* Someone else is using it too *)
-                  let c = x#cap path in   (* Increases ref by one *)
-                  (* We dropped our ref to [f], and [x#cap] added one above. The rest we pass on. *)
-                  for _ = 2 to ref_count do c#inc_ref done;
-                  f.cap#resolve c
-                ) else (
-                  f.cap#resolve invalid_cap
-                );
+                begin match RC.to_int ref_count with
+                  | None        (* Field was leaked; shouldn't happen since we hold a copy anyway. *)
+                  | Some 0 -> f.cap#resolve invalid_cap (* No other users *)
+                  | Some ref_count ->                   (* Someone else is using it too *)
+                    let c = x#cap path in   (* Increases ref by one *)
+                    (* Transfer our refs to the new target, excluding the one already addded by [x#cap]. *)
+                    c#update_rc (ref_count - 1);
+                    f.cap#resolve c
+                end;
                 self#field_resolved (f.cap :> cap)
               );
             self#on_resolve u.target x;
@@ -337,7 +329,7 @@ module Make (C : S.CORE_TYPES) = struct
         | Error `Cancelled -> fn (C.broken_cap Exception.cancelled)
         | Ok payload ->
           let cap = C.Response_payload.field_or_err payload i in
-          cap#inc_ref;
+          C.inc_ref cap;
           fn cap
       in
       dispatch state
@@ -345,7 +337,7 @@ module Make (C : S.CORE_TYPES) = struct
         ~unresolved:(fun u -> Queue.add (fun p -> p#when_resolved fn) u.when_resolved)
         ~forwarding:(fun x -> x#when_resolved fn)
 
-    method field_inc_ref path =
+    method field_update_rc path d =
       dispatch state
         ~cancelling_ok:true
         ~unresolved:(fun u ->
@@ -354,9 +346,12 @@ module Make (C : S.CORE_TYPES) = struct
             let f = Field_map.get path u.fields in
             assert (f.ref_count > RC.one);   (* rc can't be one because that's our reference *)
             let pp = self#field_pp path in
-            f.ref_count <- RC.succ f.ref_count ~pp
+            f.ref_count <- RC.sum f.ref_count d ~pp
           )
-        ~forwarding:(fun x -> ignore (x#cap path))
+        ~forwarding:(fun x ->
+            let c = x#cap path in       (* Increases rc by one *)
+            c#update_rc (d - 1)
+          )
 
     method field_dec_ref path =
       dispatch state
@@ -369,8 +364,7 @@ module Make (C : S.CORE_TYPES) = struct
           )
         ~forwarding:(fun x ->
             let c = x#cap path in       (* Increases ref by one *)
-            c#dec_ref;
-            c#dec_ref
+            c#update_rc (-2)
           )
 
     method private update_target target =
@@ -394,9 +388,12 @@ module Make (C : S.CORE_TYPES) = struct
       | Forwarding _ -> Fmt.pf f "Promise is resolved, but field %a isn't!" Wire.Path.pp path
       | Unresolved u ->
         let field = Field_map.get path u.fields in
-        let rc = RC.to_int field.ref_count in
-        (* (separate the ref-count that we hold on it) *)
-        Fmt.pf f "(rc=1+%d) -> #%a -> %t" (rc - 1) Wire.Path.pp path self#pp
+        match RC.to_int field.ref_count with
+        | None ->
+          Fmt.pf f "(rc=LEAKED) -> #%a -> %t" Wire.Path.pp path self#pp
+        | Some rc ->
+          (* (separate the ref-count that we hold on it) *)
+          Fmt.pf f "(rc=1+%d) -> #%a -> %t" (rc - 1) Wire.Path.pp path self#pp
 
     method check_invariants =
       dispatch state

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -275,7 +275,7 @@ module Vat = struct
       let n_args = Choose.int 3 in
       let args, arg_refs = n_caps state (n_args) in
       let arg_ids = List.map (fun cr -> cr.cr_target) arg_refs |> RO_array.of_list in
-      RO_array.iter (fun c -> c#inc_ref) args;
+      RO_array.iter Core_types.inc_ref args;
       let answer = Direct.make_struct () in
       Logs.info (fun f -> f ~tags:(tags state) "Call %a=%t(%a) (answer %a)"
                     Direct.pp target cap#pp
@@ -294,7 +294,7 @@ module Vat = struct
     | None -> ()
     | Some (answer, answer_id) ->
       let arg_ids = List.map (fun cr -> cr.cr_target) arg_refs in
-      RO_array.iter (fun c -> c#inc_ref) args;
+      RO_array.iter Core_types.inc_ref args;
       Logs.info (fun f -> f ~tags:(tags state)
                     "Return %a (%a)" (RO_array.pp Core_types.pp) args Direct.pp_struct answer_id);
       Direct.return answer_id (RO_array.of_list arg_ids);
@@ -357,7 +357,7 @@ module Vat = struct
     | Some cr ->
       let c = cr.cr_cap in
       Logs.info (fun f -> f ~tags:(tags state) "Release %t (%a)" c#pp Direct.pp cr.cr_target);
-      c#dec_ref
+      Core_types.dec_ref c
 
   (* Create a new local service *)
   let do_create state () =
@@ -378,7 +378,7 @@ module Vat = struct
   let free_all t =
     let rec free_caps () =
       match DynArray.pop_first t.caps with
-      | Some c -> c.cr_cap#dec_ref; free_caps ()
+      | Some c -> Core_types.dec_ref c.cr_cap; free_caps ()
       | None -> ()
     in
     let rec free_srs () =
@@ -428,7 +428,7 @@ module Vat = struct
   let destroy t =
     begin match t.bootstrap with
     | None -> ()
-    | Some (bs, _) -> bs#dec_ref; t.bootstrap <- None
+    | Some (bs, _) -> Core_types.dec_ref bs; t.bootstrap <- None
     end;
     List.iter (fun (_, e) -> Endpoint.disconnect e) t.connections;
     t.connections <- []

--- a/test/test.ml
+++ b/test/test.ml
@@ -309,7 +309,7 @@ let test_local_embargo_6 () =
   C.handle_msg c ~expect:"disembargo-request";  (* (the server is doing its own embargo on q2) *)
   S.handle_msg s ~expect:"call:Message-1";
   S.handle_msg s ~expect:"disembargo-reply";    (* (the server is doing its own embargo on q2) *)
-  C.handle_msg c ~expect:"disembargo-reply";    (* XXX: disembargo for finished answer! *)
+  C.handle_msg c ~expect:"disembargo-reply";
   S.handle_msg s ~expect:"call:Message-2";
   let m1 = service#pop0 "Message-1" in
   let m2 = service#pop0 "Message-2" in

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -130,7 +130,7 @@ module Pair ( ) = struct
     let q2 = Queue.create () in
     let c = C.create ~tags:client_tags q1 q2 in
     let s = S.create ~tags:server_tags q2 q1 ~bootstrap in
-    bootstrap#dec_ref; (* [s] took a reference *)
+    Capnp_direct.Core_types.dec_ref bootstrap; (* [s] took a reference *)
     c, s
 
   let rec flush c s =


### PR DESCRIPTION
Combine the remote promise's reference into the `ref_count` field. It needs to be treated just the same.

Also, add an `RC` module for handling ref-counts. Raises exceptions on overflow.