### PR TITLE
Replace DynArray with WrapArray in most places

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all fuzz clean test
 
-default: test
+default: test #build-fuzz
 
 all:
 	jbuilder build --dev @install test/test.bc test-lwt/test.bc

--- a/capnp-rpc/cap_proxy.ml
+++ b/capnp-rpc/cap_proxy.ml
@@ -139,7 +139,7 @@ module Make(C : S.CORE_TYPES) = struct
 
         method! pp f =
           match state with
-          | Unresolved _ -> Fmt.pf f "embargoed(%a, %t) -> %t" Debug.OID.pp id super#pp_refcount underlying#pp
+          | Unresolved _ -> Fmt.pf f "embargoed(%a, %t)" Debug.OID.pp id super#pp_refcount
           | Resolved cap -> Fmt.pf f "disembargoed(%a, %t) -> %t" Debug.OID.pp id super#pp_refcount cap#pp
       end
     in

--- a/fuzz/choose.ml
+++ b/fuzz/choose.ml
@@ -13,3 +13,6 @@ let int limit =
 
 let array options =
   options.(int (Array.length options))
+
+let bool () =
+  Char.code (input_char stdin) land 1 = 0

--- a/fuzz/wrapArray.ml
+++ b/fuzz/wrapArray.ml
@@ -1,0 +1,52 @@
+type 'a t = {
+  items : 'a option array;
+  free : 'a -> unit;
+}
+
+let create ~free size = {
+  items = Array.make size None;
+  free;
+}
+
+let add t v =
+  let i =
+    try Choose.int (Array.length t.items)
+    with Choose.End_of_fuzz_data -> 0
+  in
+  let old = t.items.(i) in
+  t.items.(i) <- Some v;
+  match old with
+  | None -> ()
+  | Some old -> t.free old
+
+let pick t =
+  t.items.(Choose.int (Array.length t.items))
+
+let iter fn t =
+  Array.iter (function
+      | None -> ()
+      | Some item -> fn item
+    ) t.items
+
+let free t =
+  for i = 0 to Array.length t.items - 1 do
+    match t.items.(i) with
+    | None -> ()
+    | Some item ->
+      t.free item;
+      t.items.(i) <- None
+  done
+
+let dump ~compare pp f t =
+  let items = Array.fold_left (fun acc -> function
+      | None -> acc
+      | Some x -> x :: acc) [] t.items in
+  let items = List.sort compare items in
+  Fmt.list ~sep:Fmt.cut pp f items
+let dump ~compare pp f = Fmt.fmt "[@[<v0>%a@]]" f (dump ~compare pp)
+
+let pop t =
+  let i = Choose.int (Array.length t.items) in
+  let v = t.items.(i) in
+  t.items.(i) <- None;
+  v

--- a/test/test.ml
+++ b/test/test.ml
@@ -17,6 +17,7 @@ let empty = RO_array.empty
 
 let inc_ref = Core_types.inc_ref
 let dec_ref = Core_types.dec_ref
+let with_inc_ref x = inc_ref x; x
 
 let error = Alcotest.of_pp Capnp_rpc.Error.pp
 let pp_cap f p = p#pp f
@@ -356,8 +357,7 @@ let test_local_embargo_7 () =
   (* Client resolves a2 to a local promise. *)
   let client_promise = Cap_proxy.local_promise () in
   let a2 = local#pop0 "q2" in
-  inc_ref client_promise;
-  resolve_ok a2 "a2" [client_promise];
+  resolve_ok a2 "a2" [with_inc_ref client_promise];
   (* Client gets answer to a1 and sends disembargo. *)
   C.handle_msg c ~expect:"return:a1";
   let m2 = call target "Message-2" [] in

--- a/test/testbed/services.ml
+++ b/test/testbed/services.ml
@@ -57,6 +57,11 @@ let manual () = object
     Alcotest.(check int) "Has one arg" 1 @@ RO_array.length args;
     RO_array.get args 0, answer
 
+  method pop_n msg =
+    let actual, args, answer = Queue.pop queue in
+    Alcotest.(check string) ("Expecting " ^ msg) msg actual;
+    args, answer
+
 end
 
 (* Callers can swap their arguments for the slot's contents. *)


### PR DESCRIPTION
DynArray makes it hard to simplify example cases, because removing one operation that added something to the array changes the positions in the array of all future allocations, so all later operations do something different.

Instead, let AFL pick the indexes to be used. If it picks one that's already used, free the existing item first.