### PR TITLE
Fix cycle detector and improve fuzzing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all fuzz clean test
 
-default: test #build-fuzz
+default: test build-fuzz
 
 all:
 	jbuilder build --dev @install test/test.bc test-lwt/test.bc test-bin/calc.exe

--- a/capnp-rpc.opam
+++ b/capnp-rpc.opam
@@ -17,5 +17,6 @@ depends: [
   "asetmap"
   "jbuilder" {build & >= "1.0+beta10" }
   "alcotest" {test}
+  "afl-persistent" {test}
 ]
 available: [ocaml-version >= "4.02.0"]

--- a/capnp-rpc/capTP.ml
+++ b/capnp-rpc/capTP.ml
@@ -1157,6 +1157,7 @@ module Make (EP : Message_types.ENDPOINT) = struct
             method resolve = resolver#resolve
 
             method set_blocker = resolver#set_blocker
+            method clear_blocker = resolver#clear_blocker
 
             method sealed_dispatch : type a. a S.brand -> a option = function
               | CapTP_results -> Some (t, answer)

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -33,7 +33,8 @@ module Make(Wire : S.WIRE) = struct
   and struct_resolver = object
     method pp : Format.formatter -> unit
     method resolve : struct_ref -> unit
-    method set_blocker : base_ref option -> unit
+    method set_blocker : base_ref -> (unit, [> `Cycle]) result
+    method clear_blocker : unit
     method sealed_dispatch : 'a. 'a S.brand -> 'a option
   end
 

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -149,11 +149,15 @@ module type CORE_TYPES = sig
     method sealed_dispatch : 'a. 'a brand -> 'a option
     (** [r#sealed_dispatch brand] extracts some private data of the given type. *)
 
-    method set_blocker : base_ref option -> unit
+    method set_blocker : base_ref -> (unit, [> `Cycle]) result
     (** [r#set_blocker b] means that [resolve] won't be called until [b] is resolved.
         [r]'s promise should report this as its blocker. This is needed to detect cycles.
         When the blocker is resolved, call this again with [None] to clear it (the promise
         will then report itself as the blocker again, until resolved). *)
+
+    method clear_blocker : unit
+    (** [r#clear_blocker] removes the blocker set by [set_blocker].
+        [r] is then blocked by itself, if unresolved. *)
   end
   (** A [struct_resolver] can be used to resolve some promise. *)
 

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -203,8 +203,15 @@ module Make (C : S.CORE_TYPES) = struct
           )
         ~forwarding:(fun x -> x#blocker)
 
-    method set_blocker b =
-      blocker <- b
+    method set_blocker (b : C.base_ref) =
+      if b#blocker = Some (self :> C.base_ref) then Error `Cycle
+      else (
+        blocker <- Some b;
+        Ok ()
+      )
+
+    method clear_blocker =
+      blocker <- None
 
     method cap path =
       dispatch state

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -199,7 +199,7 @@ module Make (C : S.CORE_TYPES) = struct
         ~unresolved:(fun _ ->
             match blocker with
             | None -> Some (self :> base_ref)
-            | Some _ as x -> x
+            | Some x -> x#blocker
           )
         ~forwarding:(fun x -> x#blocker)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -790,6 +790,20 @@ let test_cycle_4 () =
   Logs.info (fun f -> f "echo = %t" echo#pp);
   Alcotest.(check bool) "Echo released" true echo#released
 
+(* A field depends on the struct. *)
+let test_cycle_5 () =
+  let a, ar = Local_struct_promise.make () in
+  let b, br = Local_struct_promise.make () in
+  let c, cr = Local_struct_promise.make () in
+  br#set_blocker (Some (c :> Core_types.base_ref));
+  cr#set_blocker (Some (a :> Core_types.base_ref));
+  let b0 = b#cap 0 in
+  let x = Core_types.return ("reply", RO_array.of_list [b0]) in
+  ar#resolve x;
+  Logs.info (fun f -> f "a = %t" a#pp);
+  ensure_is_cycle_error_cap (a#cap 0);
+  dec_ref a
+
 (* The server returns an answer containing a promise. Later, it resolves the promise
    to a resource at the client. The client must be able to invoke the service locally. *)
 let test_resolve () =
@@ -1187,6 +1201,7 @@ let tests = [
   "Cycle 2", `Quick, test_cycle_2;
   "Cycle 3", `Quick, test_cycle_3;
   "Cycle 4", `Quick, test_cycle_4;
+  "Cycle 5", `Quick, test_cycle_5;
   "Resolve", `Quick, test_resolve;
   "Resolve 2", `Quick, test_resolve_2;
   "Resolve 3", `Quick, test_resolve_3;

--- a/test/test.ml
+++ b/test/test.ml
@@ -795,14 +795,21 @@ let test_cycle_5 () =
   let a, ar = Local_struct_promise.make () in
   let b, br = Local_struct_promise.make () in
   let c, cr = Local_struct_promise.make () in
-  br#set_blocker (Some (c :> Core_types.base_ref));
-  cr#set_blocker (Some (a :> Core_types.base_ref));
+  Alcotest.(check (result unit reject)) "Not a cycle" (Ok ()) @@ br#set_blocker (c :> Core_types.base_ref);
+  Alcotest.(check (result unit reject)) "Not a cycle" (Ok ()) @@ cr#set_blocker (a :> Core_types.base_ref);
   let b0 = b#cap 0 in
   let x = Core_types.return ("reply", RO_array.of_list [b0]) in
   ar#resolve x;
   Logs.info (fun f -> f "a = %t" a#pp);
   ensure_is_cycle_error_cap (a#cap 0);
   dec_ref a
+
+(* A blocker depends on itself. *)
+let test_cycle_6 () =
+  let a, ar = Local_struct_promise.make () in
+  let a0 = a#cap 0 in
+  a0#call ar "loop" RO_array.empty;
+  Logs.info (fun f -> f "a0 = %t" a#pp)
 
 (* The server returns an answer containing a promise. Later, it resolves the promise
    to a resource at the client. The client must be able to invoke the service locally. *)
@@ -1202,6 +1209,7 @@ let tests = [
   "Cycle 3", `Quick, test_cycle_3;
   "Cycle 4", `Quick, test_cycle_4;
   "Cycle 5", `Quick, test_cycle_5;
+  "Cycle 6", `Quick, test_cycle_6;
   "Resolve", `Quick, test_resolve;
   "Resolve 2", `Quick, test_resolve_2;
   "Resolve 3", `Quick, test_resolve_3;


### PR DESCRIPTION
- Fix another cycle-detector bug
   Blockers can be nested.

- Output `dec_ref` and `call` in the correct order in fuzz output script.
  The generated unit-test code could try to release things later than in
  the actual fuzz case.

- Output code for failing expected call during fuzzing. Before, we stopped the script
  generation before writing this.

- Handle cancellations in fuzz tests. Don't complain about out-of-order
  delivery if the client cancelled the missing message.