### PR TITLE
Fix compilation when not using --dev

### DIFF
--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -726,7 +726,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
 
   (* Forwards messages to [init] until resolved.
      Forces [release] when resolved or released. *)
-  class switchable ~release init =
+  class switchable ~(release:unit Lazy.t) init =
     let released = Core_types.broken_cap (Exception.v "(released)") in
     let pp_state f = function
       | `Unsettled (x, _) -> Fmt.pf f "(unsettled) -> %t" x#pp


### PR DESCRIPTION
The error was:

    The method resolve has type Core_types.cap -> 'b where 'b is unbound

Reported by @samoht.
