### PR TITLE
Forward pipelined calls on answers to the returned destination

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
+.git
 _build
 .*sw?
+compiler

--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,5 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc test-bin/calc.bc
-	#./_build/default/test/test.bc test core -ev 11
+	#./_build/default/test/test.bc test core -ev 16
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/capnp-rpc/cap_proxy.mli
+++ b/capnp-rpc/cap_proxy.mli
@@ -2,16 +2,9 @@ module Make(C : S.CORE_TYPES) : sig
   class type resolver_cap = object
     inherit C.cap
     method resolve : C.cap -> unit
-  end
-
-  class type embargo_cap = object
-    inherit C.cap
-    method disembargo : unit
     method break : Exception.t -> unit
   end
 
   val local_promise : unit -> resolver_cap
   (** A [local_promise ()] is a promise that buffers calls until it is resolved. *)
-
-  val embargo : C.cap -> embargo_cap
 end

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -565,7 +565,7 @@ module Vat = struct
     in
     let free_answer (ans, _, answer_var) =
       code (fun f ->
-          Fmt.pf f "%a#resolve (Error (Capnp_rpc.Error.exn \"Free all\"));" pp_resolver answer_var
+          Fmt.pf f "Core_types.resolve_exn %a (Capnp_rpc.Exception.v \"Operation rejected\");" pp_resolver answer_var
         );
       Core_types.resolve_exn ans @@ Capnp_rpc.Exception.v "Operation rejected"
     in


### PR DESCRIPTION
Forward pipelined calls on answers to the returned destination, even if we now know a shorter route. The spec requires this to ensure that messages always arrive in order.

When we get a disembargo response, check what the new target is. If it is a resolved question or import, act as if the reference now pointed at the remote object and embargo again if necessary.

Fixes #59.

Note: It currently only does this for questions. We'll probably need something similar for imports.