### PR TITLE
Pass results resolver to call methods

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -38,7 +38,9 @@ module Capability = struct
     let (interface_id, method_id) = m in
     Call.interface_id_set c interface_id;
     Call.method_id_set_exn c method_id;
-    target#call (Rpc.Builder c) (Request.caps req)
+    let results, resolver = Local_struct_promise.make () in
+    target#call resolver (Rpc.Builder c) (Request.caps req);
+    results
 
   let call_for_value cap m req =
     let p, r = Lwt.task () in

--- a/capnp-rpc/local_struct_promise.mli
+++ b/capnp-rpc/local_struct_promise.mli
@@ -1,3 +1,3 @@
 module Make (C : S.CORE_TYPES) : sig
-  val make : unit -> C.struct_resolver
+  val make : unit -> C.struct_ref * C.struct_resolver
 end

--- a/capnp-rpc/message_types.ml
+++ b/capnp-rpc/message_types.ml
@@ -80,7 +80,7 @@ module Make (Network : S.NETWORK_TYPES) (T : TABLE_TYPES) = struct
     | `Exception ex -> Fmt.pf f "Exception:%a" Exception.pp ex
     | `Cancelled -> Fmt.pf f "Cancelled"
     | `ResultsSentElsewhere -> Fmt.pf f "ResultsSentElsewhere"
-    | `TakeFromOtherQuestion qid -> Fmt.pf f "TakeFromOtherQuestion(%a)" QuestionId.pp qid
+    | `TakeFromOtherQuestion qid -> Fmt.pf f "TakeFromSenderQuestion(%a)" QuestionId.pp qid
     | `AcceptFromThirdParty -> Fmt.pf f "AcceptFromThirdParty"
 
   let pp_disembargo_request : disembargo_request Fmt.t = fun f -> function

--- a/fuzz/choose.ml
+++ b/fuzz/choose.ml
@@ -15,4 +15,4 @@ let array options =
   options.(int (Array.length options))
 
 let bool () =
-  Char.code (input_char stdin) land 1 = 0
+  Char.code (input_char stdin) land 1 = 1

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -90,7 +90,12 @@ module Endpoint (EP : Capnp_direct.ENDPOINT) = struct
         msg
 
   let handle_msg ?expect t =
-    pop_msg ?expect t |> Conn.handle_msg t.conn
+    try
+      pop_msg ?expect t |> Conn.handle_msg t.conn;
+      Conn.check t.conn
+    with ex ->
+      Logs.err (fun f -> f ~tags:(Conn.tags t.conn) "@[<v2>%a:@,%a@]" Capnp_rpc.Debug.pp_exn ex Conn.dump t.conn);
+      raise ex
 
   let maybe_handle_msg t =
     if Queue.length t.recv_queue > 0 then handle_msg t

--- a/test/testbed/test_utils.ml
+++ b/test/testbed/test_utils.ml
@@ -29,11 +29,11 @@ let reporter =
     let peer = Logs.Tag.find peer_tag tags in
     let qid = Logs.Tag.find Capnp_rpc.Debug.qid_tag tags in
     let print _ =
-      Fmt.(pf stderr) "%a@." pp_qid qid;
+      Fmt.(pf stdout) "%a@." pp_qid qid;
       over ();
       k ()
     in
-    Fmt.kpf print Fmt.stderr ("%a %a %a%a: @[" ^^ fmt ^^ "@]")
+    Fmt.kpf print Fmt.stdout ("%a %a %a%a: @[" ^^ fmt ^^ "@]")
       Fmt.(styled `Magenta string) (Printf.sprintf "%11s" src)
       Logs_fmt.pp_header (level, header)
       pp_actor actor


### PR DESCRIPTION
This allows the callee to see where the results are to be sent. CapTP will be able to use this in future to implement the send-results-to optimisation.

Also:

- Rename `resolver#connect` to `resolver#resolve` and convert the old `resolve` method into a set of helpers that can be used with any resolver, rather than requiring every resolver to implement them.

- Split structs and resolvers into separate types. `Local_struct_promise.make` now returns a `(promise, resolver)` pair.

  This means that if a service wants to use the results of a call, it must create a separate promise and then resolve the promise to that. Before, it could watch the resolver it was passed.

  This is needed to support send-results-to, because we need to know that we don't need an answer locally in order to tell the peer to keep the results for itself.

  It also clarifies the ref-counting situation (resolvers aren't ref-counted, and it's OK for a promise's ref-count to reach zero before its resolver is called).