### PR TITLE
Add TCP, encryption and authentication

### DIFF
--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -18,6 +18,11 @@ depends: [
   "logs"
   "asetmap"
   "mirage-flow-lwt"
+  "tls"
+  "mirage-kv-lwt"
+  "mirage-clock"
+  "base64"
+  "uri"
   "jbuilder" {build & >= "1.0+beta10" }
   "alcotest" {test}
 ]

--- a/capnp-rpc-lwt/auth.ml
+++ b/capnp-rpc-lwt/auth.ml
@@ -1,0 +1,140 @@
+module Log = Capnp_rpc.Debug.Log
+
+let default_rsa_key_bits = 2048
+let default_hash = `SHA256
+
+type hash = [`SHA1 | `SHA224 | `SHA256 | `SHA384 | `SHA512]
+
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
+
+let ( >>= ) x f =
+  match x with
+  | Ok y -> f y
+  | Error _ as e -> e
+
+module Digest = struct
+  type t = [`Insecure | `Fingerprint of hash * string]
+
+  let equal = ( = )
+
+  let insecure = `Insecure
+
+  let alphabet = B64.uri_safe_alphabet
+
+  let string_of_hash = function
+    | `SHA1   -> "sha-1"
+    | `SHA224 -> "sha-224"
+    | `SHA256 -> "sha-256"
+    | `SHA384 -> "sha-384"
+    | `SHA512 -> "sha-512"
+
+  let parse_hash = function
+    | "sha-1"   -> Ok `SHA1
+    | "sha-224" -> Ok `SHA224
+    | "sha-256" -> Ok `SHA256
+    | "sha-384" -> Ok `SHA384
+    | "sha-512" -> Ok `SHA512
+    | x -> error "Unknown hash type %S" x
+
+  let parse_digest s =
+    try Ok (B64.decode ~alphabet s)
+    with ex -> error "Bad base64 digest %S: %a" s Fmt.exn ex
+
+  let parse hash digest =
+    parse_hash hash >>= fun hash ->
+    parse_digest digest >>= fun digest ->
+    Ok (hash, digest)
+
+  let add_to_uri t uri =
+    match t with
+    | `Insecure -> Uri.with_userinfo uri (Some "insecure")
+    | `Fingerprint (hash, digest) ->
+      let hash = string_of_hash hash in
+      let digest = B64.encode ~alphabet ~pad:false digest in
+      let uri = Uri.with_userinfo uri (Some hash) in
+      Uri.with_password uri (Some digest)
+
+  let pp f = function
+    | `Insecure -> Fmt.string f "insecure"
+    | `Fingerprint (hash, digest) -> Fmt.pf f "%s@%s" (string_of_hash hash) (B64.encode ~alphabet ~pad:false digest)
+
+  let from_uri uri =
+    let hash_type = Uri.user uri in
+    let digest = Uri.password uri in
+    match hash_type, digest with
+    | Some "insecure", None -> Ok `Insecure
+    | Some hash, Some digest ->
+      parse hash digest >>= fun digest ->
+      Ok (`Fingerprint digest)
+    | None, _ -> Error (`Msg "Missing digest hash type (e.g. '...://sha256:...')")
+    | Some _, None -> Error (`Msg "Missing digest value (e.g. '...://sha256:DIGEST@...' or '...://insecure@...')")
+
+  let authenticator = function
+    | `Insecure -> None
+    | `Fingerprint (hash, digest) ->
+      let hash = (hash :> Nocrypto.Hash.hash) in
+      (* todo: [server_key_fingerprint] insists on checking the DN, so this must match
+         the one in [Secret_key.x509]. Maybe we should make our own authenticator in case
+         other implementations use other names. *)
+      let fingerprints = ["capnp", Cstruct.of_string digest] in
+      Some (X509.Authenticator.server_key_fingerprint ~hash ~fingerprints ?time:None)
+end
+
+module Secret_key = struct
+  type t = {
+    priv : Nocrypto.Rsa.priv;
+    tls_config : Tls.Config.server;
+  }
+
+  let equal a b = a.priv = b.priv
+
+  let tls_config t = t.tls_config
+
+  let digest ?(hash=default_hash) t =
+    let nc_hash = (hash :> Nocrypto.Hash.hash) in
+    let pub = Nocrypto.Rsa.pub_of_priv t.priv in
+    let value = X509.key_fingerprint ~hash:nc_hash (`RSA pub) |> Cstruct.to_string in
+    `Fingerprint (hash, value)
+
+  let pp_fingerprint hash f t =
+    Digest.pp f (digest ~hash t)
+
+  let x509 t =
+    let dn = [`CN "capnp"] in
+    let csr = X509.CA.request dn (`RSA t) in
+    let valid_from = { Asn.Time.
+                       date = (1970, 1, 1);
+                       time = (1, 1, 1, 0.);
+                       tz = None;
+                     } in
+    (* RFC 5280 says expiration date should be GeneralizedTime value 99991231235959Z *)
+    let valid_until = { Asn.Time.
+                        date = (9999, 12, 31);
+                        time = (23, 59, 59, 0.);
+                        tz = None;
+                      } in
+    X509.CA.sign csr ~valid_from ~valid_until (`RSA t) dn
+
+  let of_priv priv =
+    let cert = x509 priv in
+    let certificates = `Single ([cert], priv) in
+    let tls_config = Tls.Config.server ~certificates () in
+    { priv; tls_config }
+
+  let generate () =
+    Log.info (fun f -> f "Generating new private key...");
+    let priv = Nocrypto.Rsa.generate default_rsa_key_bits in
+    let t = of_priv priv in
+    Log.info (fun f -> f "Generated key with hash %a" (pp_fingerprint `SHA256) t);
+    t
+
+  let of_pem_data data =
+    match X509.Encoding.Pem.Private_key.of_pem_cstruct1 (Cstruct.of_string data) with
+    | `RSA priv -> of_priv priv
+
+  let to_pem_data t =
+    X509.Encoding.Pem.Private_key.to_pem_cstruct1 (`RSA t.priv) |> Cstruct.to_string
+end
+

--- a/capnp-rpc-lwt/auth.mli
+++ b/capnp-rpc-lwt/auth.mli
@@ -1,0 +1,69 @@
+(** Vat-level authentication and encryption.
+
+    Unless your network provides a secure mechanism for establishing connections
+    to other vats, where you can be sure of the identity of the other party,
+    you'll probably want to enable cryptographic security.
+
+    Each vat (application instance) should generate a secret key when it is first
+    deployed. For servers at least, this key must be saved to disk so that the
+    server retains its identity over re-starts. Otherwise, clients will think it
+    is an imposter and refuse to connect.
+
+    Clients that do not accept incoming connections, nor create SturdyRefs, can
+    get away with creating a new key each time. However, it might be quicker
+    to save and reload the key anyway. *)
+
+type hash = [`SHA1 | `SHA224 | `SHA256 | `SHA384 | `SHA512]
+
+module Digest : sig
+  type t
+  (** The digest of a public key, used to recognise a vat.
+      This appears in URIs as e.g. 'capnp://sha256:1234@host/'. *)
+
+  val insecure : t
+  (** A special value indicating no authentication should be performed. *)
+
+  val from_uri : Uri.t -> (t, [> `Msg of string]) result
+  (** [from_uri t] is the parsed digest information in [t]. *)
+
+  val add_to_uri : t -> Uri.t -> Uri.t
+  (** [add_to_uri t uri] is [uri] with the [user] and [password] fields set
+      to the correct values for [t]. Note that although we use the "password" field,
+      this is not secret. *)
+
+  val authenticator : t -> X509_lwt.authenticator option
+  (** [authenticator t] is an authenticator that checks that the peer's public key
+      matches [t]. Returns [None] if [t] is [insecure].
+      Note: it currently also requires the DN field to be "capnp". *)
+
+  val equal : t -> t -> bool
+
+  val pp : t Fmt.t
+end
+
+module Secret_key : sig
+  type t
+  (** A vat's [secret_key] allows it to prove its identity to other vats. *)
+
+  val generate : unit -> t
+  (** [generate ()] is a fresh secret key.
+      You must call [Nocrypto_entropy_lwt.initialize] before using this (it will give an
+      error if you forget). *)
+
+  val digest : ?hash:hash -> t -> Digest.t
+  (** [digest ~hash t] is the digest of [t]'s public key, using [hash]. *)
+
+  val of_pem_data : string -> t
+  (** [of_pem_data data] parses [data] as a PEM-encoded private key. *)
+
+  val to_pem_data : t -> string
+  (** [to_pem_data t] returns [t] as a PEM-encoded private key. *)
+
+  val tls_config : t -> Tls.Config.server
+  (** [tls_config t] is the TLS configuration to use for a server with secret key [t]. *)
+
+  val pp_fingerprint : hash -> t Fmt.t
+  (** [pp_fingerprint hash] formats the hash of [t]'s public key. *)
+
+  val equal : t -> t -> bool
+end

--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -7,7 +7,7 @@ module Reader = Schema.Reader
 
 module Table_types = Capnp_rpc.Message_types.Table_types ( )
 
-module Make (Network : Capnp_core.NETWORK) = struct
+module Make (Network : S.NETWORK) = struct
   module Endpoint_types = Capnp_rpc.Message_types.Endpoint(Capnp_core.Core_types)(Network.Types)(Table_types)
   module Conn = Capnp_rpc.CapTP.Make(Endpoint_types)
   module Parse = Parse.Make(Endpoint_types)(Network)

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -2,7 +2,7 @@
 
 open Capnp_core.Core_types
 
-module Make (N : Capnp_core.NETWORK) : sig
+module Make (N : S.NETWORK) : sig
   type t
   (** A Cap'n Proto RPC protocol handler. *)
 

--- a/capnp-rpc-lwt/capnp_core.ml
+++ b/capnp-rpc-lwt/capnp_core.ml
@@ -16,11 +16,5 @@ module Core_types = Capnp_rpc.Core_types(Capnp_content)
 module Local_struct_promise = Capnp_rpc.Local_struct_promise.Make(Core_types)
 module Cap_proxy = Capnp_rpc.Cap_proxy.Make(Core_types)
 
-module type NETWORK = sig
-  module Types : Capnp_rpc.S.NETWORK_TYPES
-
-  val parse_third_party_cap_id : Schema.Reader.pointer_t -> Types.third_party_cap_id
-end
-
 module type ENDPOINT = Capnp_rpc.Message_types.ENDPOINT with
   module Core_types = Core_types

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -140,12 +140,15 @@ module Endpoint = Endpoint
 
 module S = S
 
-module Networking (N : S.NETWORK) = struct
+module Networking (N : S.NETWORK) (F : Mirage_flow_lwt.S) = struct
+  type flow = F.flow
   type 'a capability = 'a Capability.t
 
   module Network = N
-  module Vat = Vat.Make (N)
+  module Vat = Vat.Make (N) (F)
+  module Sturdy_ref = Vat.Sturdy_ref
   module CapTP = Vat.CapTP
 end
 
 module Two_party_network = Two_party_network
+module Auth = Auth

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -138,9 +138,12 @@ end
 module Service = Service
 module Endpoint = Endpoint
 
-module type NETWORK = Capnp_core.NETWORK
+module S = S
 
-module Networking (N : NETWORK) = struct
+module Networking (N : S.NETWORK) = struct
+  type 'a capability = 'a Capability.t
+
+  module Network = N
   module Vat = Vat.Make (N)
   module CapTP = Vat.CapTP
 end

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -32,7 +32,7 @@ module Capability : sig
       You can invoke methods on a capability even while it is still only a
       promise. *)
 
-  type 'a t
+  type +'a t
   (** An ['a t] is a capability reference to a service of type ['a]. *)
 
   val problem : 'a t -> Capnp_rpc.Exception.t option
@@ -176,12 +176,13 @@ end
 module S = S
 
 module Endpoint = Endpoint
-
-module Networking (N : S.NETWORK) : S.VAT_NETWORK
-  with module Network = N and
-       type 'a capability = 'a Capability.t
-
 module Two_party_network = Two_party_network
+module Auth = Auth
+
+module Networking (N : S.NETWORK) (Flow : Mirage_flow_lwt.S) : S.VAT_NETWORK
+  with module Network = N and
+       type flow = Flow.flow and
+       type 'a capability = 'a Capability.t
 
 (**/**)
 

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -173,58 +173,13 @@ module Service : sig
   (** [fail msg] is an exception with reason [msg]. *)
 end
 
-module type NETWORK = Capnp_core.NETWORK
+module S = S
 
 module Endpoint = Endpoint
 
-module Networking (N : NETWORK) : sig
-  (** Stretching capability references across a network link.
-      Note: see {!module:Capnp_rpc_unix} for a higher-level wrapper for this API. *)
-
-  module CapTP : sig
-    (** Sharing capabilities over a network link. *)
-
-    type t
-    (** A CapTP connection to a remote peer. *)
-
-    val connect : ?offer:'a Capability.t -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
-    (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
-        receives messages using [endpoint].
-        If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
-        If the connection fails then [switch] will be turned off, and turning off the switch
-        will release all resources used by the connection. *)
-
-    val bootstrap : t -> 'a Capability.t
-    (** [bootstrap t] is the peer's public bootstrap object, if any. *)
-
-    val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
-    (** [disconnect reason] closes the connection, sending [reason] to the peer to explain why.
-        Capabilities and questions at both ends will break, with [reason] as the problem. *)
-
-    val dump : t Fmt.t
-    (** [dump] dumps the state of the connection, for debugging. *)
-  end
-
-  module Vat : sig
-    (** An actor in the CapTP network.
-        A vat is a collection of objects that can call each other directly.
-        A vat may be connected to other vats over CapTP network connections.
-        Typically an application will create only a single vat.
-        See the {!module:Capnp_rpc_unix} module for a higher-level API. *)
-
-    type t
-    (** A local vat. *)
-
-    val create : ?switch:Lwt_switch.t -> ?bootstrap:'a Capability.t -> unit -> t
-    (** [create ~switch ~bootstrap ()] is a new vat that offers [bootstrap] to its peers.
-        The vat takes ownership of [bootstrap], and will release it when the switch is turned off.
-        Turning off the switch will also disconnect any active connections. *)
-
-    val connect : t -> Endpoint.t -> CapTP.t
-    (** [connect t endpoint] runs the CapTP protocol over [endpoint], which is a
-        connection to another vat. *)
-  end
-end
+module Networking (N : S.NETWORK) : S.VAT_NETWORK
+  with module Network = N and
+       type 'a capability = 'a Capability.t
 
 module Two_party_network = Two_party_network
 

--- a/capnp-rpc-lwt/jbuild
+++ b/capnp-rpc-lwt/jbuild
@@ -5,7 +5,7 @@
   (public_name capnp-rpc-lwt)
   (ocamlc_flags (:standard -w -55-53))
   (ocamlopt_flags (:standard -w -55-53))
-  (libraries (astring capnp capnp-rpc fmt logs mirage-flow-lwt))
+  (libraries (astring capnp capnp-rpc fmt logs mirage-flow-lwt nocrypto.lwt tls.mirage base64 uri))
 ))
 
 (rule

--- a/capnp-rpc-lwt/parse.ml
+++ b/capnp-rpc-lwt/parse.ml
@@ -6,7 +6,7 @@ module Log = Capnp_rpc.Debug.Log
 (* A parser for the basic messages (excluding Unimplemented, which has a more complicated type). *)
 module Make_basic
     (Core_types : Capnp_rpc.S.CORE_TYPES)
-    (Network : Capnp_core.NETWORK)
+    (Network : S.NETWORK)
     (T : Capnp_rpc.Message_types.TABLE_TYPES) = struct
   module Message_types = Capnp_rpc.Message_types.Make(Core_types)(Network.Types)(T)
   open Message_types
@@ -165,7 +165,7 @@ end
 
 module Make
     (EP : Capnp_core.ENDPOINT)
-    (Network : Capnp_core.NETWORK with module Types = EP.Network_types)
+    (Network : S.NETWORK with module Types = EP.Network_types)
 = struct
   module Parse_in = Make_basic(EP.Core_types)(Network)(EP.Table)
   module Parse_out = Make_basic(EP.Core_types)(Network)(Capnp_rpc.Message_types.Flip(EP.Table))

--- a/capnp-rpc-lwt/parse.mli
+++ b/capnp-rpc-lwt/parse.mli
@@ -1,6 +1,6 @@
 (** Parsing of Cap'n Proto RPC messages received from a remote peer. *)
 
-module Make (EP : Capnp_core.ENDPOINT) (Network : Capnp_core.NETWORK with module Types = EP.Network_types) : sig
+module Make (EP : Capnp_core.ENDPOINT) (Network : S.NETWORK with module Types = EP.Network_types) : sig
   val message :
     Schema.Reader.Message.t ->
     [ EP.In.t

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -1,0 +1,59 @@
+module type NETWORK = sig
+  module Types : Capnp_rpc.S.NETWORK_TYPES
+
+  val parse_third_party_cap_id : Schema.Reader.pointer_t -> Types.third_party_cap_id
+end
+
+module type VAT_NETWORK = sig
+  (** Stretching capability references across a network link.
+      Note: see {!module:Capnp_rpc_unix} for a higher-level wrapper for this API. *)
+
+  type 'a capability
+  (** An ['a capability] is a capability reference to a service of type ['a]. *)
+
+  module Network : NETWORK
+
+  module CapTP : sig
+    (** Sharing capabilities over a network link. *)
+
+    type t
+    (** A CapTP connection to a remote peer. *)
+
+    val connect : ?offer:'a capability -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+    (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
+        receives messages using [endpoint].
+        If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
+        If the connection fails then [switch] will be turned off, and turning off the switch
+        will release all resources used by the connection. *)
+
+    val bootstrap : t -> 'a capability
+    (** [bootstrap t] is the peer's public bootstrap object, if any. *)
+
+    val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
+    (** [disconnect reason] closes the connection, sending [reason] to the peer to explain why.
+        Capabilities and questions at both ends will break, with [reason] as the problem. *)
+
+    val dump : t Fmt.t
+    (** [dump] dumps the state of the connection, for debugging. *)
+  end
+
+  module Vat : sig
+    (** An actor in the CapTP network.
+        A vat is a collection of objects that can call each other directly.
+        A vat may be connected to other vats over CapTP network connections.
+        Typically an application will create only a single vat.
+        See the {!module:Capnp_rpc_unix} module for a higher-level API. *)
+
+    type t
+    (** A local vat. *)
+
+    val create : ?switch:Lwt_switch.t -> ?bootstrap:'a capability -> unit -> t
+    (** [create ~switch ~bootstrap ()] is a new vat that offers [bootstrap] to its peers.
+        The vat takes ownership of [bootstrap], and will release it when the switch is turned off.
+        Turning off the switch will also disconnect any active connections. *)
+
+    val connect : t -> Endpoint.t -> CapTP.t
+    (** [connect t endpoint] runs the CapTP protocol over [endpoint], which is a
+        connection to another vat. *)
+  end
+end

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -1,9 +1,22 @@
+(** Module signatures. *)
+
 module type NETWORK = sig
   module Types : Capnp_rpc.S.NETWORK_TYPES
 
   module Address : sig
     type t
     (** A network address at which a vat can be reached. *)
+
+    val parse_uri : Uri.t -> (t, [> `Msg of string]) result
+    (** [parse_uri uri] extracts from a URI the network address.
+        It may use the scheme, host, port and path fields.
+        It may not use the user, password or query fields. *)
+
+    val to_uri : t -> Uri.t
+
+    val equal : t -> t -> bool
+
+    val pp : t Fmt.t
   end
 
   val parse_third_party_cap_id : Schema.Reader.pointer_t -> Types.third_party_cap_id
@@ -16,7 +29,64 @@ module type VAT_NETWORK = sig
   type 'a capability
   (** An ['a capability] is a capability reference to a service of type ['a]. *)
 
+  type flow
+  (** A bi-directional byte-stream. *)
+
   module Network : NETWORK
+
+  module Sturdy_ref : sig
+    (** An off-line reference to a capability.
+
+        A sturdy ref contains all the information necessary to get a live reference to the capability:
+
+        - The network address of the hosting vat (e.g. TCP host and port)
+        - A way to authenticate the hosting vat (e.g. a fingerprint of the vat's public key)
+        - A way to identify the target service within the vat and prove access to it (e.g. a Swiss number)
+
+        Note that a sturdy ref often contains secrets.
+      *)
+
+    type service = [
+      | `Bootstrap
+    ]
+    (** Identifies a service within the hosting vat.
+        todo: other targets *)
+
+    type +'a t
+    (** A persistent capability reference that can be restored after contact to the target vat is interrupted. *)
+
+    val v : auth:Auth.Digest.t -> address:Network.Address.t -> service:service -> 'a t
+    (** Create a new sturdy ref. *)
+
+    val address : 'a t -> Network.Address.t
+    (** Where to connect to access this service's vat. *)
+
+    val auth : 'a t -> Auth.Digest.t
+    (** How to check that the server is genuine. *)
+
+    val service : 'a t -> service
+    (** Which service within the vat to select. *)
+
+    val cast : _ t -> _ t
+    (** Treat this as a reference to service with a different type. *)
+
+    val of_uri : Uri.t -> ('a t, [> `Msg of string]) result
+    (** [of_uri x] constructs a sturdy ref from a URI of the form "capnp://AUTH@...".
+        AUTH is HASH-TYPE@DIGEST for connections using TLS, or "insecure" for connections without.
+        The rest of the URI is parsed using [Network.Address.parse_uri]. *)
+
+    val to_uri_with_secrets : 'a t -> Uri.t
+    (** [to_uri_with_secrets t] is a "capnp://" URI which can be converted back to [t] using [of_uri]. *)
+
+    val pp_with_secrets : 'a t Fmt.t
+    (** [pp_with_secrets] formats a sturdy ref as a URI, including any secret tokens. *)
+
+    val pp_address : 'a t Fmt.t
+    (** [pp_address] formats just the (public) address part of a [t]. *)
+
+    val equal : 'a t -> 'a t -> bool
+    (** [equal a b] is [true] iff [a] and [b] have the same address, server fingerprint and service. *)
+  end
 
   module CapTP : sig
     (** Sharing capabilities over a network link. *)
@@ -52,13 +122,51 @@ module type VAT_NETWORK = sig
     type t
     (** A local vat. *)
 
-    val create : ?switch:Lwt_switch.t -> ?bootstrap:'a capability -> unit -> t
-    (** [create ~switch ~bootstrap ()] is a new vat that offers [bootstrap] to its peers.
+    val create :
+      ?switch:Lwt_switch.t ->
+      ?secret_key:Auth.Secret_key.t ->
+      ?bootstrap:'a capability ->
+      ?address:Network.Address.t ->
+      unit -> t
+    (** [create ~switch ~secret_key ~bootstrap ~address ()] is a new vat that offers [bootstrap] to its peers.
+        [secret_key] is used to prove the vat's identity to peers. If [None], TLS cannot be used.
+        The vat will suggest other parties connect to it using [address].
         The vat takes ownership of [bootstrap], and will release it when the switch is turned off.
         Turning off the switch will also disconnect any active connections. *)
 
     val connect : t -> Endpoint.t -> CapTP.t
     (** [connect t endpoint] runs the CapTP protocol over [endpoint], which is a
         connection to another vat. *)
+
+    val public_fingerprint : t -> Auth.Digest.t
+    (** [public_fingerprint t] is the digest that peers should use when connecting
+        to this vat to authenticate it. *)
+
+    val bootstrap_ref : t -> 'a Sturdy_ref.t
+    (** [bootstrap_ref t] is a sturdy ref that can be used to connect to the
+        vat's bootstrap object. Fails if this vat does not accept incoming
+        connections. *)
+
+    val pp_bootstrap_uri : t Fmt.t
+    (** [pp_bootstrap_uri] formats [bootstrap_ref] as a URI that clients can use
+        (or formats a message explaining why there isn't one). *)
+
+    val connect_as_client :
+      switch:Lwt_switch.t ->
+      t ->
+      Auth.Digest.t ->
+      flow ->
+      (CapTP.t, [> `Msg of string ]) result Lwt.t
+    (** [connect_as_client ~switch t auth flow] performs a TLS client handshake and
+        authentication check on [flow] (if [auth] requires it) and returns the
+        resulting connection. *)
+
+    val connect_as_server :
+      switch:Lwt_switch.t ->
+      t ->
+      flow ->
+      (CapTP.t, [> `Msg of string ]) result Lwt.t
+    (** [connect_as_server ~switch t flow] performs a TLS server handshake on [flow]
+        (if encryption is on) and returns the resulting connection. *)
   end
 end

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -1,6 +1,11 @@
 module type NETWORK = sig
   module Types : Capnp_rpc.S.NETWORK_TYPES
 
+  module Address : sig
+    type t
+    (** A network address at which a vat can be reached. *)
+  end
+
   val parse_third_party_cap_id : Schema.Reader.pointer_t -> Types.third_party_cap_id
 end
 

--- a/capnp-rpc-lwt/sturdy_ref.ml
+++ b/capnp-rpc-lwt/sturdy_ref.ml
@@ -1,0 +1,53 @@
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
+
+let ( >>= ) x f =
+  match x with
+  | Ok y -> f y
+  | Error _ as e -> e
+
+module Make (N : S.NETWORK) = struct
+  type service = [
+    | `Bootstrap
+  ]
+
+  type 'a t = {
+    address : N.Address.t;
+    auth : Auth.Digest.t;
+    service : service;
+  }
+
+  let v ~auth ~address ~service = {auth; address; service}
+
+  let equal {address; auth; service} b =
+    N.Address.equal address b.address &&
+    Auth.Digest.equal auth b.auth &&
+    service = b.service
+
+  let address t = t.address
+  let auth t = t.auth
+  let service t = t.service
+  let cast t = (t :> _ t)
+
+  let to_uri_with_secrets {address; auth; service = `Bootstrap} =
+    N.Address.to_uri address |> Auth.Digest.add_to_uri auth
+
+  let pp_with_secrets f t = Uri.pp_hum f (to_uri_with_secrets t)
+
+  let pp_address f t =
+    Fmt.pf f "<SturdyRef at %a>" N.Address.pp t.address
+
+  let parse_capnp_uri uri =
+    N.Address.parse_uri uri >>= fun address ->
+    Auth.Digest.from_uri uri >>= fun auth ->
+    match Uri.query uri with
+    | [] -> Ok (v ~auth ~address ~service:`Bootstrap)
+    | _ -> error "Unexpected query in %a" Uri.pp_hum uri
+
+  let of_uri uri =
+    match Uri.scheme uri with
+    | Some "capnp" -> parse_capnp_uri uri
+    | Some scheme -> error "Unknown scheme %S (expected 'capnp://...')" scheme
+    | None -> error "Missing scheme in %a (expected 'capnp://...')" Uri.pp_hum uri
+end

--- a/capnp-rpc-lwt/two_party_network.ml
+++ b/capnp-rpc-lwt/two_party_network.ml
@@ -1,5 +1,3 @@
-(** A network where the is only one other addressable party. *)
-
 module Types = struct
   type provision_id
   type recipient_id
@@ -9,6 +7,13 @@ end
 
 module Address = struct
   type t
+
+  let pp f _ = Fmt.string f "<two-party-address>"
+
+  let to_uri _ = assert false
+  let parse_uri _ = failwith "Can't use of_uri wih Two_party_network"
+
+  let equal _ _ = assert false
 end
 
 let parse_third_party_cap_id _ = `Two_party_only

--- a/capnp-rpc-lwt/two_party_network.mli
+++ b/capnp-rpc-lwt/two_party_network.mli
@@ -1,0 +1,3 @@
+(** A network where the is only one other addressable party. *)
+
+include S.NETWORK

--- a/capnp-rpc-lwt/vat.ml
+++ b/capnp-rpc-lwt/vat.ml
@@ -1,7 +1,7 @@
 open Capnp_core
 open Lwt.Infix
 
-module Make (Network : Capnp_core.NETWORK) = struct
+module Make (Network : S.NETWORK) = struct
 
   module CapTP = CapTP_capnp.Make (Network)
 

--- a/capnp-rpc-lwt/vat.ml
+++ b/capnp-rpc-lwt/vat.ml
@@ -1,19 +1,31 @@
 open Capnp_core
 open Lwt.Infix
 
-module Make (Network : S.NETWORK) = struct
+module Log = Capnp_rpc.Debug.Log
 
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
+
+module Make (Network : S.NETWORK) (Underlying : Mirage_flow_lwt.S) = struct
+  module Flow = Tls_mirage.Make(Underlying)
+
+  module Sturdy_ref = Sturdy_ref.Make (Network)
   module CapTP = CapTP_capnp.Make (Network)
 
   type t = {
+    secret_key : Auth.Secret_key.t option;
     switch : Lwt_switch.t option;
+    address : Network.Address.t option;
     mutable bootstrap : Core_types.cap option;
     mutable connections : CapTP.t list; (* todo: should be a map, once we have Vat IDs *)
   }
 
-  let create ?switch ?bootstrap () =
+  let create ?switch ?secret_key ?bootstrap ?address () =
     let t = {
+      secret_key;
       switch;
+      address;
       bootstrap;
       connections = [];
     } in
@@ -35,4 +47,42 @@ module Make (Network : S.NETWORK) = struct
     t.connections <- conn :: t.connections;
     conn
 
+  let public_fingerprint t =
+    match t.secret_key with
+    | None -> Auth.Digest.insecure
+    | Some key -> Auth.Secret_key.digest key
+
+  let bootstrap_ref t =
+    match t.address with
+    | None -> failwith "bootstrap_ref: vat was not configured with an address"
+    | Some address ->
+      let auth = public_fingerprint t in
+      Sturdy_ref.v ~auth ~address ~service:`Bootstrap
+
+  let pp_bootstrap_uri f t =
+    if t.bootstrap = None then Fmt.string f "(vat has no bootstrap service)"
+    else if t.address = None then Fmt.string f "(vat has no public address)"
+    else Sturdy_ref.pp_with_secrets f (bootstrap_ref t)
+
+  let plain_endpoint ~switch flow =
+    Endpoint.of_flow ~switch (module Underlying) flow
+
+  let connect_as_server ~switch t flow =
+    match t.secret_key with
+    | None -> Lwt.return @@ Ok (connect t @@ plain_endpoint ~switch flow)
+    | Some key ->
+      Log.info (fun f -> f "Doing TLS server-side handshake...");
+      Flow.server_of_flow (Auth.Secret_key.tls_config key) flow >|= function
+      | Error e -> error "TLS connection failed: %a" Flow.pp_write_error e
+      | Ok flow -> Ok (connect t @@ Endpoint.of_flow ~switch (module Flow) flow)
+
+  let connect_as_client ~switch t auth flow =
+    match Auth.Digest.authenticator auth with
+    | None -> Lwt.return @@ Ok (connect t @@ plain_endpoint ~switch flow)
+    | Some authenticator ->
+      let tls_config = Tls.Config.client ~authenticator () in
+      Log.info (fun f -> f "Doing TLS client-side handshake...");
+      Flow.client_of_flow tls_config flow >|= function
+      | Error e -> error "TLS connection failed: %a" Flow.pp_write_error e
+      | Ok flow -> Ok (connect t @@ Endpoint.of_flow ~switch (module Flow) flow)
 end

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -293,7 +293,6 @@ end
 
 module type NETWORK_TYPES = sig
   (* These depend on the particular network details. *)
-  type sturdy_ref
   type provision_id
   type recipient_id
   type third_party_cap_id

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -164,7 +164,6 @@ end
 module Core_types = Capnp_rpc.Core_types(Msg)
 
 module Network_types = struct
-  type sturdy_ref
   type provision_id
   type recipient_id
   type third_party_cap_id

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -30,7 +30,8 @@ let reporter =
 
 let serve vat_config =
   Lwt_main.run begin
-    Capnp_rpc_unix.serve vat_config ~offer:Examples.Calc.local >>= fun _vat ->
+    Capnp_rpc_unix.serve vat_config ~offer:Examples.Calc.local >>= fun vat ->
+    Fmt.pr "Waiting for incoming connections at:@.%a@." Capnp_rpc_unix.Vat.pp_bootstrap_uri vat;
     fst @@ Lwt.wait ()
   end
 
@@ -38,8 +39,7 @@ let serve vat_config =
 
 let connect addr =
   Lwt_main.run begin
-    Lwt_switch.with_switch @@ fun switch ->
-    let calc = Capnp_rpc_unix.connect ~switch addr in
+    Capnp_rpc_unix.connect addr >>= fun calc ->
     Logs.info (fun f -> f "Evaluating expression...");
     let remote_add = Calc.getOperator calc `Add in
     let result = Calc.evaluate calc Calc.Expr.(Call (remote_add, [Float 40.0; Float 2.0])) in
@@ -53,8 +53,8 @@ let connect addr =
 open Cmdliner
 
 let connect_addr =
-  let i = Arg.info [] ~docv:"ADDR" ~doc:"Address of server, e.g. unix:/run/my.socket" in
-  Arg.(required @@ pos 0 (some Capnp_rpc_unix.Connect_address.conv) None i)
+  let i = Arg.info [] ~docv:"ADDR" ~doc:"Address of server (capnp://...)" in
+  Arg.(required @@ pos 0 (some (Capnp_rpc_unix.sturdy_ref ())) None i)
 
 let serve_cmd =
   Term.(const serve $ Capnp_rpc_unix.Vat_config.cmd),
@@ -77,4 +77,6 @@ let () =
   Fmt_tty.setup_std_outputs ();
   Logs.set_reporter reporter;
   Logs.set_level ~all:true (Some Logs.Info);
-  Term.eval_choice default_cmd cmds |> Term.exit
+  match Term.eval_choice ~catch:false default_cmd cmds with
+  | exception Failure msg -> Fmt.epr "%s@." msg; exit 1
+  | status -> Term.exit status

--- a/test/testbed/capnp_direct.ml
+++ b/test/testbed/capnp_direct.ml
@@ -50,7 +50,6 @@ end
 module Core_types = Capnp_rpc.Core_types(String_content)
 
 module Network_types = struct
-  type sturdy_ref
   type provision_id
   type recipient_id
   type third_party_cap_id

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -1,121 +1,20 @@
-open Astring
 open Lwt.Infix
 
-(* Slightly rude to set signal handlers in a library, but SIGPIPE makes no sense
-   in a modern application. *)
-let () = Sys.(set_signal sigpipe Signal_ignore)
-
-module Networking = Capnp_rpc_lwt.Networking (Capnp_rpc_lwt.Two_party_network)
-
-module Unix_flow = struct
-  type buffer = Cstruct.t
-  type flow = {
-    fd : Lwt_unix.file_descr;
-    mutable current_write : int Lwt.t option;
-    mutable current_read : int Lwt.t option;
-    mutable closed : bool;
-  }
-  type error = [`Closed | `Exception of exn]
-  type write_error = [`Closed | `Exception of exn]
-  type 'a io = 'a Lwt.t
-
-  let opt_cancel = function
-    | None -> ()
-    | Some x -> Lwt.cancel x
-
-  let close t =
-    assert (not t.closed);
-    t.closed <- true;
-    opt_cancel t.current_read;
-    opt_cancel t.current_write;
-    Lwt_unix.close t.fd
-
-  let pp_error f = function
-    | `Exception ex -> Fmt.exn f ex
-    | `Closed -> Fmt.string f "Closed"
-
-  let pp_write_error = pp_error
-
-  let write t buf =
-    let rec aux buf =
-      if t.closed then Lwt.return (Error `Closed)
-      else (
-        assert (t.current_write = None);
-        let write_thread = Lwt_cstruct.write t.fd buf in
-        t.current_write <- Some write_thread;
-        write_thread >>= fun wrote ->
-        t.current_write <- None;
-        if wrote = Cstruct.len buf then Lwt.return (Ok ())
-        else aux (Cstruct.shift buf wrote)
-      )
-    in
-    Lwt.catch
-      (fun () -> aux buf)
-      (fun ex -> Lwt.return @@ Error (`Exception ex))
-
-  let rec writev t = function
-    | [] -> Lwt.return (Ok ())
-    | x :: xs ->
-      write t x >>= function
-      | Ok () -> writev t xs
-      | Error _ as e -> Lwt.return e
-
-  let read t =
-    let len = 4096 in
-    let buf = Cstruct.create_unsafe len in
-    Lwt.try_bind
-      (fun () ->
-         assert (t.current_read = None);
-         if t.closed then raise Lwt.Canceled;
-         let read_thread = Lwt_cstruct.read t.fd buf in
-         t.current_read <- Some read_thread;
-         read_thread
-      )
-      (function
-        | 0 ->
-          Lwt.return @@ Ok `Eof
-        | got ->
-          t.current_read <- None;
-          Lwt.return @@ Ok (`Data (Cstruct.sub buf 0 got))
-      )
-      (function
-        | Lwt.Canceled -> Lwt.return @@ Error `Closed
-        | ex -> Lwt.return @@ Error (`Exception ex)
-      )
-
-  let connect ?switch fd =
-    let t = { fd; closed = false; current_read = None; current_write = None } in
-    Lwt_switch.add_hook switch (fun () -> close t);
-    t
-end
+include Capnp_rpc_lwt.Networking (Network)
+module Vat_config = Vat_config
 
 let endpoint_of_socket ~switch socket =
   Capnp_rpc_lwt.Endpoint.of_flow ~switch (module Unix_flow) (Unix_flow.connect ~switch socket)
 
-module Listen_address = struct
-  type t = [
-    | `Unix of string
-  ]
+module Connect_address = struct
+  include Vat_config.Listen_address (* (for now) *)
 
-  let pp f = function
-    | `Unix path -> Fmt.pf f "unix:%s" path
-
-  open Cmdliner
-
-  let of_string s =
-    match String.cut ~sep:":" s with
-    | None -> Error (`Msg "Missing ':'")
-    | Some ("unix", path) -> Ok (`Unix path)
-    | Some _ -> Error (`Msg "Only unix:PATH addresses are currently supported")
-
-  let conv = Arg.conv (of_string, pp)
+  let conv = Vat_config.Listen_address.addr_conv
 end
 
-module Connect_address = Listen_address (* (for now) *)
-
-let serve ?(backlog=5) ?offer addr =
-  let vat = Networking.Vat.create ?bootstrap:offer () in
-  let `Unix path = addr in
+let serve ?(backlog=5) ?offer {Vat_config.listen_address; public_address = _} =
+  let vat = Vat.create ?bootstrap:offer () in
+  let `Unix path = listen_address in
   begin match Unix.lstat path with
     | { Unix.st_kind = Unix.S_SOCK; _ } -> Unix.unlink path
     | _ -> ()
@@ -124,14 +23,14 @@ let serve ?(backlog=5) ?offer addr =
   let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
   Unix.bind socket (Unix.ADDR_UNIX path);
   Unix.listen socket backlog;
-  Logs.info (fun f -> f "Waiting for connections on %a" Listen_address.pp addr);
+  Logs.info (fun f -> f "Waiting for connections on %a" Vat_config.Listen_address.pp listen_address);
   let lwt_socket = Lwt_unix.of_unix_file_descr socket in
   let rec loop () =
     Lwt_unix.accept lwt_socket >>= fun (client, _addr) ->
     Logs.info (fun f -> f "New connection on %S" path);
     let switch = Lwt_switch.create () in
     let ep = endpoint_of_socket ~switch client in
-    let _ : Networking.CapTP.t = Networking.Vat.connect vat ep in
+    let _ : CapTP.t = Vat.connect vat ep in
     loop ()
   in
   loop ()
@@ -145,8 +44,8 @@ let connect ?switch ?offer (`Unix path) =
   Logs.info (fun f -> f "Connecting to %S..." path);
   let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
   Unix.connect socket (Unix.ADDR_UNIX path);
-  let vat = Networking.Vat.create ~switch ?bootstrap:offer () in
+  let vat = Vat.create ~switch ?bootstrap:offer () in
   let ep = endpoint_of_socket ~switch (Lwt_unix.of_unix_file_descr socket) in
-  let conn = Networking.Vat.connect vat ep in
-  Networking.CapTP.bootstrap conn
+  let conn = Vat.connect vat ep in
+  CapTP.bootstrap conn
 

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -1,51 +1,110 @@
 open Lwt.Infix
 
-include Capnp_rpc_lwt.Networking (Network)
+module Log = Capnp_rpc.Debug.Log
+module Unix_flow = Unix_flow
+
+let () = Nocrypto_entropy_lwt.initialize () |> ignore
+
+include Capnp_rpc_lwt.Networking (Network) (Unix_flow)
 module Vat_config = Vat_config
 
-let endpoint_of_socket ~switch socket =
-  Capnp_rpc_lwt.Endpoint.of_flow ~switch (module Unix_flow) (Unix_flow.connect ~switch socket)
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
 
-module Connect_address = struct
-  include Vat_config.Listen_address (* (for now) *)
+let sturdy_ref () =
+  let of_string s =
+    match Uri.of_string s with
+    | exception ex -> error "Failed to parse URI %S: %a" s Fmt.exn ex
+    | uri -> Sturdy_ref.of_uri uri
+  in
+  Cmdliner.Arg.conv (of_string, Sturdy_ref.pp_with_secrets)
 
-  let conv = Vat_config.Listen_address.addr_conv
-end
+let handle_connection vat client =
+  let switch = Lwt_switch.create () in
+  let raw_flow = Unix_flow.connect ~switch client in
+  Vat.connect_as_server ~switch vat raw_flow >>= function
+  | Error (`Msg msg) ->
+    Log.warn (fun f -> f "Rejecting new connection: %s" msg);
+    Lwt.return_unit
+  | Ok (_ : CapTP.t) ->
+    Lwt.return_unit
 
-let serve ?(backlog=5) ?offer {Vat_config.listen_address; public_address = _} =
-  let vat = Vat.create ?bootstrap:offer () in
-  let `Unix path = listen_address in
-  begin match Unix.lstat path with
-    | { Unix.st_kind = Unix.S_SOCK; _ } -> Unix.unlink path
-    | _ -> ()
-    | exception Unix.Unix_error(Unix.ENOENT, _, _) -> ()
-  end;
-  let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
-  Unix.bind socket (Unix.ADDR_UNIX path);
+let addr_of_host host =
+  match Unix.gethostbyname host with
+  | exception Not_found ->
+    Capnp_rpc.Debug.failf "Unknown host %S" host
+  | addr ->
+    if Array.length addr.Unix.h_addr_list = 0 then
+      Capnp_rpc.Debug.failf "No addresses found for host name %S" host
+    else
+      addr.Unix.h_addr_list.(0)
+
+let serve ?offer {Vat_config.backlog; secret_key; listen_address; public_address} =
+  let vat = Vat.create ?bootstrap:offer ?secret_key ~address:public_address () in
+  let socket =
+    match listen_address with
+    | `Unix path ->
+      begin match Unix.lstat path with
+        | { Unix.st_kind = Unix.S_SOCK; _ } -> Unix.unlink path
+        | _ -> ()
+        | exception Unix.Unix_error(Unix.ENOENT, _, _) -> ()
+      end;
+      let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
+      Unix.bind socket (Unix.ADDR_UNIX path);
+      socket
+    | `TCP (host, port) ->
+      let socket = Unix.(socket PF_INET SOCK_STREAM 0) in
+      Unix.bind socket (Unix.ADDR_INET (addr_of_host host, port));
+      socket
+  in
   Unix.listen socket backlog;
-  Logs.info (fun f -> f "Waiting for connections on %a" Vat_config.Listen_address.pp listen_address);
+  let pp_auth f = function
+    | Some _ -> Fmt.string f "(encrypted)"
+    | None -> Fmt.string f "UNENCRYPTED"
+  in
+  Logs.info (fun f -> f "Waiting for %a connections on %a"
+                pp_auth secret_key
+                Vat_config.Listen_address.pp listen_address);
   let lwt_socket = Lwt_unix.of_unix_file_descr socket in
   let rec loop () =
     Lwt_unix.accept lwt_socket >>= fun (client, _addr) ->
-    Logs.info (fun f -> f "New connection on %S" path);
-    let switch = Lwt_switch.create () in
-    let ep = endpoint_of_socket ~switch client in
-    let _ : CapTP.t = Vat.connect vat ep in
+    Logs.info (fun f -> f "Accepting new connection");
+    Lwt.async (fun () -> handle_connection vat client);
     loop ()
   in
-  loop ()
+  Lwt.async loop;
+  Lwt.return vat
 
-let connect ?switch ?offer (`Unix path) =
+let connect_socket = function
+  | `Unix path ->
+    Logs.info (fun f -> f "Connecting to %S..." path);
+    let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
+    Unix.connect socket (Unix.ADDR_UNIX path);
+    socket
+  | `TCP (host, port) ->
+    Logs.info (fun f -> f "Connecting to %s:%d..." host port);
+    let socket = Unix.(socket PF_INET SOCK_STREAM 0) in
+    Unix.connect socket (Unix.ADDR_INET (addr_of_host host, port));
+    socket
+
+let connect ?switch ?offer sr =
   let switch =
     match switch with
     | None -> Lwt_switch.create ()
     | Some x -> x
   in
-  Logs.info (fun f -> f "Connecting to %S..." path);
-  let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
-  Unix.connect socket (Unix.ADDR_UNIX path);
-  let vat = Vat.create ~switch ?bootstrap:offer () in
-  let ep = endpoint_of_socket ~switch (Lwt_unix.of_unix_file_descr socket) in
-  let conn = Vat.connect vat ep in
-  CapTP.bootstrap conn
-
+  match connect_socket (Sturdy_ref.address sr) with
+  | exception ex ->
+    Capnp_rpc.Debug.failf "@[<v2>Network connection for %a failed:@,%a@]"
+      Sturdy_ref.pp_address sr
+      Fmt.exn ex
+  | socket ->
+    let vat = Vat.create ~switch ?bootstrap:offer () in
+    let auth = Sturdy_ref.auth sr in
+    let raw_flow = Unix_flow.connect ~switch (Lwt_unix.of_unix_file_descr socket) in
+    Vat.connect_as_client ~switch vat auth raw_flow >|= function
+    | Error (`Msg msg) ->
+      Capnp_rpc.Debug.failf "Connection to %a failed: %s" Sturdy_ref.pp_address sr msg
+    | Ok conn ->
+      CapTP.bootstrap conn

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -7,8 +7,38 @@ end
 
 let parse_third_party_cap_id _ = `Two_party_only
 
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
+
+let none_if_empty = function
+  | None | Some "" -> None
+  | Some _ as x -> x
+
 module Address = struct
   type t = [
     | `Unix of string
+    | `TCP of string * int
   ]
+
+  let to_uri = function
+    | `Unix path -> Uri.make ~scheme:"capnp" ~path ()
+    | `TCP (host, port) -> Uri.make ~scheme:"capnp" ~host ~port ()
+
+  let pp f = function
+    | `Unix path -> Fmt.pf f "unix:%s" path
+    | `TCP (host, port) -> Fmt.pf f "tcp:%s:%d" host port
+
+  let parse_uri uri =
+    let host = Uri.host uri |> none_if_empty in
+    let port = Uri.port uri in
+    let path = Uri.path uri in
+    match host, port with
+    | Some host, Some port when path = "" -> Ok (`TCP (host, port))
+    | Some _,    Some _ -> error "Unexpected path component %S in %a" path Uri.pp_hum uri
+    | Some _,    None   -> error "Missing port in %a" Uri.pp_hum uri
+    | None,      Some _ -> error "Port without host in %a!" Uri.pp_hum uri
+    | None,      None   -> Ok (`Unix path)
+
+  let equal = ( = )
 end

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -1,5 +1,3 @@
-(** A network where the is only one other addressable party. *)
-
 module Types = struct
   type provision_id
   type recipient_id
@@ -7,8 +5,10 @@ module Types = struct
   type join_key_part
 end
 
-module Address = struct
-  type t
-end
-
 let parse_third_party_cap_id _ = `Two_party_only
+
+module Address = struct
+  type t = [
+    | `Unix of string
+  ]
+end

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -1,0 +1,6 @@
+(** A network using Unix-domain sockets. *)
+
+include Capnp_rpc_lwt.S.NETWORK with
+  type Address.t = [
+    | `Unix of string
+  ]

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -1,6 +1,7 @@
-(** A network using Unix-domain sockets. *)
+(** A network using TCP and Unix-domain sockets. *)
 
 include Capnp_rpc_lwt.S.NETWORK with
   type Address.t = [
     | `Unix of string
+    | `TCP of string * int
   ]

--- a/unix/unix_flow.ml
+++ b/unix/unix_flow.ml
@@ -1,0 +1,85 @@
+open Lwt.Infix
+
+(* Slightly rude to set signal handlers in a library, but SIGPIPE makes no sense
+   in a modern application. *)
+let () = Sys.(set_signal sigpipe Signal_ignore)
+
+type buffer = Cstruct.t
+type flow = {
+  fd : Lwt_unix.file_descr;
+  mutable current_write : int Lwt.t option;
+  mutable current_read : int Lwt.t option;
+  mutable closed : bool;
+}
+type error = [`Closed | `Exception of exn]
+type write_error = [`Closed | `Exception of exn]
+type 'a io = 'a Lwt.t
+
+let opt_cancel = function
+  | None -> ()
+  | Some x -> Lwt.cancel x
+
+let close t =
+  assert (not t.closed);
+  t.closed <- true;
+  opt_cancel t.current_read;
+  opt_cancel t.current_write;
+  Lwt_unix.close t.fd
+
+let pp_error f = function
+  | `Exception ex -> Fmt.exn f ex
+  | `Closed -> Fmt.string f "Closed"
+
+let pp_write_error = pp_error
+
+let write t buf =
+  let rec aux buf =
+    if t.closed then Lwt.return (Error `Closed)
+    else (
+      assert (t.current_write = None);
+      let write_thread = Lwt_cstruct.write t.fd buf in
+      t.current_write <- Some write_thread;
+      write_thread >>= fun wrote ->
+      t.current_write <- None;
+      if wrote = Cstruct.len buf then Lwt.return (Ok ())
+      else aux (Cstruct.shift buf wrote)
+    )
+  in
+  Lwt.catch
+    (fun () -> aux buf)
+    (fun ex -> Lwt.return @@ Error (`Exception ex))
+
+let rec writev t = function
+  | [] -> Lwt.return (Ok ())
+  | x :: xs ->
+    write t x >>= function
+    | Ok () -> writev t xs
+    | Error _ as e -> Lwt.return e
+
+let read t =
+  let len = 4096 in
+  let buf = Cstruct.create_unsafe len in
+  Lwt.try_bind
+    (fun () ->
+       assert (t.current_read = None);
+       if t.closed then raise Lwt.Canceled;
+       let read_thread = Lwt_cstruct.read t.fd buf in
+       t.current_read <- Some read_thread;
+       read_thread
+    )
+    (function
+      | 0 ->
+        Lwt.return @@ Ok `Eof
+      | got ->
+        t.current_read <- None;
+        Lwt.return @@ Ok (`Data (Cstruct.sub buf 0 got))
+    )
+    (function
+      | Lwt.Canceled -> Lwt.return @@ Error `Closed
+      | ex -> Lwt.return @@ Error (`Exception ex)
+    )
+
+let connect ?switch fd =
+  let t = { fd; closed = false; current_read = None; current_write = None } in
+  Lwt_switch.add_hook switch (fun () -> close t);
+  t

--- a/unix/unix_flow.mli
+++ b/unix/unix_flow.mli
@@ -3,3 +3,5 @@
 include Mirage_flow_lwt.S
 
 val connect : ?switch:Lwt_switch.t -> Lwt_unix.file_descr -> flow
+
+val socketpair : ?switch:Lwt_switch.t -> unit -> flow * flow

--- a/unix/unix_flow.mli
+++ b/unix/unix_flow.mli
@@ -1,0 +1,5 @@
+(** Wraps a Unix [file_descr] to provide the Mirage flow API. *)
+
+include Mirage_flow_lwt.S
+
+val connect : ?switch:Lwt_switch.t -> Lwt_unix.file_descr -> flow

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -1,0 +1,55 @@
+open Astring
+
+module Log = Capnp_rpc.Debug.Log
+
+module Listen_address = struct
+  type t = [
+    | `Unix of string
+  ]
+
+  let pp f = function
+    | `Unix path -> Fmt.pf f "unix:%s" path
+
+  open Cmdliner
+
+  let of_string s =
+    match String.cut ~sep:":" s with
+    | None -> Error (`Msg "Missing ':'")
+    | Some ("unix", path) -> Ok (`Unix path)
+    | Some _ -> Error (`Msg "Only unix:PATH addresses are currently supported")
+
+  let addr_conv = Arg.conv (of_string, pp)
+
+  let cmd =
+    let i = Arg.info ["listen-address"] ~docv:"ADDR" ~doc:"Address to listen on, e.g. $(b,unix:/run/my.socket)." in
+    Arg.(required @@ opt (some addr_conv) None i)
+end
+
+type t = {
+  listen_address : Listen_address.t;
+  public_address : Listen_address.t;
+}
+
+let v ?public_address listen_address =
+  let public_address =
+    match public_address with
+    | Some x -> x
+    | None -> listen_address
+  in
+  { listen_address; public_address }
+
+open Cmdliner
+
+let public_address =
+  let i = Arg.info ["public-address"] ~docv:"ADDR" ~doc:"Address to tell others to connect on" in
+  Arg.(value @@ opt (some Listen_address.addr_conv) None i)
+
+let cmd =
+  let make listen_address public_address =
+    let public_address =
+      match public_address with
+      | None -> listen_address
+      | Some x -> x
+    in
+    { listen_address; public_address } in
+  Term.(pure make $ Listen_address.cmd $ public_address)

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -1,22 +1,33 @@
 open Astring
 
+module Auth = Capnp_rpc_lwt.Auth
 module Log = Capnp_rpc.Debug.Log
 
 module Listen_address = struct
-  type t = [
-    | `Unix of string
-  ]
+  include Network.Address
 
-  let pp f = function
-    | `Unix path -> Fmt.pf f "unix:%s" path
+  let abs_path p =
+    if Filename.is_relative p then
+      Filename.concat (Sys.getcwd ()) p
+    else p
 
-  open Cmdliner
+  let parse_tcp s =
+    match String.cut ~sep:":" s with
+    | None -> Error (`Msg "Missing :PORT in listen address")
+    | Some (host, port) ->
+      match String.to_int port with
+      | None -> Error (`Msg "PORT must be an integer")
+      | Some port ->
+        Ok (`TCP (host, port))
 
   let of_string s =
     match String.cut ~sep:":" s with
+    | Some ("unix", path) -> Ok (`Unix (abs_path path))
+    | Some ("tcp", tcp) -> parse_tcp tcp
     | None -> Error (`Msg "Missing ':'")
-    | Some ("unix", path) -> Ok (`Unix path)
-    | Some _ -> Error (`Msg "Only unix:PATH addresses are currently supported")
+    | Some _ -> Error (`Msg "Only tcp:HOST:PORT and unix:PATH addresses are currently supported")
+
+  open Cmdliner
 
   let addr_conv = Arg.conv (of_string, pp)
 
@@ -26,30 +37,105 @@ module Listen_address = struct
 end
 
 type t = {
-  listen_address : Listen_address.t;
-  public_address : Listen_address.t;
+  backlog : int;
+  secret_key : Auth.Secret_key.t option;
+  listen_address : Network.Address.t;
+  public_address : Network.Address.t;
 }
 
-let v ?public_address listen_address =
+let v ?(backlog=5) ?public_address ~secret_key listen_address =
   let public_address =
     match public_address with
     | Some x -> x
     | None -> listen_address
   in
-  { listen_address; public_address }
+  { backlog; secret_key; listen_address; public_address }
+
+let secret_key_file =
+  let open Cmdliner in
+  let i = Arg.info ["secret-key-file"] ~docv:"PATH"
+      ~doc:"File in which to store secret key." in
+  Arg.(value @@ opt (some string) None i)
+
+let secret_key_type =
+  let open Cmdliner in
+  let options = [
+    "none", `Disable_crypto;
+    "RSA", `RSA;
+  ] in
+  let i = Arg.info ["secret-key-type"] ~docv:"ALG"
+      ~doc:(Fmt.strf "Type of crypto to use (%s)." (Arg.doc_alts_enum options)) in
+  Arg.(value @@ opt (enum options) `RSA i)
+
+let read_whole_file path =
+  let ic = open_in_bin path in
+  let len = in_channel_length ic in
+  let data = really_input_string ic len in
+  close_in ic;
+  data
+
+let write_whole_file path data =
+  let oc = open_out_bin path in
+  output_string oc data;
+  close_out oc
+
+let init_secret_key_file key_file =
+  if Sys.file_exists key_file then (
+    Log.info (fun f -> f "Restoring saved secret key from existing file %S" key_file);
+    let secret_key = Auth.Secret_key.of_pem_data (read_whole_file key_file) in
+    `Ok (Some secret_key)
+  ) else (
+    Log.info (fun f -> f "Generating new secret key to store in %S" key_file);
+    let secret_key = Auth.Secret_key.generate () in
+    write_whole_file key_file (Auth.Secret_key.to_pem_data secret_key);
+    `Ok (Some secret_key)
+  )
+
+let get_secret_key ty file =
+  match ty, file with
+  | `Disable_crypto, None -> `Ok None
+  | `RSA, Some key_file -> init_secret_key_file key_file
+  | `RSA, None -> `Error (false, "Missing --secret-key-file=PATH option.\n\n\
+                                  You can specify a file that doesn't exist yet to generate a new key, \
+                                  give the path to an existing PEM-encoded RSA private key file, \
+                                  or use --secret-key-type=none to disable security."
+                         )
+  | `Disable_crypto, Some _ -> `Error (false, "Can't use --secret-key-file with key type \"none\"")
+
+let secret_key = Cmdliner.Term.(ret (pure get_secret_key $ secret_key_type $ secret_key_file))
 
 open Cmdliner
+
+let pp_fingerprint =
+  Fmt.(option ~none:(unit "crypto disabled"))
+    (Auth.Secret_key.pp_fingerprint `SHA256)
+
+let pp f {backlog; secret_key; listen_address; public_address} =
+  Fmt.pf f "{backlog=%d; fingerprint=%a; listen_address=%a; public_address=%a}"
+    backlog
+    pp_fingerprint secret_key
+    Network.Address.pp listen_address
+    Network.Address.pp public_address
+
+let equal {backlog; secret_key; listen_address; public_address} b =
+  backlog = b.backlog &&
+  Network.Address.equal listen_address b.listen_address &&
+  Network.Address.equal public_address b.public_address &&
+  match secret_key, b.secret_key with
+  | None, None -> true
+  | Some a, Some b -> Auth.Secret_key.equal a b
+  | _ -> false
 
 let public_address =
   let i = Arg.info ["public-address"] ~docv:"ADDR" ~doc:"Address to tell others to connect on" in
   Arg.(value @@ opt (some Listen_address.addr_conv) None i)
 
 let cmd =
-  let make listen_address public_address =
+  let make secret_key listen_address public_address =
     let public_address =
       match public_address with
       | None -> listen_address
       | Some x -> x
     in
-    { listen_address; public_address } in
-  Term.(pure make $ Listen_address.cmd $ public_address)
+    { backlog = 5; secret_key; listen_address; public_address } in
+  Term.(pure make $ secret_key $ Listen_address.cmd $ public_address)


### PR DESCRIPTION
`Capnp_rpc_unix.serve` now takes a `Vat_config.t` rather than a plain network address. The config contains:

- The address to listen on (as before)
- The public address (if different)
- The secret key (if encryption and authentication are enabled)

It now returns the new server `Vat`, from which you can get a `Sturdy_ref` for the bootstrap object (currently, sturdy refs can *only* refer to bootstrap services).

Clients now connect using a `Sturdy_ref`, allowing them to authenticate the server.

`Sturdy_ref`s can be converted to and from URIs, allowing them to be saved to files or pasted where they're needed.

Addresses are now part of the `NETWORK` module type, and the `Unix` definition has moved to `Capnp_rpc_unix.Network.Address`. This type has been extended to include `TCP` addresses too.

The new `Auth.Secret_key` module can be used to generate a private key and a suitable TLS configuration for it. `Auth.Digest` can be used to get a TLS authenticator to check a fingerprint.

The `Capnp_rpc_unix` module now exposes the full `CapTP` and `Vat` signatures. `Capnp_rpc_unix.Listen_address` is gone - use `Capnp_rpc_unix.Network.Address` instead for addresses, and `Capnp_rpc_unix.Vat_config` for server configuration.

Closes #8.