### PR TITLE
Autogenerate unit-tests for fuzzing failures

### DIFF
--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -125,12 +125,16 @@ module Pair ( ) = struct
   module C = Endpoint(ProtoC)
   module S = Endpoint(ProtoS)
 
-  let create ~client_tags ~server_tags bootstrap =
+  let create ~client_tags ~server_tags ?client_bs bootstrap =
     let q1 = Queue.create () in
     let q2 = Queue.create () in
-    let c = C.create ~tags:client_tags q1 q2 in
+    let c = C.create ~tags:client_tags q1 q2 ?bootstrap:client_bs in
     let s = S.create ~tags:server_tags q2 q1 ~bootstrap in
     Capnp_direct.Core_types.dec_ref bootstrap; (* [s] took a reference *)
+    begin match client_bs with
+      | None -> ()
+      | Some x -> Capnp_direct.Core_types.dec_ref x;
+    end;
     c, s
 
   let rec flush c s =

--- a/test/testbed/connection.mli
+++ b/test/testbed/connection.mli
@@ -53,7 +53,7 @@ module Pair ( ) : sig
   module C : ENDPOINT
   module S : ENDPOINT
 
-  val create : client_tags:Logs.Tag.set -> server_tags:Logs.Tag.set -> #cap -> C.t * S.t
+  val create : client_tags:Logs.Tag.set -> server_tags:Logs.Tag.set -> ?client_bs:#cap -> #cap -> C.t * S.t
 
   val flush : C.t -> S.t -> unit
 

--- a/test/testbed/services.ml
+++ b/test/testbed/services.ml
@@ -43,10 +43,12 @@ let manual () = object
 
   (* Expect a message with no caps *)
   method pop0 msg =
-    let actual, args, answer = Queue.pop queue in
-    Alcotest.(check string) ("Expecting " ^ msg) msg actual;
-    Alcotest.(check int) "Has no args" 0 @@ RO_array.length args;
-    answer
+    match Queue.pop queue with
+    | exception Queue.Empty -> Capnp_rpc.Debug.failf "Empty queue (expecting %S)" msg
+    | actual, args, answer ->
+      Alcotest.(check string) ("Expecting " ^ msg) msg actual;
+      Alcotest.(check int) "Has no args" 0 @@ RO_array.length args;
+      answer
 
   (* Expect a message with one cap *)
   method pop1 msg =

--- a/test/testbed/test_utils.ml
+++ b/test/testbed/test_utils.ml
@@ -1,12 +1,12 @@
 type actor = Fmt.style * string
 
-let pp_actor f (style, name) = Fmt.(styled style (const string name)) f ()
+let pp_actor f (style, name) = Fmt.(styled style string) f name
 
 let pp_peer f = function
-  | None -> ()
+  | None -> Fmt.string f "       "
   | Some peer -> Fmt.pf f "(%a)" pp_actor peer
 
-let unknown = `Black, "------------"
+let unknown = `Black, "-----"
 
 let actor_tag = Logs.Tag.def "actor" pp_actor
 let peer_tag = Logs.Tag.def "peer" pp_actor
@@ -45,5 +45,5 @@ let () =
   Logs.set_reporter reporter;
   Logs.set_level (Some Logs.Info)
 
-let server_tags = Logs.Tag.(empty |> add actor_tag (`Red, "server"))
-let client_tags = Logs.Tag.(empty |> add actor_tag (`Green, "client"))
+let server_tags = Logs.Tag.(empty |> add actor_tag (`Red, "vat-S"))
+let client_tags = Logs.Tag.(empty |> add actor_tag (`Green, "vat-C"))


### PR DESCRIPTION
When examining a crash found by AFL, output a unit-test for it that can be added to the test suite (with a little fixing up by hand).

This makes it easier to turn bugs found by the fuzzer into test-cases.

Added a test case that this generated (commented out because it is actually failing at the moment).

Also, improved the logging output from the fuzzing in various ways.