### PR TITLE
Move TLS support out of Vat and Sturdy_ref interfaces

### DIFF
--- a/capnp-rpc-lwt/auth.mli
+++ b/capnp-rpc-lwt/auth.mli
@@ -67,3 +67,15 @@ module Secret_key : sig
 
   val equal : t -> t -> bool
 end
+
+module Tls_wrapper (Underlying : Mirage_flow_lwt.S) : sig
+  (** Make an [Endpoint] from an [Underlying.flow], using TLS if appropriate. *)
+
+  val connect_as_server :
+    switch:Lwt_switch.t -> Underlying.flow -> Secret_key.t option ->
+    (Endpoint.t, [> `Msg of string]) result Lwt.t
+
+  val connect_as_client :
+    switch:Lwt_switch.t -> Underlying.flow -> Digest.t ->
+    (Endpoint.t, [> `Msg of string]) result Lwt.t
+end

--- a/capnp-rpc-lwt/sturdy_ref.ml
+++ b/capnp-rpc-lwt/sturdy_ref.ml
@@ -14,24 +14,21 @@ module Make (N : S.NETWORK) = struct
 
   type 'a t = {
     address : N.Address.t;
-    auth : Auth.Digest.t;
     service : service;
   }
 
-  let v ~auth ~address ~service = {auth; address; service}
+  let v ~address ~service = {address; service}
 
-  let equal {address; auth; service} b =
+  let equal {address; service} b =
     N.Address.equal address b.address &&
-    Auth.Digest.equal auth b.auth &&
     service = b.service
 
   let address t = t.address
-  let auth t = t.auth
   let service t = t.service
   let cast t = (t :> _ t)
 
-  let to_uri_with_secrets {address; auth; service = `Bootstrap} =
-    N.Address.to_uri address |> Auth.Digest.add_to_uri auth
+  let to_uri_with_secrets {address; service = `Bootstrap} =
+    N.Address.to_uri address
 
   let pp_with_secrets f t = Uri.pp_hum f (to_uri_with_secrets t)
 
@@ -40,9 +37,8 @@ module Make (N : S.NETWORK) = struct
 
   let parse_capnp_uri uri =
     N.Address.parse_uri uri >>= fun address ->
-    Auth.Digest.from_uri uri >>= fun auth ->
     match Uri.query uri with
-    | [] -> Ok (v ~auth ~address ~service:`Bootstrap)
+    | [] -> Ok (v ~address ~service:`Bootstrap)
     | _ -> error "Unexpected query in %a" Uri.pp_hum uri
 
   let of_uri uri =

--- a/capnp-rpc-lwt/two_party_network.ml
+++ b/capnp-rpc-lwt/two_party_network.ml
@@ -17,3 +17,5 @@ module Address = struct
 end
 
 let parse_third_party_cap_id _ = `Two_party_only
+
+let connect _ = assert false

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -4,27 +4,24 @@ open Capnp_rpc_lwt
 
 module Unix_flow = Unix_flow
 
-include Capnp_rpc_lwt.S.VAT_NETWORK
-  with type Network.Address.t = [
-      | `Unix of string
-      | `TCP of string * int
-    ] and
+include Capnp_rpc_lwt.S.VAT_NETWORK with
   type flow = Unix_flow.flow and
-  type 'a capability = 'a Capability.t
+  type 'a capability = 'a Capability.t and
+  module Network = Network
 
 module Vat_config : sig
   type t = {
     backlog : int;
     secret_key : Auth.Secret_key.t option;
-    listen_address : Network.Address.t;
-    public_address : Network.Address.t;
+    listen_address : Network.Socket_address.t;
+    public_address : Network.Socket_address.t;
   }
 
   val v :
     ?backlog:int ->
-    ?public_address:Network.Address.t ->
+    ?public_address:Network.Socket_address.t ->
     secret_key:Auth.Secret_key.t option ->
-    Network.Address.t -> t
+    Network.Socket_address.t -> t
   (** [v ~secret_key listen_address] is the configuration for a server vat that
       listens on address [listen_address] and proves its identity to clients using [secret_key].
       [backlog] is passed to [Unix.listen].

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -1,3 +1,6 @@
+module Log = Capnp_rpc.Debug.Log
+module Tls_wrapper = Capnp_rpc_lwt.Auth.Tls_wrapper(Unix_flow)
+
 module Types = struct
   type provision_id
   type recipient_id
@@ -15,30 +18,85 @@ let none_if_empty = function
   | None | Some "" -> None
   | Some _ as x -> x
 
-module Address = struct
+module Socket_address = struct
   type t = [
     | `Unix of string
     | `TCP of string * int
   ]
 
-  let to_uri = function
-    | `Unix path -> Uri.make ~scheme:"capnp" ~path ()
-    | `TCP (host, port) -> Uri.make ~scheme:"capnp" ~host ~port ()
-
   let pp f = function
     | `Unix path -> Fmt.pf f "unix:%s" path
     | `TCP (host, port) -> Fmt.pf f "tcp:%s:%d" host port
+
+  let equal = ( = )
+end
+
+module Address = struct
+  type t = Socket_address.t * Capnp_rpc_lwt.Auth.Digest.t
+
+  let to_uri (addr, auth) =
+    let uri =
+      match addr with
+      | `Unix path -> Uri.make ~scheme:"capnp" ~path ()
+      | `TCP (host, port) -> Uri.make ~scheme:"capnp" ~host ~port ()
+    in
+    Capnp_rpc_lwt.Auth.Digest.add_to_uri auth uri
+
+  let pp f (addr, auth) =
+    Fmt.pf f "%a@%a" Capnp_rpc_lwt.Auth.Digest.pp auth Socket_address.pp addr
+
+  let ( >>= ) x f =
+    match x with
+    | Error _ as e -> e
+    | Ok y -> f y
 
   let parse_uri uri =
     let host = Uri.host uri |> none_if_empty in
     let port = Uri.port uri in
     let path = Uri.path uri in
+    Capnp_rpc_lwt.Auth.Digest.from_uri uri >>= fun auth ->
     match host, port with
-    | Some host, Some port when path = "" -> Ok (`TCP (host, port))
+    | Some host, Some port when path = "" -> Ok (`TCP (host, port), auth)
     | Some _,    Some _ -> error "Unexpected path component %S in %a" path Uri.pp_hum uri
     | Some _,    None   -> error "Missing port in %a" Uri.pp_hum uri
     | None,      Some _ -> error "Port without host in %a!" Uri.pp_hum uri
-    | None,      None   -> Ok (`Unix path)
+    | None,      None   -> Ok (`Unix path, auth)
 
-  let equal = ( = )
+  let equal (addr, auth) (addr_b, auth_b) =
+    Socket_address.equal addr addr_b &&
+    Capnp_rpc_lwt.Auth.Digest.equal auth auth_b
 end
+
+let addr_of_host host =
+  match Unix.gethostbyname host with
+  | exception Not_found ->
+    Capnp_rpc.Debug.failf "Unknown host %S" host
+  | addr ->
+    if Array.length addr.Unix.h_addr_list = 0 then
+      Capnp_rpc.Debug.failf "No addresses found for host name %S" host
+    else
+      addr.Unix.h_addr_list.(0)
+
+let connect_socket = function
+  | `Unix path ->
+    Logs.info (fun f -> f "Connecting to %S..." path);
+    let socket = Unix.(socket PF_UNIX SOCK_STREAM 0) in
+    Unix.connect socket (Unix.ADDR_UNIX path);
+    socket
+  | `TCP (host, port) ->
+    Logs.info (fun f -> f "Connecting to %s:%d..." host port);
+    let socket = Unix.(socket PF_INET SOCK_STREAM 0) in
+    Unix.connect socket (Unix.ADDR_INET (addr_of_host host, port));
+    socket
+
+let connect (addr, auth) =
+  match connect_socket addr with
+  | exception ex ->
+    Lwt.return @@ error "@[<v2>Network connection for %a failed:@,%a@]" Socket_address.pp addr Fmt.exn ex
+  | socket ->
+    let switch = Lwt_switch.create () in
+    let flow = Unix_flow.connect ~switch (Lwt_unix.of_unix_file_descr socket) in
+    Tls_wrapper.connect_as_client ~switch flow auth
+
+let accept_connection ~switch ~secret_key flow =
+  Tls_wrapper.connect_as_server ~switch flow secret_key

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -1,7 +1,24 @@
 (** A network using TCP and Unix-domain sockets. *)
 
-include Capnp_rpc_lwt.S.NETWORK with
-  type Address.t = [
+module Socket_address : sig
+  type t = [
     | `Unix of string
     | `TCP of string * int
   ]
+
+  val pp : t Fmt.t
+
+  val equal : t -> t -> bool
+end
+
+include Capnp_rpc_lwt.S.NETWORK with
+  type Address.t = Socket_address.t * Capnp_rpc_lwt.Auth.Digest.t
+
+val accept_connection :
+  switch:Lwt_switch.t ->
+  secret_key:Capnp_rpc_lwt.Auth.Secret_key.t option ->
+  Unix_flow.flow ->
+  (Capnp_rpc_lwt.Endpoint.t, [> `Msg of string]) result Lwt.t
+(** [accept_connection ~switch ~secret_key flow] is a new endpoint for [flow].
+    If [secret_key] is not [None], it is used to perform a TLS server-side handshake.
+    Otherwise, the connection is not encrypted. *)

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -4,7 +4,7 @@ module Auth = Capnp_rpc_lwt.Auth
 module Log = Capnp_rpc.Debug.Log
 
 module Listen_address = struct
-  include Network.Address
+  include Network.Socket_address
 
   let abs_path p =
     if Filename.is_relative p then
@@ -39,8 +39,8 @@ end
 type t = {
   backlog : int;
   secret_key : Auth.Secret_key.t option;
-  listen_address : Network.Address.t;
-  public_address : Network.Address.t;
+  listen_address : Network.Socket_address.t;
+  public_address : Network.Socket_address.t;
 }
 
 let v ?(backlog=5) ?public_address ~secret_key listen_address =
@@ -114,13 +114,13 @@ let pp f {backlog; secret_key; listen_address; public_address} =
   Fmt.pf f "{backlog=%d; fingerprint=%a; listen_address=%a; public_address=%a}"
     backlog
     pp_fingerprint secret_key
-    Network.Address.pp listen_address
-    Network.Address.pp public_address
+    Network.Socket_address.pp listen_address
+    Network.Socket_address.pp public_address
 
 let equal {backlog; secret_key; listen_address; public_address} b =
   backlog = b.backlog &&
-  Network.Address.equal listen_address b.listen_address &&
-  Network.Address.equal public_address b.public_address &&
+  Network.Socket_address.equal listen_address b.listen_address &&
+  Network.Socket_address.equal public_address b.public_address &&
   match secret_key, b.secret_key with
   | None, None -> true
   | Some a, Some b -> Auth.Secret_key.equal a b


### PR DESCRIPTION
Add `Network.connect` and include authentication parameters in the address type.

This moves TLS support out of the vat and sturdy ref interfaces.

The vat no longer needs to store the secret key, since TLS is now handled externally.

The new `Vat.live` function creates a live reference from a sturdy ref. The vat must handle this so that it can reuse existing connections, although this isn't implemented yet.