### PR TITLE
Extend MessageWrapper rather than including it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ocaml/opam@sha256:374934a4a512f1adf96f0a2858ef68d27719af96b7d0c28e5206f207e
 RUN cd opam-repository && git fetch && git reset --hard 109564a1fa93e39ef9a41582104718153a6e3abe && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
-RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces5" && \
+RUN opam pin add -ny capnp "https://github.com/talex5/capnp-ocaml.git#interfaces6" && \
     opam pin add -ny capnp-rpc . && \
     opam pin add -ny capnp-rpc-lwt . && \
     opam pin add -ny capnp-rpc-unix . && \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Some key features:
 
 This library should be used with the [capnp-ocaml][] schema compiler, which generates bindings from schema files.
 
-Currently, you need to pin the <https://github.com/talex5/capnp-ocaml/tree/interfaces5> branch, which adds support for compiling interface definitions.
+Currently, you need to pin the <https://github.com/talex5/capnp-ocaml/tree/interfaces6> branch, which adds support for compiling interface definitions.
 
 
 ### Status
@@ -51,7 +51,7 @@ To build, you will need a platform with the capnproto package available (e.g. De
 
     git clone https://github.com/mirage/capnp-rpc.git
     cd capnp-rpc
-    opam pin add -n capnp "https://github.com/talex5/capnp-ocaml.git#interfaces5"
+    opam pin add -n capnp "https://github.com/talex5/capnp-ocaml.git#interfaces6"
     opam pin add -nyk git capnp-rpc .
     opam pin add -nyk git capnp-rpc-lwt .
     opam depext capnp-rpc-lwt alcotest
@@ -194,7 +194,7 @@ The next step is to implement a client and server (in a new `echo.ml` file) usin
 For the server, you should inherit from the generated `Api.Builder.Echo.server` class:
 
 ```ocaml
-module Api = Echo_api.MakeRPC(Capnp.BytesMessage)(Capnp_rpc_lwt)
+module Api = Echo_api.MakeRPC(Capnp_rpc_lwt)
 
 open Lwt.Infix
 open Capnp_rpc_lwt
@@ -214,7 +214,7 @@ let service =
   end
 ```
 
-The first line (`module Api`) instantiates the generated code to use bytes-backed messages and this library's RPC implementation.
+The first line (`module Api`) instantiates the generated code to use this library's RPC implementation.
 
 `service` must provide one OCaml method for each method defined in the schema file, with `_impl` on the end of each one.
 

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -1,10 +1,10 @@
 open Lwt.Infix
 open Capnp_core
 
-module Message = Capnp.Message.BytesMessage
+include Capnp.Message.BytesMessage
 
 type 'a or_error = ('a, Capnp_rpc.Error.t) result
-type 'a reader_t = 'a Message.StructStorage.reader_t
+type 'a reader_t = 'a StructStorage.reader_t
 
 module Log = Capnp_rpc.Debug.Log
 module RO_array = Capnp_rpc.RO_array
@@ -109,12 +109,12 @@ module Untyped = struct
 
   let local = Service.local
 
-  type 'a reader_t = 'a Message.StructStorage.reader_t
+  type 'a reader_t = 'a StructStorage.reader_t
 
   type abstract_method_t = Service.abstract_method_t
 
   let abstract_method x req release =
-    x (Message.StructStorage.cast_reader req) release
+    x (StructStorage.cast_reader req) release
 
   let get_cap a i =
     Core_types.Attachments.cap (Uint32.to_int i) (Msg.unwrap_attachments a)

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -1,10 +1,10 @@
 open Capnp.RPC
 
-module Message = Capnp.Message.BytesMessage
+include (module type of Capnp.BytesMessage)
 
 type 'a or_error = ('a, Capnp_rpc.Error.t) result
 
-type 'a reader_t = 'a Message.StructStorage.reader_t
+type 'a reader_t = 'a StructStorage.reader_t
 
 module StructRef : sig
   type 'a t
@@ -32,7 +32,7 @@ module Capability : sig
     type 'a t
     (** An ['a t] is a builder for the out-going request's payload. *)
 
-    val create : (Capnp.Message.rw Message.Slice.t -> 'a) -> 'a t * 'a
+    val create : (Capnp.Message.rw Slice.t -> 'a) -> 'a t * 'a
     (** [create init] is a fresh request payload and contents builder.
         Use one of the generated [init_pointer] functions for [init]. *)
 
@@ -80,7 +80,7 @@ module Capability : sig
   val call_for_unit_exn : 't capability_t -> ('t, 'a, 'b reader_t) MethodID.t -> 'a Request.t -> unit Lwt.t
   (** Wrapper for [call_for_unit] that raises an exception on error. *)
 
-  val call_for_caps : 't capability_t -> ('t, 'a, 'b) MethodID.t -> 'a Request.t -> ('b StructRef.t -> 'c) -> 'c
+  val call_for_caps : 't capability_t -> ('t, 'a, 'b reader_t) MethodID.t -> 'a Request.t -> ('b StructRef.t -> 'c) -> 'c
   (** [call_for_caps] is a wrapper for [call] that passes the results to a
       callback and finishes them automatically when it returns.
       In the common case where you want a single cap "foo" from the result, use
@@ -118,7 +118,7 @@ module Service : sig
     type 'b t
     (** An ['a t] is a builder for the out-going response's payload. *)
 
-    val create : (Capnp.Message.rw Message.Slice.t -> 'a) -> 'a t * 'a
+    val create : (Capnp.Message.rw Slice.t -> 'a) -> 'a t * 'a
     (** [create init] is a fresh request payload and contents builder.
         Use one of the generated [init_pointer] functions for [init]. *)
 
@@ -152,7 +152,7 @@ module Untyped : sig
 
   type abstract_method_t
 
-  type 'a reader_t = 'a Message.StructStorage.reader_t
+  type 'a reader_t = 'a StructStorage.reader_t
 
   val abstract_method : ('a reader_t, 'b) Service.method_t -> abstract_method_t
 

--- a/capnp-rpc-lwt/msg.ml
+++ b/capnp-rpc-lwt/msg.ml
@@ -24,8 +24,9 @@ type 'a msg =
 
 let with_attachments a t =
   match t with
-  | Builder x -> Builder (B.with_attachments (RPC_attachments a) x)
-  | Readonly x -> Readonly (R.with_attachments (RPC_attachments a) x)
+  | Builder x -> Builder (StructStorage.with_attachments (RPC_attachments a) x)
+  | Readonly None -> Readonly None
+  | Readonly (Some x) -> Readonly (Some (StructStorage.with_attachments (RPC_attachments a) x))
 
 let unwrap_attachments = function
   | RPC_attachments x -> x
@@ -33,11 +34,9 @@ let unwrap_attachments = function
   | _ -> failwith "Unknown attachment type!"
 
 let attachments = function
-  | Builder ss -> unwrap_attachments @@ B.get_attachments ss
-  | Readonly ss -> unwrap_attachments @@ R.get_attachments ss
-
-let attachments_of_payload payload =
-  unwrap_attachments @@ R.get_attachments payload
+  | Readonly None -> Capnp_rpc.S.No_attachments
+  | Readonly (Some ss) -> unwrap_attachments @@ StructStorage.get_attachments ss
+  | Builder ss -> unwrap_attachments @@ StructStorage.get_attachments ss
 
 let wrap_attachments a = RPC_attachments a
 

--- a/capnp-rpc-lwt/msg.mli
+++ b/capnp-rpc-lwt/msg.mli
@@ -42,4 +42,3 @@ end
 
 val wrap_attachments : Capnp_rpc.S.attachments -> Capnp.MessageSig.attachments
 val unwrap_attachments : Capnp.MessageSig.attachments -> Capnp_rpc.S.attachments
-val attachments_of_payload : Schema.Reader.Payload.t -> Capnp_rpc.S.attachments

--- a/capnp-rpc-lwt/request.ml
+++ b/capnp-rpc-lwt/request.ml
@@ -1,11 +1,14 @@
 open Capnp_core
 open Schema.Builder
 module RO_array = Capnp_rpc.RO_array
+module StructStorage = Capnp.Message.BytesMessage.StructStorage
 
 type 'a t = Message.t
 
 let create init =
-  let msg = Message.init_root () |> with_attachments (Msg.wrap_attachments (Core_types.Attachments.builder ())) in
+  let msg =
+    Message.init_root ()
+    |> StructStorage.with_attachments (Msg.wrap_attachments (Core_types.Attachments.builder ())) in
   let call = Message.call_init msg in
   let p = Call.params_get call in
   let content = init (Payload.content_get p) in
@@ -26,4 +29,4 @@ let finish m t =
   | _ -> assert false
 
 let release t =
-  Core_types.Attachments.release_caps (Msg.unwrap_attachments (get_attachments t))
+  Core_types.Attachments.release_caps (Msg.unwrap_attachments (StructStorage.get_attachments t))

--- a/capnp-rpc-lwt/response.ml
+++ b/capnp-rpc-lwt/response.ml
@@ -1,13 +1,16 @@
 open Capnp_core
 open Schema.Builder
 module RO_array = Capnp_rpc.RO_array
+module StructStorage = Capnp.Message.BytesMessage.StructStorage
 
 type 'a cap = Core_types.cap
 
 type 'a t = Message.t
 
 let create init =
-  let msg = Message.init_root () |> with_attachments (Msg.wrap_attachments (Core_types.Attachments.builder ())) in
+  let msg =
+    Message.init_root ()
+    |> StructStorage.with_attachments (Msg.wrap_attachments (Core_types.Attachments.builder ())) in
   let ret = Message.return_init msg in
   let p = Return.results_init ret in
   let content = init (Payload.content_get p) in
@@ -24,4 +27,4 @@ let finish t =
   | _ -> assert false
 
 let release t =
-  Core_types.Attachments.release_caps (Msg.unwrap_attachments (get_attachments t))
+  Core_types.Attachments.release_caps (Msg.unwrap_attachments (StructStorage.get_attachments t))

--- a/capnp-rpc-lwt/schema.ml
+++ b/capnp-rpc-lwt/schema.ml
@@ -1,1 +1,2 @@
 include Rpc_schema.Make(Capnp.BytesMessage)
+module ReaderOps = Capnp.Runtime.ReaderInc.Make(Capnp.RPC.None(Capnp.BytesMessage))

--- a/capnp-rpc-lwt/service.ml
+++ b/capnp-rpc-lwt/service.ml
@@ -1,8 +1,6 @@
 open Capnp_core
 open Lwt.Infix
 
-module ReaderOps = Capnp.Runtime.ReaderInc.Make(Capnp.BytesMessage)
-
 module Log = Capnp_rpc.Debug.Log
 
 module Response = Response
@@ -44,7 +42,7 @@ let local (s:#generic) =
       let m : abstract_method_t = s#dispatch ~interface_id ~method_id in
       let release_params () = Core_types.Request_payload.release msg in
       let contents : abstract Schema.reader_t =
-        Payload.content_get p |> ReaderOps.deref_opt_struct_pointer |> ReaderOps.cast_struct in
+        Payload.content_get p |> Schema.ReaderOps.deref_opt_struct_pointer |> Schema.ReaderOps.cast_struct in
       match m contents release_params with
       | r -> results#resolve r
       | exception ex ->

--- a/capnp-rpc-lwt/xform.ml
+++ b/capnp-rpc-lwt/xform.ml
@@ -1,5 +1,3 @@
-module ReaderOps = Capnp.Runtime.ReaderInc.Make(Capnp.BytesMessage)
-
 type t =
   | Field of int
 
@@ -12,14 +10,13 @@ let to_cap_index = function
 
 (* [walk ss x xs] is the interface cap index at path [x :: xs] within struct storage [ss]. *)
 let rec walk ss x = function
-  | Field x2 :: xs -> walk (ReaderOps.get_struct ss x) x2 xs
-  | [] ->
-    ReaderOps.get_interface (fun _ i -> Uint32.to_int i) ss x
+  | Field x2 :: xs -> walk (Schema.ReaderOps.get_struct ss x) x2 xs
+  | [] -> Schema.ReaderOps.get_interface ss x |> to_cap_index
 
 let resolve payload path =
   let open Schema.Reader in
   match path with
   | [] -> Payload.content_get_interface payload |> to_cap_index    (* Bootstrap only *)
   | Field x :: xs ->
-    let ss = Payload.content_get payload |> ReaderOps.deref_opt_struct_pointer in
+    let ss = Payload.content_get payload |> Schema.ReaderOps.deref_opt_struct_pointer in
     walk ss x xs

--- a/examples/api.ml
+++ b/examples/api.ml
@@ -1,1 +1,1 @@
-include Test_api.MakeRPC(Capnp.BytesMessage)(Capnp_rpc_lwt)
+include Test_api.MakeRPC(Capnp_rpc_lwt)

--- a/examples/calc.ml
+++ b/examples/calc.ml
@@ -3,7 +3,7 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
-module Api = Calculator.MakeRPC(Capnp.BytesMessage)(Capnp_rpc_lwt)
+module Api = Calculator.MakeRPC(Capnp_rpc_lwt)
 
 type expr =
   | Float of float


### PR DESCRIPTION
The `MakeRPC` function now only takes a single argument. This avoids an OCaml inliner bug.

Also, ReaderOps now gets `get_cap` from the MessageWrapper.