### PR TITLE
Clear blockers before forwarding calls on resolve

### DIFF
--- a/capnp-rpc/local_struct_promise.ml
+++ b/capnp-rpc/local_struct_promise.ml
@@ -1,14 +1,17 @@
 module Make (C : S.CORE_TYPES) = struct
   module Struct_proxy = Struct_proxy.Make(C)
 
-  type target = (C.struct_ref -> unit) Queue.t
+  type target = {
+    mutable blocking : C.struct_resolver list;  (* Resolvers blocked on us *)
+    pending: (C.struct_ref -> unit) Queue.t;
+  }
 
   let local_promise () = object (self : _ #Struct_proxy.t)
-    inherit [target] Struct_proxy.t (Queue.create ())
+    inherit [target] Struct_proxy.t { blocking = []; pending = Queue.create () }
 
     val name = "local-promise"
 
-    method private do_pipeline q i results msg =
+    method private do_pipeline target i results msg =
       (* We add an extra resolver here so that we can report [self]
          as the blocker. *)
       match results#set_blocker (self :> C.base_ref) with
@@ -16,8 +19,8 @@ module Make (C : S.CORE_TYPES) = struct
         C.Request_payload.release msg;
         C.resolve_exn results (Exception.v "Attempt to use pipelined call's result as pipeline target!")
       | Ok () ->
-        q |> Queue.add (fun p ->
-            results#clear_blocker;
+        target.blocking <- results :: target.blocking;
+        target.pending |> Queue.add (fun p ->
             let cap = p#cap i in
             cap#call results msg;
             C.dec_ref cap
@@ -26,8 +29,9 @@ module Make (C : S.CORE_TYPES) = struct
     method pp_unresolved f _ =
       Fmt.string f "(unresolved)"
 
-    method private on_resolve q x =
-      Queue.iter (fun fn -> fn x) q
+    method private on_resolve target x =
+      List.iter (fun r -> r#clear_blocker) target.blocking;
+      Queue.iter (fun fn -> fn x) target.pending
 
     method private send_cancel _ = ()
 


### PR DESCRIPTION
When a local promise resolves, we must notify anything waiting for us that we're no longer a blocker and also forward the queued messages.

Before, we used a single queue for both. This could result in a promise that was in the process of being resolved appearing to be settled, and being reported as SenderHosted instead of SenderPromise.

Now, we have a separate list of promises we're blocking and we notify them of the resolution first.

Found by AFL (after 4 days) and simplified to new test case.