### PR TITLE
Improve error handling and add test binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: test #build-fuzz
 
 all:
-	jbuilder build --dev @install test/test.bc test-lwt/test.bc
+	jbuilder build --dev @install test/test.bc test-lwt/test.bc test-bin/calc.exe
 	rm -rf _build/_tests
 	jbuilder runtest --dev --no-buffer -j 1
 
@@ -19,6 +19,6 @@ clean:
 
 test:
 	rm -rf _build/_tests
-	jbuilder build --dev test/test.bc test-lwt/test.bc
+	jbuilder build --dev test/test.bc test-lwt/test.bc test-bin/calc.bc
 	#./_build/default/test/test.bc test core -ev 11
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/README.md
+++ b/README.md
@@ -33,13 +33,12 @@ Currently, you need to pin the <https://github.com/talex5/capnp-ocaml/tree/inter
 This library is new and unfinished, but it is usable.
 It has been only lightly used in real systems, but has unit tests and AFL fuzz tests that cover most of the core logic.
 
-Currently, level 1 support is mostly complete, though some optimisations are missing.
-In particular, the `Resolve` message is not yet implemented.
-Check the issues page for some of the known bugs.
+All level 1 features are implemented, but check the issues page for known bugs.
 
 The library does not currently provide support for establishing new network connections or for any kind of crypto.
 Instead, the user of the library is responsible for creating a secure channel to the target service and then giving it to the library.
 For example, a channel could be a local Unix-domain socket (created with `socketpair`) or a TCP connection with a TLS wrapper.
+See `test-bin/calc.ml` for an example program that can provide or consume a service over a Unix domain socket.
 
 Level 3 support is not implemented yet, so if host Alice has connections to hosts Bob and Carol and passes an object hosted at Bob to Carol, the resulting messages between Carol and Bob will be routed via Alice.
 
@@ -61,6 +60,14 @@ The `examples` directory contains some test services.
 Running `make test` will run through the tests in `test-lwt/test.ml`, which make use of the examples.
 
 If you have trouble building, you can build it with Docker from a known-good state using `docker build .`.
+
+To try the calculator service example:
+
+1. Start the server:
+   `./_build/default/test-bin/calc.bc serve unix:/tmp/calc.socket`
+
+2. In another terminal, run the client:
+   `./_build/default/test-bin/calc.bc connect unix:/tmp/calc.socket`
 
 ### Structure of the library
 

--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -94,7 +94,7 @@ let connect ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
   let queue_send msg = queue_send ~xmit_queue endpoint (Serialise.message ~tags msg) in
   let conn = Conn.create ?bootstrap:offer ~tags ~queue_send in
   Lwt_switch.add_hook (Some switch) (fun () ->
-      Conn.disconnect conn (Capnp_rpc.Exception.v "CapTP switch turned off");
+      Conn.disconnect conn (Capnp_rpc.Exception.v ~ty:`Disconnected "CapTP switch turned off");
       Lwt.return_unit
     );
   let t = {

--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -11,6 +11,7 @@ type t = {
   endpoint : Endpoint.t;
   conn : Conn.t;
   xmit_queue : Capnp.Message.rw Capnp.BytesMessage.Message.t Queue.t;
+  switch : Lwt_switch.t;
 }
 
 let bootstrap t = Conn.bootstrap t.conn
@@ -67,25 +68,28 @@ let listen t =
     Endpoint.recv t.endpoint >>= function
     | Error e -> Lwt.return e
     | Ok msg ->
-      begin
-        let open Reader.Message in
-        let msg = of_message msg in
-        match Parse.message msg with
-        | #Capnp_core.Endpoint_types.In.t as msg ->
-          Log.info (fun f ->
-              let tags = Capnp_core.Endpoint_types.In.with_qid_tag (Conn.tags t.conn) msg in
-              f ~tags "<- %a" (Capnp_core.Endpoint_types.In.pp_recv pp_msg) msg);
-          Conn.handle_msg t.conn msg
-        | `Unimplemented x as msg ->
-          Log.info (fun f ->
-              let tags = Capnp_core.Endpoint_types.Out.with_qid_tag (Conn.tags t.conn) x in
-              f ~tags "<- Unimplemented(%a)" (Capnp_core.Endpoint_types.Out.pp_recv pp_msg) x);
-          Conn.handle_msg t.conn msg
-        | `Not_implemented ->
-          Log.info (fun f -> f "<- unsupported message type");
-          return_not_implemented t msg
-      end;
-      loop ()
+      let open Reader.Message in
+      let msg = of_message msg in
+      match Parse.message msg with
+      | #Capnp_core.Endpoint_types.In.t as msg ->
+        Log.info (fun f ->
+            let tags = Capnp_core.Endpoint_types.In.with_qid_tag (Conn.tags t.conn) msg in
+            f ~tags "<- %a" (Capnp_core.Endpoint_types.In.pp_recv pp_msg) msg);
+        Conn.handle_msg t.conn msg;
+        begin match msg with
+          | `Abort _ -> Lwt.return `Aborted
+          | _ -> loop ()
+        end
+      | `Unimplemented x as msg ->
+        Log.info (fun f ->
+            let tags = Capnp_core.Endpoint_types.Out.with_qid_tag (Conn.tags t.conn) x in
+            f ~tags "<- Unimplemented(%a)" (Capnp_core.Endpoint_types.Out.pp_recv pp_msg) x);
+        Conn.handle_msg t.conn msg;
+        loop ()
+      | `Not_implemented ->
+        Log.info (fun f -> f "<- unsupported message type");
+        return_not_implemented t msg;
+        loop ()
   in
   loop ()
 
@@ -101,23 +105,29 @@ let connect ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
     conn;
     endpoint;
     xmit_queue;
+    switch;
   } in
   Lwt.async (fun () ->
       Lwt.catch
         (fun () ->
-           listen t >|= fun `Closed -> ()
+           listen t >|= fun (`Closed | `Aborted) -> ()
         )
         (fun ex ->
            Log.warn (fun f ->
                f ~tags "Uncaught exception handling CapTP connection: %a (dropping connection)" Fmt.exn ex
              );
+           queue_send @@ `Abort (Capnp_rpc.Exception.v ~ty:`Failed (Printexc.to_string ex));
            Lwt.return_unit
         )
       >>= fun () ->
       Log.info (fun f -> f ~tags "Connection closed");
       Lwt_switch.turn_off switch
-      (* todo: notify users *)
     );
   t
+
+let disconnect t ex =
+  let tags = Conn.tags t.conn in
+  queue_send ~xmit_queue:t.xmit_queue t.endpoint (Serialise.message ~tags (`Abort ex));
+  Lwt_switch.turn_off t.switch
 
 let dump f t = Conn.dump f t.conn

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -15,5 +15,7 @@ val connect : ?offer:cap -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoin
 val bootstrap : t -> cap
 (** [bootstrap t] is the peer's public bootstrap object, if any. *)
 
+val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
+
 val dump : t Fmt.t
 (** [dump] dumps the state of the connection, for debugging. *)

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -183,6 +183,10 @@ module CapTP : sig
   val bootstrap : t -> 'a Capability.t
   (** [bootstrap t] is the peer's public bootstrap object, if any. *)
 
+  val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
+  (** [disconnect reason] closes the connection, sending [reason] to the peer to explain why.
+      Capabilities and questions at both ends will break, with [reason] as the problem. *)
+
   val dump : t Fmt.t
   (** [dump] dumps the state of the connection, for debugging. *)
 end

--- a/capnp-rpc-lwt/endpoint.mli
+++ b/capnp-rpc-lwt/endpoint.mli
@@ -9,7 +9,7 @@ val of_socket : switch:Lwt_switch.t -> Unix.file_descr -> t
 val send : t -> 'a Capnp.BytesMessage.Message.t -> unit Lwt.t
 (** [send t msg] transmits [msg] atomically. *)
 
-val recv : t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [`Closed]) result Lwt.t
+val recv : t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [> `Closed]) result Lwt.t
 (** [recv t] reads the next message from the remote peer.
     It returns [Error `Closed] if the connection to the peer is lost
     (this will also happen if the switch is turned off). *)

--- a/capnp-rpc-lwt/parse.ml
+++ b/capnp-rpc-lwt/parse.ml
@@ -159,7 +159,7 @@ module Make(T : Capnp_rpc.Message_types.TABLE_TYPES) = struct
     | Disembargo x     -> parse_disembargo x
     | Resolve x        -> parse_resolve x
     | Release x        -> parse_release x
-    | Abort _          -> failwith "Received Abort" (* TODO: handle this better *)
+    | Abort x          -> `Abort (parse_exn x)
     | Provide _
     | Accept _
     | Join _           -> `Not_implemented        (* TODO *)

--- a/capnp-rpc-lwt/serialise.ml
+++ b/capnp-rpc-lwt/serialise.ml
@@ -60,6 +60,10 @@ let write_exn b ex =
 let message ~tags : Endpoint_types.Out.t -> _ =
   let open Builder in
   function
+  | `Abort ex ->
+    let b = Message.init_root () in
+    write_exn (Message.abort_init b) ex;
+    Message.to_message b
   | `Bootstrap qid ->
     let b = Message.init_root () in
     let boot = Message.bootstrap_init b in

--- a/capnp-rpc/capTP.mli
+++ b/capnp-rpc/capTP.mli
@@ -20,7 +20,8 @@ module Make (EP : Message_types.ENDPOINT) : sig
       Messages MUST be fed to [handle_msg] in the order in which they arrive from the peer. *)
 
   val disconnect : t -> Exception.t -> unit
-  (** [disconnect t reason] breaks all references with [reason] and releases the bootstrap object. *)
+  (** [disconnect t reason] breaks all references with [reason] and releases the bootstrap object.
+      Does nothing if already disconnected. *)
 
   (** {2 Debugging and diagnostics} *)
 

--- a/capnp-rpc/message_types.ml
+++ b/capnp-rpc/message_types.ml
@@ -89,6 +89,7 @@ module Make (Network : S.NETWORK_TYPES) (T : TABLE_TYPES) = struct
                                     EmbargoId.pp id
 
   type t = [
+    | `Abort of Exception.t
     | `Bootstrap of QuestionId.t
     | `Call of QuestionId.t * message_target * Request.t * desc RO_array.t * send_results_to
     | `Finish of (QuestionId.t * bool)      (* bool is release-caps *)
@@ -109,6 +110,7 @@ module Make (Network : S.NETWORK_TYPES) (T : TABLE_TYPES) = struct
       Logs.Tag.add Debug.qid_tag (QuestionId.uint32 qid) tags
     | `Return (aid, _, _) ->
       Logs.Tag.add Debug.qid_tag (AnswerId.uint32 aid) tags
+    | `Abort _
     | `Disembargo_reply _
     | `Disembargo_request _
     | `Release _
@@ -122,6 +124,7 @@ module Make (Network : S.NETWORK_TYPES) (T : TABLE_TYPES) = struct
 
   (* Describe message from the point of view of the receiver. *)
   let pp_recv pp_msg : t Fmt.t = fun f -> function
+    | `Abort ex -> Fmt.pf f "Abort(%a)" Exception.pp ex
     | `Bootstrap _ -> Fmt.pf f "Bootstrap"
     | `Call (_, target, msg, caps, results_to) -> Fmt.pf f "Call %a.%a with %a%a"
                                         pp_desc target

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -106,6 +106,7 @@ module Msg = struct
     failwith "ref_leak_detected"
 
   let summary = function
+    | `Abort _ -> "abort"
     | `Bootstrap _ -> "bootstrap"
     | `Call (_, _, msg, _, _) -> Fmt.strf "call:%a:%d" OID.pp msg.Request.sender msg.Request.seq
     | `Return (_, `Results (msg, _), _) -> "return:" ^ msg

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -1,0 +1,108 @@
+open Astring
+
+open Lwt.Infix
+
+module Calc = Examples.Calc
+
+let pp_addr f = function
+  | `Unix path -> Fmt.pf f "unix:%s" path
+
+let serve addr =
+  let `Unix path = addr in
+  begin match Unix.lstat path with
+    | { Unix.st_kind = Unix.S_SOCK; _ } -> Unix.unlink path
+    | _ -> ()
+    | exception Unix.Unix_error(Unix.ENOENT, _, _) -> ()
+  end;
+  let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
+  Unix.bind socket (Unix.ADDR_UNIX path);
+  Unix.listen socket 5;
+  Fmt.pr "Waiting for connections on %a" pp_addr addr;
+  let lwt_socket = Lwt_unix.of_unix_file_descr socket in
+  let rec loop () =
+    Lwt_unix.accept lwt_socket >>= fun (client, _addr) ->
+    Logs.info (fun f -> f "New connection");
+    let switch = Lwt_switch.create () in
+    let ep = Capnp_rpc_lwt.Endpoint.of_socket ~switch (Lwt_unix.unix_file_descr client) in
+    let calc = Calc.service in
+    let _conn = Capnp_rpc_lwt.CapTP.connect ~switch ep ~offer:calc in
+    loop ()
+  in
+  Lwt_main.run (loop ())
+
+let connect (`Unix path) =
+  Logs.info (fun f -> f "Connecting to %S..." path);
+  let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
+  Unix.connect socket (Unix.ADDR_UNIX path);
+  let switch = Lwt_switch.create () in
+  let ep = Capnp_rpc_lwt.Endpoint.of_socket ~switch socket in
+  let conn = Capnp_rpc_lwt.CapTP.connect ~switch ep in
+  let calc = Capnp_rpc_lwt.CapTP.bootstrap conn in
+  Lwt_main.run begin
+    Logs.info (fun f -> f "Evaluating expression...");
+    let remote_add = Calc.Client.getOperator calc `Add in
+    let result = Calc.Client.evaluate calc Calc.(Call (remote_add, [Float 40.0; Float 2.0])) in
+    Calc.Client.read result >>= fun v ->
+    Fmt.pr "Result: %f@." v;
+    Capnp_rpc_lwt.CapTP.disconnect conn (Capnp_rpc.Exception.v ~ty:`Disconnected "Bye!")
+  end
+
+let pp_qid f = function
+  | None -> ()
+  | Some x ->
+    let s = Uint32.to_string x in
+    Fmt.(styled `Magenta (fun f x -> Fmt.pf f " (qid=%s)" x)) f s
+
+let reporter =
+  let report src level ~over k msgf =
+    let src = Logs.Src.name src in
+    msgf @@ fun ?header ?(tags=Logs.Tag.empty) fmt ->
+    let qid = Logs.Tag.find Capnp_rpc.Debug.qid_tag tags in
+    let print _ =
+      Fmt.(pf stdout) "%a@." pp_qid qid;
+      over ();
+      k ()
+    in
+    Fmt.kpf print Fmt.stdout ("%a %a: @[" ^^ fmt ^^ "@]")
+      Fmt.(styled `Magenta string) (Printf.sprintf "%11s" src)
+      Logs_fmt.pp_header (level, header)
+  in
+  { Logs.report = report }
+
+open Cmdliner
+
+let addr_of_string s =
+  match String.cut ~sep:":" s with
+  | None -> Error (`Msg "Missing ':'")
+  | Some ("unix", path) -> Ok (`Unix path)
+  | Some _ -> Error (`Msg "Only unix:PATH addresses are currently supported")
+
+let addr_conv =
+  Arg.conv (addr_of_string, pp_addr)
+
+let addr_t =
+  let i = Arg.info [] ~docv:"ADDR" ~doc:"e.g. unix:/path/socket or tcp:host:port" in
+  Arg.(required @@ pos 0 (some addr_conv) None i)
+
+let serve_cmd =
+  Term.(const serve $ addr_t),
+  let doc = "provide a Cap'n Proto calculator service" in
+  Term.info "serve" ~doc
+
+let connect_cmd =
+  Term.(const connect $ addr_t),
+  let doc = "connect to a Cap'n Proto calculator service" in
+  Term.info "connect" ~doc
+
+let default_cmd =
+  let doc = "a calculator example" in
+  Term.(ret (const (`Help (`Pager, None)))),
+  Term.info "calc" ~version:"v0.1" ~doc
+
+let cmds = [serve_cmd; connect_cmd]
+
+let () =
+  Fmt_tty.setup_std_outputs ();
+  Logs.set_reporter reporter;
+  Logs.set_level ~all:true (Some Logs.Info);
+  Term.(exit @@ eval_choice default_cmd cmds)

--- a/test-bin/jbuild
+++ b/test-bin/jbuild
@@ -1,0 +1,7 @@
+(jbuild_version 1)
+
+(executable (
+  (name calc)
+  (libraries (examples cmdliner astring logs.fmt fmt.tty))
+))
+

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -7,6 +7,7 @@ module Stats = Capnp_rpc.Stats
 let stats_t = Alcotest.of_pp Stats.pp
 
 let summary_of_msg = function
+  | `Abort _ -> "abort"
   | `Bootstrap _ -> "bootstrap"
   | `Call (_, _, msg, _, _) -> "call:" ^ msg
   | `Return (_, `Results (msg, _), _) -> "return:" ^ msg

--- a/test/testbed/connection.mli
+++ b/test/testbed/connection.mli
@@ -2,6 +2,7 @@ open Capnp_direct.Core_types
 
 val summary_of_msg :
   [< `Bootstrap of _
+  | `Abort of _
   | `Call of _ * _ * string * _ * _
   | `Disembargo_reply of _
   | `Disembargo_request of _


### PR DESCRIPTION
- Disconnect a CapTP connections with exn type Disconnected (fixes #57).
- Add support for Abort messages (fixes #58).
- Add calculator example binary, showing how to run across multiple Unix processes.