### PR TITLE
Move Unix FD support to unix module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM ocaml/opam@sha256:a469435632d0cacbceab799d7e48201b727d025fa1805cbbe210d94233b251ad
+FROM ocaml/opam@sha256:374934a4a512f1adf96f0a2858ef68d27719af96b7d0c28e5206f207edd98b6d
 #FROM ocaml/opam:debian-9_ocaml-4.04.0
-RUN cd opam-repository && git fetch && git reset --hard f946b0ab58422e1f38b9bd3069a6c874d9df0129 && opam update
+RUN cd opam-repository && git fetch && git reset --hard 109564a1fa93e39ef9a41582104718153a6e3abe && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
 RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces2" && \
     opam pin add -ny capnp-rpc . && \
     opam pin add -ny capnp-rpc-lwt . && \
-    opam depext capnp-rpc-lwt
-RUN opam install capnp-rpc-lwt alcotest afl-persistent
+    opam pin add -ny capnp-rpc-unix . && \
+    opam depext capnp-rpc-unix
+RUN opam install capnp-rpc-unix alcotest afl-persistent
 ADD . /home/opam/capnp-rpc
 RUN sudo chown -R opam /home/opam/capnp-rpc
-RUN opam config exec -- make test build-fuzz
+RUN opam config exec -- make all test

--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -17,7 +17,7 @@ depends: [
   "fmt"
   "logs"
   "asetmap"
-  "mirage-flow-unix"
+  "mirage-flow-lwt"
   "jbuilder" {build & >= "1.0+beta10" }
   "alcotest" {test}
 ]

--- a/capnp-rpc-lwt/endpoint.mli
+++ b/capnp-rpc-lwt/endpoint.mli
@@ -2,12 +2,8 @@
 
 type t
 
-val of_socket : switch:Lwt_switch.t -> Unix.file_descr -> t
-(** [of_socket ~switch fd] sends and receives on [fd].
-    When [switch] is turned off, [fd] is closed. *)
-
-val send : t -> 'a Capnp.BytesMessage.Message.t -> unit Lwt.t
-(** [send t msg] transmits [msg] atomically. *)
+val send : t -> 'a Capnp.BytesMessage.Message.t -> (unit, [`Closed | `Msg of string]) result Lwt.t
+(** [send t msg] transmits [msg]. *)
 
 val recv : t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [> `Closed]) result Lwt.t
 (** [recv t] reads the next message from the remote peer.
@@ -16,4 +12,6 @@ val recv : t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [> `Closed]) res
 
 val of_flow : switch:Lwt_switch.t -> (module Mirage_flow_lwt.S with type flow = 'flow) -> 'flow -> t
 (** [of_flow ~switch (module F) flow] sends and receives on [flow].
-    When [switch] is turned off, [flow] is closed. *)
+    The caller should arrange for [flow] to be closed when the switch is turned off. *)
+
+val pp_error : [< `Closed | `Msg of string] Fmt.t

--- a/capnp-rpc-lwt/jbuild
+++ b/capnp-rpc-lwt/jbuild
@@ -5,7 +5,7 @@
   (public_name capnp-rpc-lwt)
   (ocamlc_flags (:standard -w -55-53))
   (ocamlopt_flags (:standard -w -55-53))
-  (libraries (lwt.unix astring capnp capnp-rpc fmt logs mirage-flow-lwt mirage-flow-unix))
+  (libraries (astring capnp capnp-rpc fmt logs mirage-flow-lwt))
 ))
 
 (rule

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -11,6 +11,8 @@ build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
   "capnp-rpc-lwt"
+  "mirage-flow-unix"
+  "cstruct-lwt"
   "astring"
   "fmt"
   "logs"

--- a/examples/jbuild
+++ b/examples/jbuild
@@ -3,7 +3,7 @@
 (library (
   (name examples)
   (libraries (astring capnp-rpc-lwt))
-  (ocamlc_flags (:standard -w -53))
+  (flags (:standard -w -53-55))
 ))
 
 (rule

--- a/test-lwt/jbuild
+++ b/test-lwt/jbuild
@@ -2,7 +2,7 @@
 
 (executable (
   (name test)
-  (libraries (capnp-rpc-lwt alcotest examples logs.fmt testbed))
+  (libraries (capnp-rpc-lwt capnp-rpc-unix alcotest examples logs.fmt testbed))
 ))
 
 (alias

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -26,12 +26,14 @@ end
    Return the client proxy to it.
    Everything gets shut down when the switch is turned off. *)
 let run_server ~switch ~service () =
-  let server_socket, client_socket = Unix.(socketpair PF_UNIX SOCK_STREAM 0) in
+  let server_socket, client_socket = Lwt_unix.(socketpair PF_UNIX SOCK_STREAM 0) in
   let server =
-    CapTP.connect ~tags:Test_utils.server_tags ~switch ~offer:service (Endpoint.of_socket ~switch server_socket)
+    Capnp_rpc_unix.endpoint_of_socket ~switch server_socket
+    |> CapTP.connect ~tags:Test_utils.server_tags ~switch ~offer:service
   in
   let client =
-    CapTP.connect ~tags:Test_utils.client_tags ~switch (Endpoint.of_socket ~switch client_socket)
+    Capnp_rpc_unix.endpoint_of_socket ~switch client_socket
+    |> CapTP.connect ~tags:Test_utils.client_tags ~switch
   in
   Capability.dec_ref service;
   { client; server }

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -2,6 +2,95 @@ open Astring
 open Lwt.Infix
 open Capnp_rpc_lwt
 
+(* Slightly rude to set signal handlers in a library, but SIGPIPE makes no sense
+   in a modern application. *)
+let () = Sys.(set_signal sigpipe Signal_ignore)
+
+module Unix_flow = struct
+  type buffer = Cstruct.t
+  type flow = {
+    fd : Lwt_unix.file_descr;
+    mutable current_write : int Lwt.t option;
+    mutable current_read : int Lwt.t option;
+    mutable closed : bool;
+  }
+  type error = [`Closed | `Exception of exn]
+  type write_error = [`Closed | `Exception of exn]
+  type 'a io = 'a Lwt.t
+
+  let opt_cancel = function
+    | None -> ()
+    | Some x -> Lwt.cancel x
+
+  let close t =
+    assert (not t.closed);
+    t.closed <- true;
+    opt_cancel t.current_read;
+    opt_cancel t.current_write;
+    Lwt_unix.close t.fd
+
+  let pp_error f = function
+    | `Exception ex -> Fmt.exn f ex
+    | `Closed -> Fmt.string f "Closed"
+
+  let pp_write_error = pp_error
+
+  let write t buf =
+    let rec aux buf =
+      if t.closed then Lwt.return (Error `Closed)
+      else (
+        assert (t.current_write = None);
+        let write_thread = Lwt_cstruct.write t.fd buf in
+        t.current_write <- Some write_thread;
+        write_thread >>= fun wrote ->
+        t.current_write <- None;
+        if wrote = Cstruct.len buf then Lwt.return (Ok ())
+        else aux (Cstruct.shift buf wrote)
+      )
+    in
+    Lwt.catch
+      (fun () -> aux buf)
+      (fun ex -> Lwt.return @@ Error (`Exception ex))
+
+  let rec writev t = function
+    | [] -> Lwt.return (Ok ())
+    | x :: xs ->
+      write t x >>= function
+      | Ok () -> writev t xs
+      | Error _ as e -> Lwt.return e
+
+  let read t =
+    let len = 4096 in
+    let buf = Cstruct.create_unsafe len in
+    Lwt.try_bind
+      (fun () ->
+         assert (t.current_read = None);
+         if t.closed then raise Lwt.Canceled;
+         let read_thread = Lwt_cstruct.read t.fd buf in
+         t.current_read <- Some read_thread;
+         read_thread
+      )
+      (function
+        | 0 ->
+          Lwt.return @@ Ok `Eof
+        | got ->
+          t.current_read <- None;
+          Lwt.return @@ Ok (`Data (Cstruct.sub buf 0 got))
+      )
+      (function
+        | Lwt.Canceled -> Lwt.return @@ Error `Closed
+        | ex -> Lwt.return @@ Error (`Exception ex)
+      )
+
+  let connect ?switch fd =
+    let t = { fd; closed = false; current_read = None; current_write = None } in
+    Lwt_switch.add_hook switch (fun () -> close t);
+    t
+end
+
+let endpoint_of_socket ~switch socket =
+  Capnp_rpc_lwt.Endpoint.of_flow ~switch (module Unix_flow) (Unix_flow.connect ~switch socket)
+
 module Listen_address = struct
   type t = [
     | `Unix of string
@@ -40,7 +129,7 @@ let serve ?(backlog=5) ?offer addr =
     Lwt_unix.accept lwt_socket >>= fun (client, _addr) ->
     Logs.info (fun f -> f "New connection on %S" path);
     let switch = Lwt_switch.create () in
-    let ep = Capnp_rpc_lwt.Endpoint.of_socket ~switch (Lwt_unix.unix_file_descr client) in
+    let ep = endpoint_of_socket ~switch client in
     let _ : CapTP.t = Vat.connect vat ep in
     loop ()
   in
@@ -56,7 +145,7 @@ let connect ?switch ?offer (`Unix path) =
   let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
   Unix.connect socket (Unix.ADDR_UNIX path);
   let vat = Vat.create ~switch ?bootstrap:offer () in
-  let ep = Endpoint.of_socket ~switch socket in
+  let ep = endpoint_of_socket ~switch (Lwt_unix.of_unix_file_descr socket) in
   let conn = Vat.connect vat ep in
   CapTP.bootstrap conn
 

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -22,6 +22,10 @@ module Connect_address : sig
   val pp : t Fmt.t
 end
 
+val endpoint_of_socket : switch:Lwt_switch.t -> Lwt_unix.file_descr -> Capnp_rpc_lwt.Endpoint.t
+(** [endpoint_of_socket ~switch fd] is an endpoint that sends and receives on [fd].
+    When [switch] is turned off, [fd] is closed. *)
+
 val serve : ?backlog:int -> ?offer:'a Capability.t -> Listen_address.t -> 'b Lwt.t
 (** [serve ~offer address] listens for new connections on [address] and handles them.
     Clients can get access to the bootstrap object [offer].

--- a/unix/jbuild
+++ b/unix/jbuild
@@ -3,5 +3,5 @@
 (library (
   (name capnp_rpc_unix)
   (public_name capnp-rpc-unix)
-  (libraries (lwt.unix astring capnp-rpc-lwt capnp-rpc fmt logs mirage-flow-unix cmdliner))
+  (libraries (lwt.unix astring capnp-rpc-lwt capnp-rpc fmt logs mirage-flow-unix cmdliner cstruct-lwt))
 ))


### PR DESCRIPTION
Also, the code now works natively on flows, and wraps Unix sockets as flows (rather than the other way around).

Closes #5.