### PR TITLE
Remove extra local promise when pipelining

### DIFF
--- a/capnp-rpc-lwt/serialise.ml
+++ b/capnp-rpc-lwt/serialise.ml
@@ -129,7 +129,18 @@ let message ~tags : Endpoint_types.Out.t -> _ =
         let ret = Message.return_init m in
         Return.canceled_set ret;
         ret
-      | _ -> failwith "TODO: other return type"
+      | `ResultsSentElsewhere ->
+        let m = Message.init_root () in
+        let ret = Message.return_init m in
+        Return.results_sent_elsewhere_set ret;
+        ret
+      | `TakeFromOtherQuestion qid ->
+        let m = Message.init_root () in
+        let ret = Message.return_init m in
+        Return.take_from_other_question_set ret (QuestionId.uint32 qid);
+        ret
+      | `AcceptFromThirdParty ->
+        failwith "TODO: AcceptFromThirdParty"
     in
     Return.answer_id_set ret (AnswerId.uint32 aid);
     Return.release_param_caps_set ret release;

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -1156,6 +1156,8 @@ module Make (EP : Message_types.ENDPOINT) = struct
 
             method resolve = resolver#resolve
 
+            method set_blocker = resolver#set_blocker
+
             method sealed_dispatch : type a. a S.brand -> a option = function
               | CapTP_results -> Some (t, answer)
               | _ -> None

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -33,6 +33,7 @@ module Make(Wire : S.WIRE) = struct
   and struct_resolver = object
     method pp : Format.formatter -> unit
     method resolve : struct_ref -> unit
+    method set_blocker : base_ref option -> unit
     method sealed_dispatch : 'a. 'a S.brand -> 'a option
   end
 

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -148,6 +148,12 @@ module type CORE_TYPES = sig
 
     method sealed_dispatch : 'a. 'a brand -> 'a option
     (** [r#sealed_dispatch brand] extracts some private data of the given type. *)
+
+    method set_blocker : base_ref option -> unit
+    (** [r#set_blocker b] means that [resolve] won't be called until [b] is resolved.
+        [r]'s promise should report this as its blocker. This is needed to detect cycles.
+        When the blocker is resolved, call this again with [None] to clear it (the promise
+        will then report itself as the blocker again, until resolved). *)
   end
   (** A [struct_resolver] can be used to resolve some promise. *)
 


### PR DESCRIPTION
This prevented us from doing the send-results-to optimisation in some cases.

Also, implement take-from-other-question and results-sent-elsewhere Cap'n Proto serialisations.