### PR TITLE
Remove the need for a separate Payload type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ocaml/opam@sha256:374934a4a512f1adf96f0a2858ef68d27719af96b7d0c28e5206f207e
 RUN cd opam-repository && git fetch && git reset --hard 109564a1fa93e39ef9a41582104718153a6e3abe && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
-RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces3" && \
+RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces4" && \
     opam pin add -ny capnp-rpc . && \
     opam pin add -ny capnp-rpc-lwt . && \
     opam pin add -ny capnp-rpc-unix . && \

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -1,17 +1,13 @@
 open Lwt.Infix
 open Capnp_core
 
+module Message = Capnp.Message.BytesMessage
+
 type 'a or_error = ('a, Capnp_rpc.Error.t) result
+type 'a reader_t = 'a Message.StructStorage.reader_t
 
 module Log = Capnp_rpc.Debug.Log
 module RO_array = Capnp_rpc.RO_array
-
-module Payload = struct
-  type 'a t = Schema.Reader.Payload.t
-
-  let release t =
-    Core_types.Attachments.release_caps (Msg.attachments_of_payload t)
-end
 
 module Capability = struct
   type 'a t = Core_types.cap
@@ -24,7 +20,7 @@ module Capability = struct
   let dec_ref = Core_types.dec_ref
   let pp f x = x#pp f
 
-  let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) req =
+  let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) (req : 'a Request.t) =
     Log.info (fun f -> f "Calling %a" Capnp.RPC.Registry.pp_method m);
     let (interface_id, method_id) = m in
     let msg = Request.finish ~interface_id ~method_id req in
@@ -32,7 +28,7 @@ module Capability = struct
     target#call resolver msg;
     results
 
-  let call_for_value cap m req : _ Payload.t or_error Lwt.t =
+  let call_and_wait cap (m : ('t, 'a, 'b) method_t) req : 'b or_error Lwt.t =
     let p, r = Lwt.task () in
     let result = call cap m req in
     let finish = lazy (Core_types.dec_ref result) in
@@ -41,9 +37,19 @@ module Capability = struct
         | Error _ as e -> Lwt.wakeup r e
         | Ok resp ->
           Lazy.force finish;
-          Lwt.wakeup r @@ Ok (Msg.Response.readable resp)
+          let payload = Msg.Response.readable resp in
+          let release_response_caps () = Core_types.Response_payload.release resp in
+          let contents = Schema.Reader.Payload.content_get payload |> Schema.Reader.of_pointer in
+          Lwt.wakeup r @@ Ok (contents, release_response_caps)
       );
     p
+
+  let call_for_value cap m req =
+    call_and_wait cap m req >|= function
+    | Error _ as response -> response
+    | Ok (response, release_response_caps) ->
+      release_response_caps ();
+      Ok response
 
   let call_for_value_exn cap m req =
     call_for_value cap m req >>= function
@@ -54,6 +60,13 @@ module Capability = struct
           Capnp.RPC.Registry.pp_method m
           Capnp_rpc.Error.pp e in
       Lwt.fail (Failure msg)
+
+  let call_for_unit cap m req =
+    call_for_value cap m req >|= function
+    | Ok _ -> Ok ()
+    | Error _ as e -> e
+
+  let call_for_unit_exn cap m req = call_for_value_exn cap m req >|= ignore
 
   let call_for_caps cap m req fn =
     let q = call cap m req in
@@ -80,8 +93,6 @@ module StructRef = struct
 end
 
 module Untyped = struct
-  type pointer_r = Capnp.Message.ro Capnp.BytesMessage.Slice.t option
-
   let struct_field t i =
     (* todo: would be better to have a separate type for this *)
     object (_ : Core_types.struct_ref)
@@ -97,17 +108,17 @@ module Untyped = struct
 
   let capability_field t f = t#cap [Xform.Field f]
 
-  let content_of_payload (t : 'a Payload.t) : pointer_r =
-    Schema.Reader.Payload.content_get t
-
   let local = Service.local
 
   let define_method ~interface_id ~method_id : ('t, 'a, 'b) Capability.method_t =
     (interface_id, method_id)
 
+  type 'a reader_t = 'a Message.StructStorage.reader_t
+
   type abstract_method_t = Service.abstract_method_t
 
-  let abstract_method x = x
+  let abstract_method x req release =
+    x (Message.StructStorage.cast_reader req) release
 
   let get_cap a i =
     Core_types.Attachments.cap (Uint32.to_int i) (Msg.unwrap_attachments a)
@@ -118,10 +129,12 @@ module Untyped = struct
   let clear_cap a i =
     Core_types.Attachments.clear_cap (Msg.unwrap_attachments a) (Uint32.to_int i)
 
-  let unknown_interface ~interface_id _req =
+  let unknown_interface ~interface_id _req release_params =
+    release_params ();
     Core_types.fail ~ty:`Unimplemented "Unknown interface %a" Uint64.printer interface_id
 
-  let unknown_method ~interface_id ~method_id _req =
+  let unknown_method ~interface_id ~method_id _req release_params =
+    release_params ();
     Core_types.fail ~ty:`Unimplemented "Unknown method %a.%d" Uint64.printer interface_id method_id
 
   class type generic_service = Service.generic

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -206,7 +206,12 @@ module Make(Wire : S.WIRE) = struct
       let old = Dyn_array.replace (rw_caps t) i null in
       dec_ref old
 
-    let release_caps = iter dec_ref
+    let released = broken_cap (Exception.v "Capabilities have already been released!")
+
+    let release_caps =
+      dispatch
+        ~ro:(fun caps -> RO_array.iter dec_ref caps; RO_array.release caps released)
+        ~rw:(fun caps -> Dyn_array.iter dec_ref caps; Dyn_array.reset caps)
 
     let builder () = RW_caps (Dyn_array.create 4 ~unused:null)
   end

--- a/capnp-rpc/rO_array.ml
+++ b/capnp-rpc/rO_array.ml
@@ -41,3 +41,8 @@ let equal eq a b =
     in
     loop l
   )
+
+let release t v =
+  for i = 0 to Array.length t - 1 do
+    t.(i) <- v;
+  done

--- a/capnp-rpc/rO_array.mli
+++ b/capnp-rpc/rO_array.mli
@@ -14,3 +14,7 @@ val find : ('a -> bool) -> 'a t -> 'a option
 val empty : 'a t
 val pp : 'a Fmt.t -> 'a t Fmt.t
 val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+
+val release : 'a t -> 'a -> unit
+(** [release t null] replaces every element in the array with [null].
+    This is useful to mark the array as finished. *)

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -79,6 +79,8 @@ module type PAYLOAD = sig
       embargoes may be needed, and to break cycles. *)
 
   val release : t -> unit
+  (** [release t] frees all the capabilities attached to this message.
+      It is safe to call this multiple times; only the first call has any effect. *)
 
   val pp : t Fmt.t
 end

--- a/examples/registry.ml
+++ b/examples/registry.ml
@@ -6,7 +6,8 @@ let version_service =
   object
     inherit Api.Builder.Version.service
 
-    method read_impl _ =
+    method read_impl _ release_params =
+      release_params ();
       let module R = Api.Builder.Version.Read_results in
       let resp, results = Service.Response.create R.init_pointer in
       R.version_set results "0.1";
@@ -26,17 +27,19 @@ let service () =
 
     method! pp f = Fmt.string f "registry"
 
-    method set_echo_service_impl params =
+    method set_echo_service_impl params release_params =
       let module P = Api.Reader.Registry.SetEchoService_params in
-      match P.service_get (P.of_payload params) with
+      let new_service = P.service_get params in
+      release_params ();
+      match new_service with
       | None -> assert false
       | Some new_service ->
         Capability.dec_ref echo_service;
         echo_service <- new_service;
-        Payload.release params;
         Service.return_empty ()
 
-    method echo_service_impl _params =
+    method echo_service_impl _params release_params =
+      release_params ();
       let module R = Api.Builder.Registry.EchoService_results in
       let resp, results = Service.Response.create R.init_pointer in
       R.service_set results (Some echo_service);
@@ -44,7 +47,8 @@ let service () =
         fst blocked >|= fun () -> Ok resp
       )
 
-    method echo_service_promise_impl _params =
+    method echo_service_promise_impl _params release_params =
+      release_params ();
       let module R = Api.Builder.Registry.EchoServicePromise_results in
       let resp, results = Service.Response.create R.init_pointer in
       let promise, resolver = Capability.promise () in
@@ -57,12 +61,14 @@ let service () =
         );
       Service.return resp
 
-    method unblock_impl _ =
+    method unblock_impl _ release_params =
+      release_params ();
       Lwt.wakeup (snd blocked) ();
       blocked <- Lwt.wait ();
       Service.return_empty ()
 
-    method complex_impl _ =
+    method complex_impl _ release_params =
+      release_params ();
       (* Returns:
          foo (f1):
            b (b2) = {}
@@ -87,7 +93,7 @@ module Client = struct
     let module P = Api.Builder.Registry.SetEchoService_params in
     let req, p = Capability.Request.create P.init_pointer in
     P.service_set p (Some echo_service);
-    Capability.call_for_value t Api.Reader.Registry.set_echo_service_method req >|= ignore
+    Capability.call_for_unit_exn t Api.Reader.Registry.set_echo_service_method req
 
   (* Waits until unblocked before returning *)
   let echo_service t =
@@ -103,7 +109,7 @@ module Client = struct
 
   let unblock t =
     let req = Capability.Request.create_no_args () in
-    Capability.call_for_value t Api.Reader.Registry.unblock_method req >|= ignore
+    Capability.call_for_unit_exn t Api.Reader.Registry.unblock_method req
 
   let complex t =
     let req = Capability.Request.create_no_args () in
@@ -120,6 +126,5 @@ module Version = struct
   let read t =
     let req = Capability.Request.create_no_args () in
     let module R = Api.Reader.Version.Read_results in
-    Capability.call_for_value_exn t Api.Reader.Version.read_method req >|= fun p ->
-    R.version_get (R.of_payload p)
+    Capability.call_for_value_exn t Api.Reader.Version.read_method req >|= R.version_get
 end


### PR DESCRIPTION
Instead, pass the payload contents directly.

Also, make it easier to release payload capabilities:

- Pass a `release_payload_caps` argument to method implementations.
  The OCaml compiler will warn if you forget to use this.

- Make `call_for_value` release any capabilities automatically.

- Add `call_and_wait` to wait for the response and return the results with the capabilities, including a function to free them.

Also, add `call_for_unit` to simplify the common case of methods that aren't expected to return anything.

Note: requires pinning the capnp-ocaml `interfaces4` branch.