### PR TITLE
Update to new API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ocaml/opam@sha256:374934a4a512f1adf96f0a2858ef68d27719af96b7d0c28e5206f207e
 RUN cd opam-repository && git fetch && git reset --hard 109564a1fa93e39ef9a41582104718153a6e3abe && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
-RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces4" && \
+RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces5" && \
     opam pin add -ny capnp-rpc . && \
     opam pin add -ny capnp-rpc-lwt . && \
     opam pin add -ny capnp-rpc-unix . && \

--- a/capnp-rpc-lwt/msg.ml
+++ b/capnp-rpc-lwt/msg.ml
@@ -13,8 +13,8 @@ module Path = struct
   let root = []
 end
 
-type request = [`Call_9469473312751832276]
-type response = [`Return_11392333052105676602]
+type request = [`Call_836a53ce789d4cd4]
+type response = [`Return_9e19b28d3db3573a]
 type 'a msg =
   | Builder of 'a StructStorage.builder_t
   | Readonly of 'a StructStorage.reader_t

--- a/capnp-rpc-lwt/request.ml
+++ b/capnp-rpc-lwt/request.ml
@@ -16,12 +16,12 @@ let create_no_args () =
   ignore (Message.call_init msg);
   msg
 
-let finish ~interface_id ~method_id t =
+let finish m t =
   match Message.get t with
   | Message.Call c ->
     let msg = Msg.Request.of_builder c in
-    Call.interface_id_set c interface_id;
-    Call.method_id_set_exn c method_id;
+    Call.interface_id_set c @@ Capnp.RPC.MethodID.interface_id m;
+    Call.method_id_set_exn c @@ Capnp.RPC.MethodID.method_id m;
     msg
   | _ -> assert false
 

--- a/capnp-rpc-lwt/request.mli
+++ b/capnp-rpc-lwt/request.mli
@@ -4,5 +4,5 @@ module RO_array = Capnp_rpc.RO_array
 
 val create : (Capnp.Message.rw Capnp.BytesMessage.Slice.t -> 'a) -> 'a t * 'a
 val create_no_args : unit -> 'a t
-val finish : interface_id:Uint64.t -> method_id:int -> 'a t -> Msg.Request.t
+val finish : (_, 'a, _) Capnp.RPC.MethodID.t -> 'a t -> Msg.Request.t
 val release : 'a t -> unit

--- a/examples/echo.ml
+++ b/examples/echo.ml
@@ -4,9 +4,9 @@ open Capnp_rpc_lwt
 (* This was supposed to be a simple ping service, but I wanted to test out-of-order
    replies, so it has become a bit messy... *)
 let service () =
-  Api.Builder.Echo.local @@
-  object
-    inherit Api.Builder.Echo.service
+  let module Echo = Api.Service.Echo in
+  Echo.local @@ object
+    inherit Echo.service
 
     val mutable blocked = Lwt.wait ()
     val mutable count = 0
@@ -16,14 +16,13 @@ let service () =
     method! pp f = Fmt.pf f "echo-service(%a)" Capnp_rpc.Debug.OID.pp id
 
     method ping_impl params release_params =
-      let module P = Api.Reader.Echo.Ping_params in
-      let module R = Api.Builder.Echo.Ping_results in
-      let msg = P.msg_get params in
+      let open Echo.Ping in
+      let msg = Params.msg_get params in
       release_params ();
-      let resp, results = Service.Response.create R.init_pointer in
-      R.reply_set results (Fmt.strf "got:%d:%s" count msg);
+      let resp, results = Service.Response.create Results.init_pointer in
+      Results.reply_set results (Fmt.strf "got:%d:%s" count msg);
       count <- count + 1;
-      if P.slow_get params then (
+      if Params.slow_get params then (
         Service.return_lwt (fun () ->
           fst blocked >|= fun () -> Ok resp
         )
@@ -38,17 +37,19 @@ let service () =
   end
 
 module Client = struct
-  type t = Api.Reader.Echo.t Capability.t
+  module Echo = Api.Client.Echo
+
+  type t = Echo.t Capability.t
 
   let ping t ?(slow=false) msg =
-    let module P = Api.Builder.Echo.Ping_params in
-    let module R = Api.Reader.Echo.Ping_results in
-    let req, p = Capability.Request.create P.init_pointer in
-    P.slow_set p slow;
-    P.msg_set p msg;
-    Capability.call_for_value_exn t Api.Reader.Echo.ping_method req >|= R.reply_get
+    let open Echo.Ping in
+    let req, p = Capability.Request.create Params.init_pointer in
+    Params.slow_set p slow;
+    Params.msg_set p msg;
+    Capability.call_for_value_exn t method_id req >|= Results.reply_get
 
   let unblock t =
+    let open Echo.Unblock in
     let req = Capability.Request.create_no_args () in
-    Capability.call_for_unit_exn t Api.Reader.Echo.unblock_method req
+    Capability.call_for_unit_exn t method_id req
 end

--- a/examples/registry.ml
+++ b/examples/registry.ml
@@ -2,23 +2,23 @@ open Lwt.Infix
 open Capnp_rpc_lwt
 
 let version_service =
-  Api.Builder.Version.local @@
-  object
-    inherit Api.Builder.Version.service
+  let module Version = Api.Service.Version in
+  Version.local @@ object
+    inherit Version.service
 
     method read_impl _ release_params =
+      let open Version.Read in
       release_params ();
-      let module R = Api.Builder.Version.Read_results in
-      let resp, results = Service.Response.create R.init_pointer in
-      R.version_set results "0.1";
+      let resp, results = Service.Response.create Results.init_pointer in
+      Results.version_set results "0.1";
       Service.return resp
   end
 
 (* A service that can return other services. *)
 let service () =
-  Api.Builder.Registry.local @@
-  object
-    inherit Api.Builder.Registry.service
+  let module Registry = Api.Service.Registry in
+  Registry.local @@ object
+    inherit Registry.service
 
     val mutable blocked = Lwt.wait ()
     val mutable echo_service = Echo.service ()
@@ -28,8 +28,8 @@ let service () =
     method! pp f = Fmt.string f "registry"
 
     method set_echo_service_impl params release_params =
-      let module P = Api.Reader.Registry.SetEchoService_params in
-      let new_service = P.service_get params in
+      let open Registry.SetEchoService in
+      let new_service = Params.service_get params in
       release_params ();
       match new_service with
       | None -> assert false
@@ -40,19 +40,19 @@ let service () =
 
     method echo_service_impl _params release_params =
       release_params ();
-      let module R = Api.Builder.Registry.EchoService_results in
-      let resp, results = Service.Response.create R.init_pointer in
-      R.service_set results (Some echo_service);
+      let open Registry.EchoService in
+      let resp, results = Service.Response.create Results.init_pointer in
+      Results.service_set results (Some echo_service);
       Service.return_lwt (fun () ->
         fst blocked >|= fun () -> Ok resp
       )
 
     method echo_service_promise_impl _params release_params =
       release_params ();
-      let module R = Api.Builder.Registry.EchoServicePromise_results in
-      let resp, results = Service.Response.create R.init_pointer in
+      let open Registry.EchoServicePromise in
+      let resp, results = Service.Response.create Results.init_pointer in
       let promise, resolver = Capability.promise () in
-      R.service_set results (Some promise);
+      Results.service_set results (Some promise);
       Capability.dec_ref promise;
       Lwt.async (fun () ->
           fst blocked >|= fun () ->
@@ -76,10 +76,10 @@ let service () =
          bar (b1):
            version = version_service
        *)
-      let module R = Api.Builder.Registry.Complex_results in
-      let resp, results = Service.Response.create R.init_pointer in
-      let f1 = R.foo_init results in
-      let b1 = R.bar_init results in
+      let open Registry.Complex in
+      let resp, results = Service.Response.create Results.init_pointer in
+      let f1 = Results.foo_init results in
+      let b1 = Results.bar_init results in
       let module Foo = Api.Builder.Foo in
       let module Bar = Api.Builder.Bar in
       let _b2 = Foo.b_init f1 in
@@ -89,42 +89,47 @@ let service () =
   end
 
 module Client = struct
+  module Registry = Api.Client.Registry
+
   let set_echo_service t echo_service =
-    let module P = Api.Builder.Registry.SetEchoService_params in
-    let req, p = Capability.Request.create P.init_pointer in
-    P.service_set p (Some echo_service);
-    Capability.call_for_unit_exn t Api.Reader.Registry.set_echo_service_method req
+    let open Registry.SetEchoService in
+    let req, p = Capability.Request.create Params.init_pointer in
+    Params.service_set p (Some echo_service);
+    Capability.call_for_unit_exn t method_id req
 
   (* Waits until unblocked before returning *)
   let echo_service t =
+    let open Registry.EchoService in
     let req = Capability.Request.create_no_args () in
-    let module R = Api.Reader.Registry.EchoService_results in
-    Capability.call_for_caps t Api.Reader.Registry.echo_service_method req R.service_get_pipelined
+    Capability.call_for_caps t method_id req Results.service_get_pipelined
 
   (* Returns a promise immediately. Resolves promise when unblocked. *)
   let echo_service_promise t =
+    let open Registry.EchoServicePromise in
     let req = Capability.Request.create_no_args () in
-    let module R = Api.Reader.Registry.EchoServicePromise_results in
-    Capability.call_for_caps t Api.Reader.Registry.echo_service_promise_method req R.service_get_pipelined
+    Capability.call_for_caps t method_id req Results.service_get_pipelined
 
   let unblock t =
+    let open Registry.Unblock in
     let req = Capability.Request.create_no_args () in
-    Capability.call_for_unit_exn t Api.Reader.Registry.unblock_method req
+    Capability.call_for_unit_exn t method_id req
 
   let complex t =
+    let open Registry.Complex in
     let req = Capability.Request.create_no_args () in
-    let module R = Api.Reader.Registry.Complex_results in
     let module Foo = Api.Reader.Foo in
     let module Bar = Api.Reader.Bar in
-    Capability.call_for_caps t Api.Reader.Registry.complex_method req @@ fun result ->
-    let echo_service = R.foo_get_pipelined result |> Foo.echo_get_pipelined in
-    let version = R.bar_get_pipelined result |> Bar.version_get_pipelined in
+    Capability.call_for_caps t method_id req @@ fun result ->
+    let echo_service = Results.foo_get_pipelined result |> Foo.echo_get_pipelined in
+    let version = Results.bar_get_pipelined result |> Bar.version_get_pipelined in
     (echo_service, version)
 end
 
 module Version = struct
+  module Version = Api.Client.Version
+
   let read t =
+    let open Version.Read in
     let req = Capability.Request.create_no_args () in
-    let module R = Api.Reader.Version.Read_results in
-    Capability.call_for_value_exn t Api.Reader.Version.read_method req >|= R.version_get
+    Capability.call_for_value_exn t method_id req >|= Results.version_get
 end


### PR DESCRIPTION
A client method needs a *builder* for the parameters and a *reader* for the results. This was awkward because both needed to be imported using a full path.

Now, there are generated `Client.Interface.Method.Params` and `.Results` aliases, so you can just open the client method module (which also contains the method ID).

A similar `Service` module is provided for services.

For example, instead of:
```ocaml
     method ping_impl params release_param_caps =
       let module P = Api.Reader.Echo.Ping_params in
       let module R = Api.Builder.Echo.Ping_results in
       let msg = P.msg_get params in
```

Use:

```ocaml
module Echo = Api.Service.Echo
...
     method ping_impl params release_param_caps =
       let open Echo.Ping in
       let msg = Params.msg_get params in
```