### PR TITLE
Allow library user to supply their own network types

### DIFF
--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -5,133 +5,140 @@ module Log = Capnp_rpc.Debug.Log
 module Builder = Schema.Builder
 module Reader = Schema.Reader
 
-module Conn = Capnp_rpc.CapTP.Make(Capnp_core.Endpoint_types)
+module Table_types = Capnp_rpc.Message_types.Table_types ( )
 
-type t = {
-  endpoint : Endpoint.t;
-  conn : Conn.t;
-  xmit_queue : Capnp.Message.rw Capnp.BytesMessage.Message.t Queue.t;
-  switch : Lwt_switch.t;
-}
+module Make (Network : Capnp_core.NETWORK) = struct
+  module Endpoint_types = Capnp_rpc.Message_types.Endpoint(Capnp_core.Core_types)(Network.Types)(Table_types)
+  module Conn = Capnp_rpc.CapTP.Make(Endpoint_types)
+  module Parse = Parse.Make(Endpoint_types)(Network)
+  module Serialise = Serialise.Make(Endpoint_types)
 
-let bootstrap t = Conn.bootstrap t.conn
+  type t = {
+    endpoint : Endpoint.t;
+    conn : Conn.t;
+    xmit_queue : Capnp.Message.rw Capnp.BytesMessage.Message.t Queue.t;
+    switch : Lwt_switch.t;
+  }
 
-let async_tagged label fn =
-  Lwt.async
-    (fun () ->
-      Lwt.catch fn
-        (fun ex ->
-           Log.warn (fun f -> f "Uncaught async exception in %S: %a" label Fmt.exn ex);
-           Lwt.return_unit
-        )
-    )
+  let bootstrap t = Conn.bootstrap t.conn
 
-let pp_msg f call =
-  let open Reader in
-  let call = Msg.Request.readable call in
-  let interface_id = Call.interface_id_get call in
-  let method_id = Call.method_id_get call in
-  Capnp.RPC.Registry.pp_method f (interface_id, method_id)
+  let async_tagged label fn =
+    Lwt.async
+      (fun () ->
+        Lwt.catch fn
+          (fun ex ->
+             Log.warn (fun f -> f "Uncaught async exception in %S: %a" label Fmt.exn ex);
+             Lwt.return_unit
+          )
+      )
 
-let tags t = Conn.tags t.conn
+  let pp_msg f call =
+    let open Reader in
+    let call = Msg.Request.readable call in
+    let interface_id = Call.interface_id_get call in
+    let method_id = Call.method_id_get call in
+    Capnp.RPC.Registry.pp_method f (interface_id, method_id)
 
-(* [flush ~xmit_queue endpoint] writes each message in the queue until it is empty.
-   Invariant:
-     Whenever Lwt blocks or switches threads, a flush thread is running iff the
-     queue is non-empty. *)
-let rec flush ~switch ~xmit_queue endpoint =
-  (* We keep the item on the queue until it is transmitted, as the queue state
-     tells us whether there is a [flush] currently running. *)
-  let next = Queue.peek xmit_queue in
-  Endpoint.send endpoint next >>= function
-  | Error e when Lwt_switch.is_on switch ->
-    Log.warn (fun f -> f "Error sending messages: %a (will shutdown connection)" Endpoint.pp_error e);
-    Lwt_switch.turn_off switch
-  | Error _ -> Lwt.return_unit  (* We're shutting down *)
-  | Ok () ->
-    ignore (Queue.pop xmit_queue);
-    if not (Queue.is_empty xmit_queue) then
-      flush ~switch ~xmit_queue endpoint
-    else (* queue is empty and flush thread is done *)
-      Lwt.return_unit
+  let tags t = Conn.tags t.conn
 
-(* Enqueue [message] in [xmit_queue] and ensure the flush thread is running. *)
-let queue_send ~switch ~xmit_queue endpoint message =
-  let was_idle = Queue.is_empty xmit_queue in
-  Queue.add message xmit_queue;
-  if was_idle then async_tagged "Message sender thread" (fun () -> flush ~switch ~xmit_queue endpoint)
-
-let return_not_implemented t x =
-  Log.info (fun f -> f ~tags:(tags t) "Returning Unimplemented");
-  let open Builder in
-  let m = Message.init_root () in
-  let _ : Builder.Message.t = Message.unimplemented_set_reader m x in
-  queue_send ~switch:t.switch ~xmit_queue:t.xmit_queue t.endpoint (Message.to_message m)
-
-let listen t =
-  let rec loop () =
-    Endpoint.recv t.endpoint >>= function
-    | Error e -> Lwt.return e
-    | Ok msg ->
-      let open Reader.Message in
-      let msg = of_message msg in
-      match Parse.message msg with
-      | #Capnp_core.Endpoint_types.In.t as msg ->
-        Log.info (fun f ->
-            let tags = Capnp_core.Endpoint_types.In.with_qid_tag (Conn.tags t.conn) msg in
-            f ~tags "<- %a" (Capnp_core.Endpoint_types.In.pp_recv pp_msg) msg);
-        Conn.handle_msg t.conn msg;
-        begin match msg with
-          | `Abort _ -> Lwt.return `Aborted
-          | _ -> loop ()
-        end
-      | `Unimplemented x as msg ->
-        Log.info (fun f ->
-            let tags = Capnp_core.Endpoint_types.Out.with_qid_tag (Conn.tags t.conn) x in
-            f ~tags "<- Unimplemented(%a)" (Capnp_core.Endpoint_types.Out.pp_recv pp_msg) x);
-        Conn.handle_msg t.conn msg;
-        loop ()
-      | `Not_implemented ->
-        Log.info (fun f -> f "<- unsupported message type");
-        return_not_implemented t msg;
-        loop ()
-  in
-  loop ()
-
-let connect ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
-  let xmit_queue = Queue.create () in
-  let queue_send msg = queue_send ~switch ~xmit_queue endpoint (Serialise.message msg) in
-  let conn = Conn.create ?bootstrap:offer ~tags ~queue_send in
-  Lwt_switch.add_hook (Some switch) (fun () ->
-      Conn.disconnect conn (Capnp_rpc.Exception.v ~ty:`Disconnected "CapTP switch turned off");
-      Lwt.return_unit
-    );
-  let t = {
-    conn;
-    endpoint;
-    xmit_queue;
-    switch;
-  } in
-  Lwt.async (fun () ->
-      Lwt.catch
-        (fun () ->
-           listen t >|= fun (`Closed | `Aborted) -> ()
-        )
-        (fun ex ->
-           Log.warn (fun f ->
-               f ~tags "Uncaught exception handling CapTP connection: %a (dropping connection)" Fmt.exn ex
-             );
-           queue_send @@ `Abort (Capnp_rpc.Exception.v ~ty:`Failed (Printexc.to_string ex));
-           Lwt.return_unit
-        )
-      >>= fun () ->
-      Log.info (fun f -> f ~tags "Connection closed");
+  (* [flush ~xmit_queue endpoint] writes each message in the queue until it is empty.
+     Invariant:
+       Whenever Lwt blocks or switches threads, a flush thread is running iff the
+       queue is non-empty. *)
+  let rec flush ~switch ~xmit_queue endpoint =
+    (* We keep the item on the queue until it is transmitted, as the queue state
+       tells us whether there is a [flush] currently running. *)
+    let next = Queue.peek xmit_queue in
+    Endpoint.send endpoint next >>= function
+    | Error e when Lwt_switch.is_on switch ->
+      Log.warn (fun f -> f "Error sending messages: %a (will shutdown connection)" Endpoint.pp_error e);
       Lwt_switch.turn_off switch
-    );
-  t
+    | Error _ -> Lwt.return_unit  (* We're shutting down *)
+    | Ok () ->
+      ignore (Queue.pop xmit_queue);
+      if not (Queue.is_empty xmit_queue) then
+        flush ~switch ~xmit_queue endpoint
+      else (* queue is empty and flush thread is done *)
+        Lwt.return_unit
 
-let disconnect t ex =
-  queue_send ~switch:t.switch ~xmit_queue:t.xmit_queue t.endpoint (Serialise.message (`Abort ex));
-  Lwt_switch.turn_off t.switch
+  (* Enqueue [message] in [xmit_queue] and ensure the flush thread is running. *)
+  let queue_send ~switch ~xmit_queue endpoint message =
+    let was_idle = Queue.is_empty xmit_queue in
+    Queue.add message xmit_queue;
+    if was_idle then async_tagged "Message sender thread" (fun () -> flush ~switch ~xmit_queue endpoint)
 
-let dump f t = Conn.dump f t.conn
+  let return_not_implemented t x =
+    Log.info (fun f -> f ~tags:(tags t) "Returning Unimplemented");
+    let open Builder in
+    let m = Message.init_root () in
+    let _ : Builder.Message.t = Message.unimplemented_set_reader m x in
+    queue_send ~switch:t.switch ~xmit_queue:t.xmit_queue t.endpoint (Message.to_message m)
+
+  let listen t =
+    let rec loop () =
+      Endpoint.recv t.endpoint >>= function
+      | Error e -> Lwt.return e
+      | Ok msg ->
+        let open Reader.Message in
+        let msg = of_message msg in
+        match Parse.message msg with
+        | #Endpoint_types.In.t as msg ->
+          Log.info (fun f ->
+              let tags = Endpoint_types.In.with_qid_tag (Conn.tags t.conn) msg in
+              f ~tags "<- %a" (Endpoint_types.In.pp_recv pp_msg) msg);
+          Conn.handle_msg t.conn msg;
+          begin match msg with
+            | `Abort _ -> Lwt.return `Aborted
+            | _ -> loop ()
+          end
+        | `Unimplemented x as msg ->
+          Log.info (fun f ->
+              let tags = Endpoint_types.Out.with_qid_tag (Conn.tags t.conn) x in
+              f ~tags "<- Unimplemented(%a)" (Endpoint_types.Out.pp_recv pp_msg) x);
+          Conn.handle_msg t.conn msg;
+          loop ()
+        | `Not_implemented ->
+          Log.info (fun f -> f "<- unsupported message type");
+          return_not_implemented t msg;
+          loop ()
+    in
+    loop ()
+
+  let connect ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
+    let xmit_queue = Queue.create () in
+    let queue_send msg = queue_send ~switch ~xmit_queue endpoint (Serialise.message msg) in
+    let conn = Conn.create ?bootstrap:offer ~tags ~queue_send in
+    Lwt_switch.add_hook (Some switch) (fun () ->
+        Conn.disconnect conn (Capnp_rpc.Exception.v ~ty:`Disconnected "CapTP switch turned off");
+        Lwt.return_unit
+      );
+    let t = {
+      conn;
+      endpoint;
+      xmit_queue;
+      switch;
+    } in
+    Lwt.async (fun () ->
+        Lwt.catch
+          (fun () ->
+             listen t >|= fun (`Closed | `Aborted) -> ()
+          )
+          (fun ex ->
+             Log.warn (fun f ->
+                 f ~tags "Uncaught exception handling CapTP connection: %a (dropping connection)" Fmt.exn ex
+               );
+             queue_send @@ `Abort (Capnp_rpc.Exception.v ~ty:`Failed (Printexc.to_string ex));
+             Lwt.return_unit
+          )
+        >>= fun () ->
+        Log.info (fun f -> f ~tags "Connection closed");
+        Lwt_switch.turn_off switch
+      );
+    t
+
+  let disconnect t ex =
+    queue_send ~switch:t.switch ~xmit_queue:t.xmit_queue t.endpoint (Serialise.message (`Abort ex));
+    Lwt_switch.turn_off t.switch
+
+  let dump f t = Conn.dump f t.conn
+end

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -1,21 +1,23 @@
-(** Provides the RPC layer on top of [Endpoint]. *)
+(** Provides the RPC layer on top of some network. *)
 
 open Capnp_core.Core_types
 
-type t
-(** A Cap'n Proto RPC protocol handler. *)
+module Make (N : Capnp_core.NETWORK) : sig
+  type t
+  (** A Cap'n Proto RPC protocol handler. *)
 
-val connect : ?offer:cap -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
-(** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
-    receives messages using [endpoint].
-    If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
-    If the connection fails then [switch] will be turned off, and turning off the switch
-    will release all resources used by the connection. *)
+  val connect : ?offer:cap -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+  (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
+      receives messages using [endpoint].
+      If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
+      If the connection fails then [switch] will be turned off, and turning off the switch
+      will release all resources used by the connection. *)
 
-val bootstrap : t -> cap
-(** [bootstrap t] is the peer's public bootstrap object, if any. *)
+  val bootstrap : t -> cap
+  (** [bootstrap t] is the peer's public bootstrap object, if any. *)
 
-val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
+  val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
 
-val dump : t Fmt.t
-(** [dump] dumps the state of the connection, for debugging. *)
+  val dump : t Fmt.t
+  (** [dump] dumps the state of the connection, for debugging. *)
+end

--- a/capnp-rpc-lwt/capnp_core.ml
+++ b/capnp-rpc-lwt/capnp_core.ml
@@ -11,16 +11,16 @@ module Capnp_content = struct
       )
 end
 
-module Core_types = struct
-  include Capnp_rpc.Core_types(Capnp_content)
+module Core_types = Capnp_rpc.Core_types(Capnp_content)
 
-  type sturdy_ref
-  type provision_id
-  type recipient_id
-  type third_party_cap_id = [`TODO_3rd_party]
-  type join_key_part
-end
-
-module Endpoint_types = Capnp_rpc.Message_types.Endpoint(Core_types)( )
 module Local_struct_promise = Capnp_rpc.Local_struct_promise.Make(Core_types)
 module Cap_proxy = Capnp_rpc.Cap_proxy.Make(Core_types)
+
+module type NETWORK = sig
+  module Types : Capnp_rpc.S.NETWORK_TYPES
+
+  val parse_third_party_cap_id : Schema.Reader.pointer_t -> Types.third_party_cap_id
+end
+
+module type ENDPOINT = Capnp_rpc.Message_types.ENDPOINT with
+  module Core_types = Core_types

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -136,6 +136,13 @@ module Untyped = struct
 end
 
 module Service = Service
-module CapTP = CapTP_capnp
 module Endpoint = Endpoint
-module Vat = Vat
+
+module type NETWORK = Capnp_core.NETWORK
+
+module Networking (N : NETWORK) = struct
+  module Vat = Vat.Make (N)
+  module CapTP = Vat.CapTP
+end
+
+module Two_party_network = Two_party_network

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -173,52 +173,60 @@ module Service : sig
   (** [fail msg] is an exception with reason [msg]. *)
 end
 
-module CapTP : sig
-  (** Stretching capability references across a network link.
-      Note: see {!module:Capnp_rpc_unix} for a higher-level wrapper for this API. *)
-
-  type t
-  (** A CapTP connection to a remote peer. *)
-
-  val connect : ?offer:'a Capability.t -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
-  (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
-      receives messages using [endpoint].
-      If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
-      If the connection fails then [switch] will be turned off, and turning off the switch
-      will release all resources used by the connection. *)
-
-  val bootstrap : t -> 'a Capability.t
-  (** [bootstrap t] is the peer's public bootstrap object, if any. *)
-
-  val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
-  (** [disconnect reason] closes the connection, sending [reason] to the peer to explain why.
-      Capabilities and questions at both ends will break, with [reason] as the problem. *)
-
-  val dump : t Fmt.t
-  (** [dump] dumps the state of the connection, for debugging. *)
-end
+module type NETWORK = Capnp_core.NETWORK
 
 module Endpoint = Endpoint
 
-module Vat : sig
-  (** An actor in the CapTP network.
-      A vat is a collection of objects that can call each other directly.
-      A vat may be connected to other vats over CapTP network connections.
-      Typically an application will create only a single vat.
-      See the {!module:Capnp_rpc_unix} module for a higher-level API. *)
+module Networking (N : NETWORK) : sig
+  (** Stretching capability references across a network link.
+      Note: see {!module:Capnp_rpc_unix} for a higher-level wrapper for this API. *)
 
-  type t
-  (** A local vat. *)
+  module CapTP : sig
+    (** Sharing capabilities over a network link. *)
 
-  val create : ?switch:Lwt_switch.t -> ?bootstrap:'a Capability.t -> unit -> t
-  (** [create ~switch ~bootstrap ()] is a new vat that offers [bootstrap] to its peers.
-      The vat takes ownership of [bootstrap], and will release it when the switch is turned off.
-      Turning off the switch will also disconnect any active connections. *)
+    type t
+    (** A CapTP connection to a remote peer. *)
 
-  val connect : t -> Endpoint.t -> CapTP.t
-  (** [connect t endpoint] runs the CapTP protocol over [endpoint], which is a
-      connection to another vat. *)
+    val connect : ?offer:'a Capability.t -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+    (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
+        receives messages using [endpoint].
+        If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
+        If the connection fails then [switch] will be turned off, and turning off the switch
+        will release all resources used by the connection. *)
+
+    val bootstrap : t -> 'a Capability.t
+    (** [bootstrap t] is the peer's public bootstrap object, if any. *)
+
+    val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
+    (** [disconnect reason] closes the connection, sending [reason] to the peer to explain why.
+        Capabilities and questions at both ends will break, with [reason] as the problem. *)
+
+    val dump : t Fmt.t
+    (** [dump] dumps the state of the connection, for debugging. *)
+  end
+
+  module Vat : sig
+    (** An actor in the CapTP network.
+        A vat is a collection of objects that can call each other directly.
+        A vat may be connected to other vats over CapTP network connections.
+        Typically an application will create only a single vat.
+        See the {!module:Capnp_rpc_unix} module for a higher-level API. *)
+
+    type t
+    (** A local vat. *)
+
+    val create : ?switch:Lwt_switch.t -> ?bootstrap:'a Capability.t -> unit -> t
+    (** [create ~switch ~bootstrap ()] is a new vat that offers [bootstrap] to its peers.
+        The vat takes ownership of [bootstrap], and will release it when the switch is turned off.
+        Turning off the switch will also disconnect any active connections. *)
+
+    val connect : t -> Endpoint.t -> CapTP.t
+    (** [connect t endpoint] runs the CapTP protocol over [endpoint], which is a
+        connection to another vat. *)
+  end
 end
+
+module Two_party_network = Two_party_network
 
 (**/**)
 

--- a/capnp-rpc-lwt/parse.mli
+++ b/capnp-rpc-lwt/parse.mli
@@ -1,9 +1,11 @@
 (** Parsing of Cap'n Proto RPC messages received from a remote peer. *)
 
-val message :
-  Schema.Reader.Message.t ->
-  [ Capnp_core.Endpoint_types.In.t
-  | `Unimplemented of Capnp_core.Endpoint_types.Out.t
-  | `Not_implemented ]
-(** Parse a message received from a peer.
-    Returns [`Not_implemented] if we don't understand it. *)
+module Make (EP : Capnp_core.ENDPOINT) (Network : Capnp_core.NETWORK with module Types = EP.Network_types) : sig
+  val message :
+    Schema.Reader.Message.t ->
+    [ EP.In.t
+    | `Unimplemented of EP.Out.t
+    | `Not_implemented ]
+  (** Parse a message received from a peer.
+      Returns [`Not_implemented] if we don't understand it. *)
+end

--- a/capnp-rpc-lwt/serialise.ml
+++ b/capnp-rpc-lwt/serialise.ml
@@ -1,156 +1,157 @@
-open Capnp_core
-open Capnp_core.Endpoint_types.Table
-
 module EmbargoId = Capnp_rpc.Message_types.EmbargoId
 module Log = Capnp_rpc.Debug.Log
 module Builder = Schema.Builder
 module RO_array = Capnp_rpc.RO_array
 
-let results_of_return ret =
-  let open Builder in
-  match Return.get ret with
-  | Return.Results r -> r
-  | _ -> failwith "results_of_return: not results!"
+module Make (EP : Capnp_core.ENDPOINT) = struct
+  open EP.Table
 
-let write_promised_answer pa (qid, xforms) =
-  let open Builder in
-  PromisedAnswer.question_id_set pa (QuestionId.uint32 qid);
-  let xforms_builder = PromisedAnswer.transform_init pa (List.length xforms) in
-  xforms |> List.iteri (fun i (Xform.Field f) ->
-      let b = Capnp.Array.get xforms_builder i in
-      PromisedAnswer.Op.get_pointer_field_set_exn b f
-    )
+  let results_of_return ret =
+    let open Builder in
+    match Return.get ret with
+    | Return.Results r -> r
+    | _ -> failwith "results_of_return: not results!"
 
-let write_cap slot =
-  let open Builder in function
-    | `ReceiverHosted id -> CapDescriptor.receiver_hosted_set slot (ImportId.uint32 id)
-    | `ReceiverAnswer x -> write_promised_answer (CapDescriptor.receiver_answer_init slot) x
-    | `SenderHosted id -> CapDescriptor.sender_hosted_set slot (ExportId.uint32 id)
-    | `SenderPromise id -> CapDescriptor.sender_promise_set slot (ExportId.uint32 id)
-    | `ThirdPartyHosted _ -> failwith "TODO: write_caps_array"
-    | `None -> CapDescriptor.none_set slot
+  let write_promised_answer pa (qid, xforms) =
+    let open Builder in
+    PromisedAnswer.question_id_set pa (QuestionId.uint32 qid);
+    let xforms_builder = PromisedAnswer.transform_init pa (List.length xforms) in
+    xforms |> List.iteri (fun i (Xform.Field f) ->
+        let b = Capnp.Array.get xforms_builder i in
+        PromisedAnswer.Op.get_pointer_field_set_exn b f
+      )
 
-let write_caps_array caps payload =
-  let open Builder in
-  let builder = Payload.cap_table_init payload (RO_array.length caps) in
-  caps |> RO_array.iteri (fun i -> write_cap (Capnp.Array.get builder i))
+  let write_cap slot =
+    let open Builder in function
+      | `ReceiverHosted id -> CapDescriptor.receiver_hosted_set slot (ImportId.uint32 id)
+      | `ReceiverAnswer x -> write_promised_answer (CapDescriptor.receiver_answer_init slot) x
+      | `SenderHosted id -> CapDescriptor.sender_hosted_set slot (ExportId.uint32 id)
+      | `SenderPromise id -> CapDescriptor.sender_promise_set slot (ExportId.uint32 id)
+      | `ThirdPartyHosted _ -> failwith "TODO: write_caps_array"
+      | `None -> CapDescriptor.none_set slot
 
-let set_target b target =
-  let open Builder in
-  match target with
-  | `ReceiverAnswer (id, i) ->
-    let builder = MessageTarget.promised_answer_init b in
-    write_promised_answer builder (id, i)
-  | `ReceiverHosted id ->
-    MessageTarget.imported_cap_set b (ImportId.uint32 id)
+  let write_caps_array caps payload =
+    let open Builder in
+    let builder = Payload.cap_table_init payload (RO_array.length caps) in
+    caps |> RO_array.iteri (fun i -> write_cap (Capnp.Array.get builder i))
 
-let write_exn b ex =
-  let open Builder.Exception in
-  let ty =
-    match ex.Capnp_rpc.Exception.ty with
-    | `Failed        -> Type.Failed
-    | `Overloaded    -> Type.Overloaded
-    | `Disconnected  -> Type.Disconnected
-    | `Unimplemented -> Type.Unimplemented
-    | `Undefined x   -> Type.Undefined x
-  in
-  type_set b ty;
-  reason_set b ex.Capnp_rpc.Exception.reason
+  let set_target b target =
+    let open Builder in
+    match target with
+    | `ReceiverAnswer (id, i) ->
+      let builder = MessageTarget.promised_answer_init b in
+      write_promised_answer builder (id, i)
+    | `ReceiverHosted id ->
+      MessageTarget.imported_cap_set b (ImportId.uint32 id)
 
-let message : Endpoint_types.Out.t -> _ =
-  let open Builder in
-  function
-  | `Abort ex ->
-    let b = Message.init_root () in
-    write_exn (Message.abort_init b) ex;
-    Message.to_message b
-  | `Bootstrap qid ->
-    let b = Message.init_root () in
-    let boot = Message.bootstrap_init b in
-    Bootstrap.question_id_set boot (QuestionId.uint32 qid);
-    Message.to_message b
-  | `Call (qid, target, request, descs, results_to) ->
-    let c = Msg.Request.writable request in
-    Call.question_id_set c (QuestionId.uint32 qid);
-    set_target (Call.target_init c) target;
-    let p = Call.params_get c in
-    write_caps_array descs p;
-    let dest = Call.send_results_to_init c in
-    begin match results_to with
-      | `Caller -> Call.SendResultsTo.caller_set dest
-      | `Yourself -> Call.SendResultsTo.yourself_set dest
-      | `ThirdParty _ -> failwith "TODO: send_results_to ThirdParty"
-    end;
-    Call.to_message c
-  | `Finish (qid, release_result_caps) ->
-    let b = Message.init_root () in
-    let fin = Message.finish_init b in
-    Finish.question_id_set fin (QuestionId.uint32 qid);
-    Finish.release_result_caps_set fin release_result_caps;
-    Message.to_message b
-  | `Release (id, count) ->
-    let m = Message.init_root () in
-    let rel = Message.release_init m in
-    Release.id_set rel (ImportId.uint32 id);
-    Release.reference_count_set_int_exn rel count;
-    Message.to_message m
-  | `Disembargo_request disembargo_request ->
-    let m = Message.init_root () in
-    let dis = Message.disembargo_init m in
-    let ctx = Disembargo.context_init dis in
-    begin match disembargo_request with
-      | `Loopback (old_path, embargo_id) ->
-        set_target (Disembargo.target_init dis) old_path;
-        Disembargo.Context.sender_loopback_set ctx (EmbargoId.uint32 embargo_id)
-    end;
-    Message.to_message m
-  | `Disembargo_reply (target, embargo_id) ->
-    let m = Message.init_root () in
-    let dis = Message.disembargo_init m in
-    let ctx = Disembargo.context_init dis in
-    set_target (Disembargo.target_init dis) target;
-    Disembargo.Context.receiver_loopback_set ctx (EmbargoId.uint32 embargo_id);
-    Message.to_message m
-  | `Return (aid, return, release) ->
-    let ret =
-      match return with
-      | `Results (msg, descs) ->
-        (* [msg] has payload filled in, but nothing else. *)
-        let ret = Msg.Response.writable msg in
-        write_caps_array descs (results_of_return ret);
-        ret
-      | `Exception ex ->
-        let m = Message.init_root () in
-        let ret = Message.return_init m in
-        write_exn (Return.exception_init ret) ex;
-        ret
-      | `Cancelled ->
-        let m = Message.init_root () in
-        let ret = Message.return_init m in
-        Return.canceled_set ret;
-        ret
-      | `ResultsSentElsewhere ->
-        let m = Message.init_root () in
-        let ret = Message.return_init m in
-        Return.results_sent_elsewhere_set ret;
-        ret
-      | `TakeFromOtherQuestion qid ->
-        let m = Message.init_root () in
-        let ret = Message.return_init m in
-        Return.take_from_other_question_set ret (QuestionId.uint32 qid);
-        ret
-      | `AcceptFromThirdParty ->
-        failwith "TODO: AcceptFromThirdParty"
+  let write_exn b ex =
+    let open Builder.Exception in
+    let ty =
+      match ex.Capnp_rpc.Exception.ty with
+      | `Failed        -> Type.Failed
+      | `Overloaded    -> Type.Overloaded
+      | `Disconnected  -> Type.Disconnected
+      | `Unimplemented -> Type.Unimplemented
+      | `Undefined x   -> Type.Undefined x
     in
-    Return.answer_id_set ret (AnswerId.uint32 aid);
-    Return.release_param_caps_set ret release;
-    Return.to_message ret
-  | `Resolve (id, new_target) ->
-    let m = Message.init_root () in
-    let r = Message.resolve_init m in
-    begin match new_target with
-      | Ok cap -> write_cap (Resolve.cap_init r) cap
-      | Error e -> write_exn (Resolve.exception_init r) e
-    end;
-    Resolve.promise_id_set r (ExportId.uint32 id);
-    Message.to_message m
+    type_set b ty;
+    reason_set b ex.Capnp_rpc.Exception.reason
+
+  let message : EP.Out.t -> _ =
+    let open Builder in
+    function
+    | `Abort ex ->
+      let b = Message.init_root () in
+      write_exn (Message.abort_init b) ex;
+      Message.to_message b
+    | `Bootstrap qid ->
+      let b = Message.init_root () in
+      let boot = Message.bootstrap_init b in
+      Bootstrap.question_id_set boot (QuestionId.uint32 qid);
+      Message.to_message b
+    | `Call (qid, target, request, descs, results_to) ->
+      let c = Msg.Request.writable request in
+      Call.question_id_set c (QuestionId.uint32 qid);
+      set_target (Call.target_init c) target;
+      let p = Call.params_get c in
+      write_caps_array descs p;
+      let dest = Call.send_results_to_init c in
+      begin match results_to with
+        | `Caller -> Call.SendResultsTo.caller_set dest
+        | `Yourself -> Call.SendResultsTo.yourself_set dest
+        | `ThirdParty _ -> failwith "TODO: send_results_to ThirdParty"
+      end;
+      Call.to_message c
+    | `Finish (qid, release_result_caps) ->
+      let b = Message.init_root () in
+      let fin = Message.finish_init b in
+      Finish.question_id_set fin (QuestionId.uint32 qid);
+      Finish.release_result_caps_set fin release_result_caps;
+      Message.to_message b
+    | `Release (id, count) ->
+      let m = Message.init_root () in
+      let rel = Message.release_init m in
+      Release.id_set rel (ImportId.uint32 id);
+      Release.reference_count_set_int_exn rel count;
+      Message.to_message m
+    | `Disembargo_request disembargo_request ->
+      let m = Message.init_root () in
+      let dis = Message.disembargo_init m in
+      let ctx = Disembargo.context_init dis in
+      begin match disembargo_request with
+        | `Loopback (old_path, embargo_id) ->
+          set_target (Disembargo.target_init dis) old_path;
+          Disembargo.Context.sender_loopback_set ctx (EmbargoId.uint32 embargo_id)
+      end;
+      Message.to_message m
+    | `Disembargo_reply (target, embargo_id) ->
+      let m = Message.init_root () in
+      let dis = Message.disembargo_init m in
+      let ctx = Disembargo.context_init dis in
+      set_target (Disembargo.target_init dis) target;
+      Disembargo.Context.receiver_loopback_set ctx (EmbargoId.uint32 embargo_id);
+      Message.to_message m
+    | `Return (aid, return, release) ->
+      let ret =
+        match return with
+        | `Results (msg, descs) ->
+          (* [msg] has payload filled in, but nothing else. *)
+          let ret = Msg.Response.writable msg in
+          write_caps_array descs (results_of_return ret);
+          ret
+        | `Exception ex ->
+          let m = Message.init_root () in
+          let ret = Message.return_init m in
+          write_exn (Return.exception_init ret) ex;
+          ret
+        | `Cancelled ->
+          let m = Message.init_root () in
+          let ret = Message.return_init m in
+          Return.canceled_set ret;
+          ret
+        | `ResultsSentElsewhere ->
+          let m = Message.init_root () in
+          let ret = Message.return_init m in
+          Return.results_sent_elsewhere_set ret;
+          ret
+        | `TakeFromOtherQuestion qid ->
+          let m = Message.init_root () in
+          let ret = Message.return_init m in
+          Return.take_from_other_question_set ret (QuestionId.uint32 qid);
+          ret
+        | `AcceptFromThirdParty ->
+          failwith "TODO: AcceptFromThirdParty"
+      in
+      Return.answer_id_set ret (AnswerId.uint32 aid);
+      Return.release_param_caps_set ret release;
+      Return.to_message ret
+    | `Resolve (id, new_target) ->
+      let m = Message.init_root () in
+      let r = Message.resolve_init m in
+      begin match new_target with
+        | Ok cap -> write_cap (Resolve.cap_init r) cap
+        | Error e -> write_exn (Resolve.exception_init r) e
+      end;
+      Resolve.promise_id_set r (ExportId.uint32 id);
+      Message.to_message m
+end

--- a/capnp-rpc-lwt/serialise.mli
+++ b/capnp-rpc-lwt/serialise.mli
@@ -1,1 +1,3 @@
-val message : Capnp_core.Endpoint_types.Out.t -> Rpc_schema.rw Schema.message_t
+module Make (EP : Capnp_core.ENDPOINT) : sig
+  val message : EP.Out.t -> Rpc_schema.rw Schema.message_t
+end

--- a/capnp-rpc-lwt/two_party_network.ml
+++ b/capnp-rpc-lwt/two_party_network.ml
@@ -1,0 +1,11 @@
+(** A network where the is only one other addressable party. *)
+
+module Types = struct
+  type sturdy_ref
+  type provision_id
+  type recipient_id
+  type third_party_cap_id = [`Two_party_only]
+  type join_key_part
+end
+
+let parse_third_party_cap_id _ = `Two_party_only

--- a/capnp-rpc-lwt/vat.ml
+++ b/capnp-rpc-lwt/vat.ml
@@ -1,32 +1,38 @@
 open Capnp_core
 open Lwt.Infix
 
-type t = {
-  switch : Lwt_switch.t option;
-  mutable bootstrap : Core_types.cap option;
-  mutable connections : CapTP_capnp.t list; (* todo: should be a map, once we have Vat IDs *)
-}
+module Make (Network : Capnp_core.NETWORK) = struct
 
-let create ?switch ?bootstrap () =
-  let t = {
-    switch;
-    bootstrap;
-    connections = [];
-  } in
-  Lwt_switch.add_hook switch (fun () ->
-      begin match t.bootstrap with
-        | Some x -> Core_types.dec_ref x; t.bootstrap <- None
-        | None -> ()
-      end;
-      let ex = Capnp_rpc.Exception.v ~ty:`Disconnected "Vat shut down" in
-      Lwt_list.iter_p (fun c -> CapTP_capnp.disconnect c ex) t.connections >|= fun () ->
-      t.connections <- []
-    );
-  t
+  module CapTP = CapTP_capnp.Make (Network)
 
-let connect t endpoint =
-  let switch = Lwt_switch.create () in
-  Lwt_switch.add_hook t.switch (fun () -> Lwt_switch.turn_off switch);
-  let conn = CapTP_capnp.connect ~switch ?offer:t.bootstrap endpoint in
-  t.connections <- conn :: t.connections;
-  conn
+  type t = {
+    switch : Lwt_switch.t option;
+    mutable bootstrap : Core_types.cap option;
+    mutable connections : CapTP.t list; (* todo: should be a map, once we have Vat IDs *)
+  }
+
+  let create ?switch ?bootstrap () =
+    let t = {
+      switch;
+      bootstrap;
+      connections = [];
+    } in
+    Lwt_switch.add_hook switch (fun () ->
+        begin match t.bootstrap with
+          | Some x -> Core_types.dec_ref x; t.bootstrap <- None
+          | None -> ()
+        end;
+        let ex = Capnp_rpc.Exception.v ~ty:`Disconnected "Vat shut down" in
+        Lwt_list.iter_p (fun c -> CapTP.disconnect c ex) t.connections >|= fun () ->
+        t.connections <- []
+      );
+    t
+
+  let connect t endpoint =
+    let switch = Lwt_switch.create () in
+    Lwt_switch.add_hook t.switch (fun () -> Lwt_switch.turn_off switch);
+    let conn = CapTP.connect ~switch ?offer:t.bootstrap endpoint in
+    t.connections <- conn :: t.connections;
+    conn
+
+end

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -292,10 +292,6 @@ module type CORE_TYPES = sig
 end
 
 module type NETWORK_TYPES = sig
-  (**  Extends the core types with types related to networking. *)
-
-  include CORE_TYPES
-
   (* These depend on the particular network details. *)
   type sturdy_ref
   type provision_id
@@ -303,4 +299,3 @@ module type NETWORK_TYPES = sig
   type third_party_cap_id
   type join_key_part
 end
-

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -161,8 +161,9 @@ module Msg = struct
 
 end
 
-module Core_types = struct
-  include Capnp_rpc.Core_types(Msg)
+module Core_types = Capnp_rpc.Core_types(Msg)
+
+module Network_types = struct
   type sturdy_ref
   type provision_id
   type recipient_id
@@ -172,19 +173,13 @@ end
 
 module Local_struct_promise = Capnp_rpc.Local_struct_promise.Make(Core_types)
 
-module EP = struct
-  module Core_types = Core_types
-
-  module Table = struct
-    module QuestionId = Capnp_rpc.Id.Make ( )
-    module AnswerId = QuestionId
-    module ImportId = Capnp_rpc.Id.Make ( )
-    module ExportId = ImportId
-  end
-
-  module Out = Capnp_rpc.Message_types.Make(Core_types)(Table)
-  module In = Capnp_rpc.Message_types.Make(Core_types)(Table)
+module Table_types = struct
+  module QuestionId = Capnp_rpc.Id.Make ( )
+  module AnswerId = QuestionId
+  module ImportId = Capnp_rpc.Id.Make ( )
+  module ExportId = ImportId
 end
+module EP = Capnp_rpc.Message_types.Endpoint(Core_types)(Network_types)(Table_types)
 
 module Endpoint = struct
   module Conn = Capnp_rpc.CapTP.Make(EP)

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -4,6 +4,9 @@ open Capnp_rpc_lwt
 
 module Test_utils = Testbed.Test_utils
 
+module Networking = Capnp_rpc_lwt.Networking (Capnp_rpc_lwt.Two_party_network)
+module CapTP = Networking.CapTP
+
 type cs = {
   client : CapTP.t;
   server : CapTP.t;

--- a/test/testbed/capnp_direct.ml
+++ b/test/testbed/capnp_direct.ml
@@ -47,9 +47,9 @@ module String_content = struct
     incr ref_leaks
 end
 
-module Core_types = struct
-  include Capnp_rpc.Core_types(String_content)
+module Core_types = Capnp_rpc.Core_types(String_content)
 
+module Network_types = struct
   type sturdy_ref
   type provision_id
   type recipient_id
@@ -58,7 +58,8 @@ module Core_types = struct
 end
 
 module type ENDPOINT = Capnp_rpc.Message_types.ENDPOINT with
-  module Core_types = Core_types
+  module Core_types = Core_types and
+  module Network_types = Network_types
 
 module Local_struct_promise = Capnp_rpc.Local_struct_promise.Make(Core_types)
 module Cap_proxy = Capnp_rpc.Cap_proxy.Make(Core_types)

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -132,9 +132,11 @@ module Endpoint (EP : Capnp_direct.ENDPOINT) = struct
 end
 
 module Pair ( ) = struct
-  module ProtoC = Capnp_rpc.Message_types.Endpoint(Capnp_direct.Core_types) ( )
+  module Table_types = Capnp_rpc.Message_types.Table_types ( )
+  module ProtoC = Capnp_rpc.Message_types.Endpoint(Capnp_direct.Core_types)(Capnp_direct.Network_types)(Table_types)
   module ProtoS = struct
     module Core_types = Capnp_direct.Core_types
+    module Network_types = Capnp_direct.Network_types
     module Table = Capnp_rpc.Message_types.Flip(ProtoC.Table)
     module In = ProtoC.Out
     module Out = ProtoC.In


### PR DESCRIPTION
It should be possible to use capnp-rpc-lwt with different network types (or even several at the same time).