### PR TITLE
Add mli files for examples and simplify APIs

### DIFF
--- a/examples/calc.ml
+++ b/examples/calc.ml
@@ -7,19 +7,44 @@ type calc = [`Calculator_97983392df35cc36]
 type value = [`Value_c3e69d34d3ee48d2]
 type fn = [`Function_ede83a3d96840394]
 
-type expr =
-  | Float of float
-  | Prev of Api.Reader.Calculator.Value.t Capability.t
-  | Param of int
-  | Call of Api.Reader.Calculator.Function.t Capability.t * expr list
-
 let or_fail msg = function
   | Some x -> x
   | None -> failwith msg
 
+module Expr = struct
+  type t =
+    | Float of float
+    | Prev of Api.Reader.Calculator.Value.t Capability.t
+    | Param of int
+    | Call of Api.Reader.Calculator.Function.t Capability.t * t list
+
+  let rec parse r =
+    let open Api.Reader.Calculator in
+    match Expression.get r with
+    | Expression.Literal f -> Float f
+    | Expression.PreviousResult None -> failwith "PreviousResult but no cap!"
+    | Expression.PreviousResult (Some v) -> Prev v
+    | Expression.Parameter p -> Param (Uint32.to_int p)
+    | Expression.Call c ->
+      let fn_obj = Expression.Call.function_get c |> or_fail "Missing fn" in
+      let params = Expression.Call.params_get_list c |> List.map parse in
+      Call (fn_obj, params)
+    | Expression.Undefined _ ->
+      failwith "Unknown expression type"
+
+  let rec release = function
+    | Float _ -> ()
+    | Prev v -> Capability.dec_ref v
+    | Param _ -> ()
+    | Call (f, params) ->
+      Capability.dec_ref f;
+      List.iter release params
+end
+
 (* Write an expression into a message, exporting function capabilities. *)
 let rec write_expr b expr =
   let open Api.Builder.Calculator in
+  let open Expr in
   match expr with
   | Float f -> Expression.literal_set b f
   | Prev v -> Expression.previous_result_set b (Some v)
@@ -32,72 +57,64 @@ let rec write_expr b expr =
         write_expr (Capnp.Array.get args_b i) arg
       )
 
-(* A more user-friendly API for the Calculator interface *)
-module Client = struct
-  module C = Api.Client.Calculator
+module C = Api.Client.Calculator
 
-  type t = calc Capability.t
+type t = calc Capability.t
 
-  let evaluate t expr =
-    let open C.Evaluate in
-    let req, p = Capability.Request.create Params.init_pointer in
-    write_expr (Params.expression_init p) expr;
-    Capability.call_for_caps t method_id req Results.value_get_pipelined
+let evaluate t expr =
+  let open C.Evaluate in
+  let req, p = Capability.Request.create Params.init_pointer in
+  write_expr (Params.expression_init p) expr;
+  Capability.call_for_caps t method_id req Results.value_get_pipelined
 
-  let getOperator t op =
-    let open C.GetOperator in
-    let module O = Api.Builder.Calculator.Operator in
-    let req, p = Capability.Request.create Params.init_pointer in
-    Params.op_set p (match op with
-        | `Add -> O.Add
-        | `Subtract -> O.Subtract
-        | `Multiply -> O.Multiply
-        | `Divide -> O.Divide
-      );
-    Capability.call_for_caps t method_id req Results.func_get_pipelined
+let getOperator t op =
+  let open C.GetOperator in
+  let module O = Api.Builder.Calculator.Operator in
+  let req, p = Capability.Request.create Params.init_pointer in
+  Params.op_set p (match op with
+      | `Add -> O.Add
+      | `Subtract -> O.Subtract
+      | `Multiply -> O.Multiply
+      | `Divide -> O.Divide
+    );
+  Capability.call_for_caps t method_id req Results.func_get_pipelined
 
-  module Value = struct
-    type t = value Capability.t
+module Value = struct
+  type t = value Capability.t
 
-    let read v =
-      let open Api.Client.Calculator.Value.Read in
-      let req = Capability.Request.create_no_args () in
-      Capability.call_for_value_exn v method_id req >|= Results.value_get
+  let read v =
+    let open Api.Client.Calculator.Value.Read in
+    let req = Capability.Request.create_no_args () in
+    Capability.call_for_value_exn v method_id req >|= Results.value_get
 
-    let final_read v =
-      read v >|= fun result ->
-      Capability.dec_ref v;
-      result
-  end
+  let final_read v =
+    read v >|= fun result ->
+    Capability.dec_ref v;
+    result
 
-  module Fn = struct
-    type t = fn Capability.t
+  let local f =
+    let module Value = Api.Service.Calculator.Value in
+    Value.local @@ object
+      inherit Value.service
 
-    let call fn args =
-      let open Api.Client.Calculator.Function.Call in
-      let req, p = Capability.Request.create Params.init_pointer in
-      ignore (Params.params_set_list p args);
-      Capability.call_for_value_exn fn method_id req >|= Results.value_get
-  end
+      val id = Capnp_rpc.Debug.OID.next ()
+
+      method! pp fmt = Fmt.pf fmt "Literal(%a) = %f" Capnp_rpc.Debug.OID.pp id f
+
+      method read_impl _ release_params =
+        let open Value.Read in
+        release_params ();
+        let resp, c = Service.Response.create Results.init_pointer in
+        Results.value_set c f;
+        Service.return resp
+    end
 end
 
-(* Export a literal float as a service with a [read] method. *)
-let literal f =
-  let module Value = Api.Service.Calculator.Value in
-  Value.local @@ object
-    inherit Value.service
-
-    val id = Capnp_rpc.Debug.OID.next ()
-
-    method! pp fmt = Fmt.pf fmt "Literal(%a) = %f" Capnp_rpc.Debug.OID.pp id f
-
-    method read_impl _ release_params =
-      let open Value.Read in
-      release_params ();
-      let resp, c = Service.Response.create Results.init_pointer in
-      Results.value_set c f;
-      Service.return resp
-  end
+let call_fn fn args =
+  let open Api.Client.Calculator.Function.Call in
+  let req, p = Capability.Request.create Params.init_pointer in
+  ignore (Params.params_set_list p args);
+  Capability.call_for_value_exn fn method_id req >|= Results.value_get
 
 let pp_result_lwt f x =
   match Lwt.state x with
@@ -106,16 +123,17 @@ let pp_result_lwt f x =
   | Lwt.Sleep -> Fmt.string f "(still calculating)"
 
 (* Evaluate an expression, where some sub-expressions may require remote calls. *)
-let rec eval ?(args=[||]) : _ -> Api.Reader.Calculator.Value.t Capability.t = function
-  | Float f -> literal f
+let rec eval ?(args=[||]) : _ -> Api.Reader.Calculator.Value.t Capability.t =
+  let open Expr in function
+  | Float f -> Value.local f
   | Prev v -> v
-  | Param p -> literal args.(p)
+  | Param p -> Value.local args.(p)
   | Call (f, params) ->
     let params = params |> Lwt_list.map_p (fun p ->
         let value = eval ~args p in
-        Client.Value.final_read value
+        Value.final_read value
       ) in
-    let result = params >>= Client.Fn.call f in
+    let result = params >>= call_fn f in
     let open Api.Service.Calculator in
     Value.local @@ object
       inherit Value.service
@@ -136,75 +154,57 @@ let rec eval ?(args=[||]) : _ -> Api.Reader.Calculator.Value.t Capability.t = fu
           )
     end
 
-let rec release_expr = function
-  | Float _ -> ()
-  | Prev v -> Capability.dec_ref v
-  | Param _ -> ()
-  | Call (f, params) ->
-    Capability.dec_ref f;
-    List.iter release_expr params
+module Fn = struct
+  type t = fn Capability.t
 
-(* A local service that provides the function [body]. *)
-let fn n_args body =
-  let module Function = Api.Service.Calculator.Function in
-  Function.local @@ object
-    inherit Function.service
+  let call = call_fn
 
-    method call_impl params release_params =
-      let open Function.Call in
-      let args = Params.params_get_array params in
-      assert (Array.length args = n_args);
-      let value = eval ~args body in
-      release_params ();
-      (* Functions return floats, not Value objects, so we have to wait here. *)
-      Service.return_lwt (fun () ->
-          Client.Value.final_read value >|= fun value ->
+  let local n_args body =
+    let module Function = Api.Service.Calculator.Function in
+    Function.local @@ object
+      inherit Function.service
+
+      method call_impl params release_params =
+        let open Function.Call in
+        let args = Params.params_get_array params in
+        assert (Array.length args = n_args);
+        let value = eval ~args body in
+        release_params ();
+        (* Functions return floats, not Value objects, so we have to wait here. *)
+        Service.return_lwt (fun () ->
+            Value.final_read value >|= fun value ->
+            let resp, r = Service.Response.create Results.init_pointer in
+            Results.value_set r value;
+            Ok resp
+          )
+    end
+
+  let local_binop op : Api.Builder.Calculator.Function.t Capability.t =
+    let module Function = Api.Service.Calculator.Function in
+    Function.local @@ object
+      inherit Function.service
+
+      method call_impl params release_params =
+        release_params ();
+        let open Function.Call in
+        match Params.params_get_array params with
+        | [| a; b |] ->
           let resp, r = Service.Response.create Results.init_pointer in
-          Results.value_set r value;
-          Ok resp
-        )
-  end
+          let ans = op a b in
+          Logs.info (fun f -> f "%f op %f -> %f" a b ans);
+          Results.value_set r ans;
+          Service.return resp
+        | _ -> failwith "Wrong number of args"
+    end
 
-(* A local service exporting function [op] (of two arguments). *)
-let binop op : Api.Builder.Calculator.Function.t Capability.t =
-  let module Function = Api.Service.Calculator.Function in
-  Function.local @@ object
-    inherit Function.service
-
-    method call_impl params release_params =
-      release_params ();
-      let open Function.Call in
-      match Params.params_get_array params with
-      | [| a; b |] ->
-        let resp, r = Service.Response.create Results.init_pointer in
-        let ans = op a b in
-        Logs.info (fun f -> f "%f op %f -> %f" a b ans);
-        Results.value_set r ans;
-        Service.return resp
-      | _ -> failwith "Wrong number of args"
-  end
-
-let add = binop ( +. ) 
-let sub = binop ( -. )
-let mul = binop ( *. )
-let div = binop ( /. )
-
-let rec parse_expr r =
-  let open Api.Reader.Calculator in
-  match Expression.get r with
-  | Expression.Literal f -> Float f
-  | Expression.PreviousResult None -> failwith "PreviousResult but no cap!"
-  | Expression.PreviousResult (Some v) -> Prev v
-  | Expression.Parameter p -> Param (Uint32.to_int p)
-  | Expression.Call c ->
-    let fn_obj = Expression.Call.function_get c |> or_fail "Missing fn" in
-    let params = Expression.Call.params_get_list c |> List.map parse_expr in
-    Call (fn_obj, params)
-  | Expression.Undefined _ ->
-    failwith "Unknown expression type"
+  let add = local_binop ( +. ) 
+  let sub = local_binop ( -. )
+  let mul = local_binop ( *. )
+  let div = local_binop ( /. )
+end
 
 (* The main calculator service *)
-let service =
+let local =
   let module Calculator = Api.Service.Calculator in
   Calculator.local @@ object
     inherit Calculator.service
@@ -212,9 +212,9 @@ let service =
     method def_function_impl params release_params =
       let open Calculator.DefFunction in
       let n_args = Params.param_count_get_int_exn params in
-      let body = Params.body_get params |> parse_expr in
-      let fn_obj = fn n_args body in
-      release_expr body;
+      let body = Params.body_get params |> Expr.parse in
+      let fn_obj = Fn.local n_args body in
+      Expr.release body;
       release_params ();
       let resp, results = Service.Response.create Results.init_pointer in
       Results.func_set results (Some fn_obj);
@@ -222,10 +222,10 @@ let service =
 
     method evaluate_impl params release_params =
       let open Calculator.Evaluate in
-      let expr = parse_expr (Params.expression_get params) in
+      let expr = Expr.parse (Params.expression_get params) in
       release_params ();
       let value_obj = eval expr in
-      release_expr expr;
+      Expr.release expr;
       let resp, results = Service.Response.create Results.init_pointer in
       Results.value_set results (Some value_obj);
       Capability.dec_ref value_obj;
@@ -237,10 +237,10 @@ let service =
       let module O = Api.Reader.Calculator.Operator in
       let op_obj =
         match Params.op_get params with
-        | O.Add -> add
-        | O.Subtract -> sub
-        | O.Multiply -> mul
-        | O.Divide -> div
+        | O.Add         -> Fn.add
+        | O.Subtract    -> Fn.sub
+        | O.Multiply    -> Fn.mul
+        | O.Divide      -> Fn.div
         | O.Undefined _ -> failwith "Unknown operator"
       in
       let resp, results = Service.Response.create Results.init_pointer in

--- a/examples/calc.mli
+++ b/examples/calc.mli
@@ -2,65 +2,61 @@
 
 open Capnp_rpc_lwt
 
-type calc = [`Calculator_97983392df35cc36]
-type value = [`Value_c3e69d34d3ee48d2]
-type fn = [`Function_ede83a3d96840394]
+type t = [`Calculator_97983392df35cc36] Capability.t
 
-type expr =
-  | Float of float              (** [Float v] evaluates to [v]. *)
-  | Prev of value Capability.t  (** [Prev v] evaluates to the value returned by service [v]. *)
-  | Param of int                (** [Param i] evaluates to parameter number [i] (starting from zero). *)
-  | Call of fn Capability.t * expr list (** [Call fn args] evaluates to [fn args]. *)
+module rec Value : sig
+  type t = [`Value_c3e69d34d3ee48d2] Capability.t
 
-module Client : sig
-  type t = calc Capability.t
+  val read : t -> float Lwt.t
+  (** [read t] reads the value of the remote value object. *)
 
-  module Value : sig
-    type t = value Capability.t
+  val final_read : t -> float Lwt.t
+  (** [final_read t] reads the value and dec_ref's [t]. *)
 
-    val read : t -> float Lwt.t
-    (** [read t] reads the value of the remote value object. *)
-
-    val final_read : t -> float Lwt.t
-    (** [final_read t] reads the value and dec_ref's [t]. *)
-  end
-
-  module Fn : sig
-    type t = fn Capability.t
-
-    val call : t -> float list -> float Lwt.t
-    (** [call fn args] does [fn args]. *)
-  end
-
-  val evaluate : t -> expr -> Value.t
-  (** [evaluate t expr] evaluates [expr] using calculator service [t] and
-      returns a capability to the result service. *)
-
-  val getOperator : t -> [`Add | `Subtract | `Multiply | `Divide] -> Fn.t
-  (** [getOperator t op] is a remote operator function provided by [t]. *)
+  val local : float -> t
+  (** [local v] is a capability to a local value service holding value [v]. *)
 end
 
-val literal : float -> Client.Value.t
-(** [literal v] is a capability to a local value service holding value [v]. *)
+and Fn : sig
+  type t = [`Function_ede83a3d96840394] Capability.t
 
-val fn : int -> expr -> Client.Fn.t
-(** [fn n_args body] is a capability to a local service that takes [n_args] arguments
-    and evaluates [body]. *)
+  val call : t -> float list -> float Lwt.t
+  (** [call fn args] does [fn args]. *)
 
-val binop : (float -> float -> float) -> Client.Fn.t
-(** [binop fn] is a capability to a local service providing function [op] (of two arguments). *)
+  val local : int -> Expr.t -> Fn.t
+  (** [local n_args body] is a capability to a local service that takes [n_args] arguments
+      and evaluates [body]. *)
 
-val add : Client.Fn.t
-(** [add] is [binop ( +. )] *)
+  val local_binop : (float -> float -> float) -> Fn.t
+  (** [local_binop fn] is a capability to a local service providing function [op] (of two arguments). *)
 
-val sub : Client.Fn.t
-(** [sub] is [binop ( -. )] *)
+  val add : t
+  (** [add] is [binop ( +. )] *)
 
-val mul : Client.Fn.t
-(** [mul] is [binop ( *. )] *)
+  val sub : t
+  (** [sub] is [binop ( -. )] *)
 
-val div : Client.Fn.t
-(** [div] is [binop ( /. )] *)
+  val mul : t
+  (** [mul] is [binop ( *. )] *)
 
-val service : Client.t
+  val div : t
+  (** [div] is [binop ( /. )] *)
+end
+
+and Expr : sig
+  type t =
+    | Float of float              (** [Float v] evaluates to [v]. *)
+    | Prev of Value.t             (** [Prev v] evaluates to the value returned by service [v]. *)
+    | Param of int                (** [Param i] evaluates to parameter number [i] (starting from zero). *)
+    | Call of Fn.t * Expr.t list  (** [Call fn args] evaluates to [fn args]. *)
+end
+
+val evaluate : t -> Expr.t -> Value.t
+(** [evaluate t expr] evaluates [expr] using calculator service [t] and
+    returns a capability to the result service. *)
+
+val getOperator : t -> [`Add | `Subtract | `Multiply | `Divide] -> Fn.t
+(** [getOperator t op] is a remote operator function provided by [t]. *)
+
+val local : t
 (* A capability to a local calculator service *)

--- a/examples/calc.mli
+++ b/examples/calc.mli
@@ -1,0 +1,66 @@
+(** This is the OCaml version of the C++ capnp calculator example. *)
+
+open Capnp_rpc_lwt
+
+type calc = [`Calculator_97983392df35cc36]
+type value = [`Value_c3e69d34d3ee48d2]
+type fn = [`Function_ede83a3d96840394]
+
+type expr =
+  | Float of float              (** [Float v] evaluates to [v]. *)
+  | Prev of value Capability.t  (** [Prev v] evaluates to the value returned by service [v]. *)
+  | Param of int                (** [Param i] evaluates to parameter number [i] (starting from zero). *)
+  | Call of fn Capability.t * expr list (** [Call fn args] evaluates to [fn args]. *)
+
+module Client : sig
+  type t = calc Capability.t
+
+  module Value : sig
+    type t = value Capability.t
+
+    val read : t -> float Lwt.t
+    (** [read t] reads the value of the remote value object. *)
+
+    val final_read : t -> float Lwt.t
+    (** [final_read t] reads the value and dec_ref's [t]. *)
+  end
+
+  module Fn : sig
+    type t = fn Capability.t
+
+    val call : t -> float list -> float Lwt.t
+    (** [call fn args] does [fn args]. *)
+  end
+
+  val evaluate : t -> expr -> Value.t
+  (** [evaluate t expr] evaluates [expr] using calculator service [t] and
+      returns a capability to the result service. *)
+
+  val getOperator : t -> [`Add | `Subtract | `Multiply | `Divide] -> Fn.t
+  (** [getOperator t op] is a remote operator function provided by [t]. *)
+end
+
+val literal : float -> Client.Value.t
+(** [literal v] is a capability to a local value service holding value [v]. *)
+
+val fn : int -> expr -> Client.Fn.t
+(** [fn n_args body] is a capability to a local service that takes [n_args] arguments
+    and evaluates [body]. *)
+
+val binop : (float -> float -> float) -> Client.Fn.t
+(** [binop fn] is a capability to a local service providing function [op] (of two arguments). *)
+
+val add : Client.Fn.t
+(** [add] is [binop ( +. )] *)
+
+val sub : Client.Fn.t
+(** [sub] is [binop ( -. )] *)
+
+val mul : Client.Fn.t
+(** [mul] is [binop ( *. )] *)
+
+val div : Client.Fn.t
+(** [div] is [binop ( /. )] *)
+
+val service : Client.t
+(* A capability to a local calculator service *)

--- a/examples/echo.ml
+++ b/examples/echo.ml
@@ -1,6 +1,8 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
+type t = Api.Service.Echo.t Capability.t
+
 (* This was supposed to be a simple ping service, but I wanted to test out-of-order
    replies, so it has become a bit messy... *)
 let service () =
@@ -38,8 +40,6 @@ let service () =
 
 module Client = struct
   module Echo = Api.Client.Echo
-
-  type t = Echo.t Capability.t
 
   let ping t ?(slow=false) msg =
     let open Echo.Ping in

--- a/examples/echo.ml
+++ b/examples/echo.ml
@@ -5,7 +5,7 @@ type t = Api.Service.Echo.t Capability.t
 
 (* This was supposed to be a simple ping service, but I wanted to test out-of-order
    replies, so it has become a bit messy... *)
-let service () =
+let local () =
   let module Echo = Api.Service.Echo in
   Echo.local @@ object
     inherit Echo.service
@@ -38,18 +38,16 @@ let service () =
       Service.return_empty ()
   end
 
-module Client = struct
-  module Echo = Api.Client.Echo
+module Echo = Api.Client.Echo
 
-  let ping t ?(slow=false) msg =
-    let open Echo.Ping in
-    let req, p = Capability.Request.create Params.init_pointer in
-    Params.slow_set p slow;
-    Params.msg_set p msg;
-    Capability.call_for_value_exn t method_id req >|= Results.reply_get
+let ping t ?(slow=false) msg =
+  let open Echo.Ping in
+  let req, p = Capability.Request.create Params.init_pointer in
+  Params.slow_set p slow;
+  Params.msg_set p msg;
+  Capability.call_for_value_exn t method_id req >|= Results.reply_get
 
-  let unblock t =
-    let open Echo.Unblock in
-    let req = Capability.Request.create_no_args () in
-    Capability.call_for_unit_exn t method_id req
-end
+let unblock t =
+  let open Echo.Unblock in
+  let req = Capability.Request.create_no_args () in
+  Capability.call_for_unit_exn t method_id req

--- a/examples/echo.mli
+++ b/examples/echo.mli
@@ -2,14 +2,12 @@ open Capnp_rpc_lwt
 
 type t = [`Echo_bb48258560861cec] Capability.t
 
-val service : unit -> t
-(** [service ()] is a capability to a new local echo service. *)
+val local : unit -> t
+(** [local ()] is a capability to a new local echo service. *)
 
-module Client : sig
-  val ping : t -> ?slow:bool -> string -> string Lwt.t
-  (** [ping t msg] sends [msg] to [t] and returns its response.
-      If [slow] is given, the service will wait until [unblock] is called before replying. *)
+val ping : t -> ?slow:bool -> string -> string Lwt.t
+(** [ping t msg] sends [msg] to [t] and returns its response.
+    If [slow] is given, the service will wait until [unblock] is called before replying. *)
 
-  val unblock : t -> unit Lwt.t
-  (** [unblock t] tells the service to return any blocked ping responses. *)
-end
+val unblock : t -> unit Lwt.t
+(** [unblock t] tells the service to return any blocked ping responses. *)

--- a/examples/echo.mli
+++ b/examples/echo.mli
@@ -1,0 +1,15 @@
+open Capnp_rpc_lwt
+
+type t = [`Echo_bb48258560861cec] Capability.t
+
+val service : unit -> t
+(** [service ()] is a capability to a new local echo service. *)
+
+module Client : sig
+  val ping : t -> ?slow:bool -> string -> string Lwt.t
+  (** [ping t msg] sends [msg] to [t] and returns its response.
+      If [slow] is given, the service will wait until [unblock] is called before replying. *)
+
+  val unblock : t -> unit Lwt.t
+  (** [unblock t] tells the service to return any blocked ping responses. *)
+end

--- a/examples/registry.ml
+++ b/examples/registry.ml
@@ -1,8 +1,11 @@
 open Lwt.Infix
 open Capnp_rpc_lwt
 
+type t = Api.Service.Registry.t Capability.t
+
 let version_service =
   let module Version = Api.Service.Version in
+
   Version.local @@ object
     inherit Version.service
 
@@ -14,7 +17,6 @@ let version_service =
       Service.return resp
   end
 
-(* A service that can return other services. *)
 let service () =
   let module Registry = Api.Service.Registry in
   Registry.local @@ object
@@ -97,13 +99,11 @@ module Client = struct
     Params.service_set p (Some echo_service);
     Capability.call_for_unit_exn t method_id req
 
-  (* Waits until unblocked before returning *)
   let echo_service t =
     let open Registry.EchoService in
     let req = Capability.Request.create_no_args () in
     Capability.call_for_caps t method_id req Results.service_get_pipelined
 
-  (* Returns a promise immediately. Resolves promise when unblocked. *)
   let echo_service_promise t =
     let open Registry.EchoServicePromise in
     let req = Capability.Request.create_no_args () in
@@ -127,6 +127,8 @@ end
 
 module Version = struct
   module Version = Api.Client.Version
+
+  type t = Version.t Capability.t
 
   let read t =
     let open Version.Read in

--- a/examples/registry.ml
+++ b/examples/registry.ml
@@ -17,13 +17,13 @@ let version_service =
       Service.return resp
   end
 
-let service () =
+let local () =
   let module Registry = Api.Service.Registry in
   Registry.local @@ object
     inherit Registry.service
 
     val mutable blocked = Lwt.wait ()
-    val mutable echo_service = Echo.service ()
+    val mutable echo_service = Echo.local ()
 
     method! release = Capability.dec_ref echo_service
 
@@ -90,40 +90,38 @@ let service () =
       Service.return resp
   end
 
-module Client = struct
-  module Registry = Api.Client.Registry
+module Registry = Api.Client.Registry
 
-  let set_echo_service t echo_service =
-    let open Registry.SetEchoService in
-    let req, p = Capability.Request.create Params.init_pointer in
-    Params.service_set p (Some echo_service);
-    Capability.call_for_unit_exn t method_id req
+let set_echo_service t echo_service =
+  let open Registry.SetEchoService in
+  let req, p = Capability.Request.create Params.init_pointer in
+  Params.service_set p (Some echo_service);
+  Capability.call_for_unit_exn t method_id req
 
-  let echo_service t =
-    let open Registry.EchoService in
-    let req = Capability.Request.create_no_args () in
-    Capability.call_for_caps t method_id req Results.service_get_pipelined
+let echo_service t =
+  let open Registry.EchoService in
+  let req = Capability.Request.create_no_args () in
+  Capability.call_for_caps t method_id req Results.service_get_pipelined
 
-  let echo_service_promise t =
-    let open Registry.EchoServicePromise in
-    let req = Capability.Request.create_no_args () in
-    Capability.call_for_caps t method_id req Results.service_get_pipelined
+let echo_service_promise t =
+  let open Registry.EchoServicePromise in
+  let req = Capability.Request.create_no_args () in
+  Capability.call_for_caps t method_id req Results.service_get_pipelined
 
-  let unblock t =
-    let open Registry.Unblock in
-    let req = Capability.Request.create_no_args () in
-    Capability.call_for_unit_exn t method_id req
+let unblock t =
+  let open Registry.Unblock in
+  let req = Capability.Request.create_no_args () in
+  Capability.call_for_unit_exn t method_id req
 
-  let complex t =
-    let open Registry.Complex in
-    let req = Capability.Request.create_no_args () in
-    let module Foo = Api.Reader.Foo in
-    let module Bar = Api.Reader.Bar in
-    Capability.call_for_caps t method_id req @@ fun result ->
-    let echo_service = Results.foo_get_pipelined result |> Foo.echo_get_pipelined in
-    let version = Results.bar_get_pipelined result |> Bar.version_get_pipelined in
-    (echo_service, version)
-end
+let complex t =
+  let open Registry.Complex in
+  let req = Capability.Request.create_no_args () in
+  let module Foo = Api.Reader.Foo in
+  let module Bar = Api.Reader.Bar in
+  Capability.call_for_caps t method_id req @@ fun result ->
+  let echo_service = Results.foo_get_pipelined result |> Foo.echo_get_pipelined in
+  let version = Results.bar_get_pipelined result |> Bar.version_get_pipelined in
+  (echo_service, version)
 
 module Version = struct
   module Version = Api.Client.Version

--- a/examples/registry.mli
+++ b/examples/registry.mli
@@ -1,0 +1,28 @@
+open Capnp_rpc_lwt
+
+module Version : sig
+  type t = [`Version_ed7d11372e0a7243] Capability.t
+
+  val read : t -> string Lwt.t
+end
+
+type t = [`Registry_d9975f668b337b6d] Capability.t
+
+val service : unit -> t
+(** [service ()] is a new local registry. *)
+
+module Client : sig
+  val set_echo_service : t -> Echo.t -> unit Lwt.t
+
+  val echo_service : t -> Echo.t
+  (** Waits until unblocked before returning. *)
+
+  val echo_service_promise : t -> Echo.t
+  (** Returns a promise immediately. Resolves promise when unblocked.
+      (should appear to work the same as [echo_service] to users) *)
+
+  val unblock : t -> unit Lwt.t
+
+  val complex : t -> Echo.t * Version.t
+  (** [complex t] returns two capabilities in a single, somewhat complex, message. *)
+end

--- a/examples/registry.mli
+++ b/examples/registry.mli
@@ -8,21 +8,19 @@ end
 
 type t = [`Registry_d9975f668b337b6d] Capability.t
 
-val service : unit -> t
-(** [service ()] is a new local registry. *)
+val set_echo_service : t -> Echo.t -> unit Lwt.t
 
-module Client : sig
-  val set_echo_service : t -> Echo.t -> unit Lwt.t
+val echo_service : t -> Echo.t
+(** Waits until unblocked before returning. *)
 
-  val echo_service : t -> Echo.t
-  (** Waits until unblocked before returning. *)
+val echo_service_promise : t -> Echo.t
+(** Returns a promise immediately. Resolves promise when unblocked.
+    (should appear to work the same as [echo_service] to users) *)
 
-  val echo_service_promise : t -> Echo.t
-  (** Returns a promise immediately. Resolves promise when unblocked.
-      (should appear to work the same as [echo_service] to users) *)
+val unblock : t -> unit Lwt.t
 
-  val unblock : t -> unit Lwt.t
+val complex : t -> Echo.t * Version.t
+(** [complex t] returns two capabilities in a single, somewhat complex, message. *)
 
-  val complex : t -> Echo.t * Version.t
-  (** [complex t] returns two capabilities in a single, somewhat complex, message. *)
-end
+val local : unit -> t
+(** [local ()] is a new local registry. *)

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -25,16 +25,16 @@ let reporter =
   { Logs.report = report }
 
 let serve addr : unit =
-  Lwt_main.run @@ Capnp_rpc_unix.serve ~offer:Examples.Calc.service addr
+  Lwt_main.run @@ Capnp_rpc_unix.serve ~offer:Examples.Calc.local addr
 
 let connect addr =
   Lwt_main.run begin
     Lwt_switch.with_switch @@ fun switch ->
     let calc = Capnp_rpc_unix.connect ~switch addr in
     Logs.info (fun f -> f "Evaluating expression...");
-    let remote_add = Calc.Client.getOperator calc `Add in
-    let result = Calc.Client.evaluate calc Calc.(Call (remote_add, [Float 40.0; Float 2.0])) in
-    Calc.Client.Value.read result >>= fun v ->
+    let remote_add = Calc.getOperator calc `Add in
+    let result = Calc.evaluate calc Calc.Expr.(Call (remote_add, [Float 40.0; Float 2.0])) in
+    Calc.Value.read result >>= fun v ->
     Fmt.pr "Result: %f@." v;
     Lwt.return_unit
   end

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -34,7 +34,7 @@ let connect addr =
     Logs.info (fun f -> f "Evaluating expression...");
     let remote_add = Calc.Client.getOperator calc `Add in
     let result = Calc.Client.evaluate calc Calc.(Call (remote_add, [Float 40.0; Float 2.0])) in
-    Calc.Client.read result >>= fun v ->
+    Calc.Client.Value.read result >>= fun v ->
     Fmt.pr "Result: %f@." v;
     Lwt.return_unit
   end

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -161,14 +161,14 @@ let test_calculator switch =
   let open Calc in
   let cs = run_server ~switch ~service:Calc.service () in
   let c = get_bootstrap cs in
-  Client.evaluate c (Float 1.) |> Client.final_read >|= Alcotest.check float "Simple calc" 1. >>= fun () ->
+  Client.evaluate c (Float 1.) |> Client.Value.final_read >|= Alcotest.check float "Simple calc" 1. >>= fun () ->
   let local_add = Calc.add in
   let expr = Call (local_add, [Float 1.; Float 2.]) in
-  Client.evaluate c expr |> Client.final_read >|= Alcotest.check float "Complex with local fn" 3. >>= fun () ->
+  Client.evaluate c expr |> Client.Value.final_read >|= Alcotest.check float "Complex with local fn" 3. >>= fun () ->
   let remote_add = Calc.Client.getOperator c `Add in
-  Calc.Client.call remote_add [5.; 3.] >|= Alcotest.check float "Check fn" 8. >>= fun () ->
+  Calc.Client.Fn.call remote_add [5.; 3.] >|= Alcotest.check float "Check fn" 8. >>= fun () ->
   let expr = Call (remote_add, [Float 1.; Float 2.]) in
-  Client.evaluate c expr |> Client.final_read >|= Alcotest.check float "Complex with remote fn" 3. >>= fun () ->
+  Client.evaluate c expr |> Client.Value.final_read >|= Alcotest.check float "Complex with remote fn" 3. >>= fun () ->
   Capability.dec_ref remote_add;
   Capability.dec_ref c;
   Lwt.return ()

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -71,77 +71,77 @@ let run_lwt fn () =
   Alcotest.(check int) "Check log for warnings" 0 (warnings_at_end - warnings_at_start)
 
 let test_simple switch =
-  let cs = run_server ~switch ~service:(Echo.service ()) () in
+  let cs = run_server ~switch ~service:(Echo.local ()) () in
   let service = get_bootstrap cs in
-  Echo.Client.ping service "ping" >>= fun reply ->
+  Echo.ping service "ping" >>= fun reply ->
   Alcotest.(check string) "Ping response" "got:0:ping" reply;
   Capability.dec_ref service;
   Lwt.return ()
 
 let test_parallel switch =
-  let cs = run_server ~switch ~service:(Echo.service ()) () in
+  let cs = run_server ~switch ~service:(Echo.local ()) () in
   let service = get_bootstrap cs in
-  let reply1 = Echo.Client.ping service ~slow:true "ping1" in
-  Echo.Client.ping service "ping2" >|= Alcotest.(check string) "Ping2 response" "got:1:ping2" >>= fun () ->
+  let reply1 = Echo.ping service ~slow:true "ping1" in
+  Echo.ping service "ping2" >|= Alcotest.(check string) "Ping2 response" "got:1:ping2" >>= fun () ->
   assert (Lwt.state reply1 = Lwt.Sleep);
-  Echo.Client.unblock service >>= fun () ->
+  Echo.unblock service >>= fun () ->
   reply1 >|= Alcotest.(check string) "Ping1 response" "got:0:ping1" >>= fun () ->
   Capability.dec_ref service;
   Lwt.return ()
 
 let test_registry switch =
-  let registry_impl = Registry.service () in
+  let registry_impl = Registry.local () in
   let cs = run_server ~switch ~service:registry_impl () in
   let registry = get_bootstrap cs in
-  let echo_service = Registry.Client.echo_service registry in
-  Registry.Client.unblock registry >>= fun () ->
-  Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
+  let echo_service = Registry.echo_service registry in
+  Registry.unblock registry >>= fun () ->
+  Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
   Capability.dec_ref registry;
   Capability.dec_ref echo_service;
   Lwt.return ()
 
 let test_embargo switch =
-  let registry_impl = Registry.service () in
-  let local_echo = Echo.service () in
+  let registry_impl = Registry.local () in
+  let local_echo = Echo.local () in
   let cs = run_server ~switch ~service:registry_impl () in
   let registry = get_bootstrap cs in
-  Registry.Client.set_echo_service registry local_echo >>= fun () ->
+  Registry.set_echo_service registry local_echo >>= fun () ->
   Capability.dec_ref local_echo;
-  let echo_service = Registry.Client.echo_service registry in
-  let reply1 = Echo.Client.ping echo_service "ping" in
-  Registry.Client.unblock registry >>= fun () ->
+  let echo_service = Registry.echo_service registry in
+  let reply1 = Echo.ping echo_service "ping" in
+  Registry.unblock registry >>= fun () ->
   reply1 >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
   (* Flush, to ensure we resolve the echo_service's location. *)
-  Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:1:ping" >>= fun () ->
+  Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:1:ping" >>= fun () ->
   (* Test local connection. *)
-  Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:2:ping" >>= fun () ->
+  Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:2:ping" >>= fun () ->
   Capability.dec_ref echo_service;
   Capability.dec_ref registry;
   Lwt.return ()
 
 let test_resolve switch =
-  let registry_impl = Registry.service () in
-  let local_echo = Echo.service () in
+  let registry_impl = Registry.local () in
+  let local_echo = Echo.local () in
   let cs = run_server ~switch ~service:registry_impl () in
   let registry = get_bootstrap cs in
-  Registry.Client.set_echo_service registry local_echo >>= fun () ->
+  Registry.set_echo_service registry local_echo >>= fun () ->
   Capability.dec_ref local_echo;
-  let echo_service = Registry.Client.echo_service_promise registry in
-  let reply1 = Echo.Client.ping echo_service "ping" in
-  Registry.Client.unblock registry >>= fun () ->
+  let echo_service = Registry.echo_service_promise registry in
+  let reply1 = Echo.ping echo_service "ping" in
+  Registry.unblock registry >>= fun () ->
   reply1 >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
   (* Flush, to ensure we resolve the echo_service's location. *)
-  Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:1:ping" >>= fun () ->
+  Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:1:ping" >>= fun () ->
   (* Test local connection. *)
-  Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:2:ping" >>= fun () ->
+  Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:2:ping" >>= fun () ->
   Capability.dec_ref echo_service;
   Capability.dec_ref registry;
   Lwt.return ()
 
 let test_cancel switch =
-  let cs = run_server ~switch ~service:(Echo.service ()) () in
+  let cs = run_server ~switch ~service:(Echo.local ()) () in
   let service = get_bootstrap cs in
-  let reply1 = Echo.Client.ping service ~slow:true "ping1" in
+  let reply1 = Echo.ping service ~slow:true "ping1" in
   assert (Lwt.state reply1 = Lwt.Sleep);
   Lwt.cancel reply1;
   Lwt.try_bind
@@ -152,33 +152,33 @@ let test_cancel switch =
       | ex -> Lwt.fail ex
     )
   >>= fun () ->
-  Echo.Client.unblock service >|= fun () ->
+  Echo.unblock service >|= fun () ->
   Capability.dec_ref service
 
 let float = Alcotest.testable Fmt.float (=)
 
 let test_calculator switch =
   let open Calc in
-  let cs = run_server ~switch ~service:Calc.service () in
+  let cs = run_server ~switch ~service:Calc.local () in
   let c = get_bootstrap cs in
-  Client.evaluate c (Float 1.) |> Client.Value.final_read >|= Alcotest.check float "Simple calc" 1. >>= fun () ->
-  let local_add = Calc.add in
-  let expr = Call (local_add, [Float 1.; Float 2.]) in
-  Client.evaluate c expr |> Client.Value.final_read >|= Alcotest.check float "Complex with local fn" 3. >>= fun () ->
-  let remote_add = Calc.Client.getOperator c `Add in
-  Calc.Client.Fn.call remote_add [5.; 3.] >|= Alcotest.check float "Check fn" 8. >>= fun () ->
-  let expr = Call (remote_add, [Float 1.; Float 2.]) in
-  Client.evaluate c expr |> Client.Value.final_read >|= Alcotest.check float "Complex with remote fn" 3. >>= fun () ->
+  Calc.evaluate c (Float 1.) |> Value.final_read >|= Alcotest.check float "Simple calc" 1. >>= fun () ->
+  let local_add = Calc.Fn.add in
+  let expr = Expr.(Call (local_add, [Float 1.; Float 2.])) in
+  Calc.evaluate c expr |> Value.final_read >|= Alcotest.check float "Complex with local fn" 3. >>= fun () ->
+  let remote_add = Calc.getOperator c `Add in
+  Calc.Fn.call remote_add [5.; 3.] >|= Alcotest.check float "Check fn" 8. >>= fun () ->
+  let expr = Expr.(Call (remote_add, [Float 1.; Float 2.])) in
+  Calc.evaluate c expr |> Value.final_read >|= Alcotest.check float "Complex with remote fn" 3. >>= fun () ->
   Capability.dec_ref remote_add;
   Capability.dec_ref c;
   Lwt.return ()
 
 let test_indexing switch =
-  let registry_impl = Registry.service () in
+  let registry_impl = Registry.local () in
   let cs = run_server ~switch ~service:registry_impl () in
   let registry = get_bootstrap cs in
-  let echo_service, version = Registry.Client.complex registry in
-  Echo.Client.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
+  let echo_service, version = Registry.complex registry in
+  Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
   Registry.Version.read version >|= Alcotest.(check string) "Version response" "0.1" >>= fun () ->
   Capability.dec_ref registry;
   Capability.dec_ref echo_service;


### PR DESCRIPTION
Add `.mli` files for the example services.

Also, simplify the API used there and in the tutorial:

Instead of having a `Client` module and a `service` function, have all the client functions at the top-level and rename `service` to `local`.

The `Client` module didn't add anything useful, and even `service` returned a `Client.t`.

This also makes it easier to have sub-modules (e.g. `Calc.Fn.call`) without having to add another layer (`Calc.Fn.Client.call`).