### PR TITLE
Separate steps of creating a client vat and connecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,9 @@ let () =
   Lwt_main.run begin
     Capnp_rpc_unix.serve server_config ~offer:Echo.local >>= fun server_vat ->
     let sr = Capnp_rpc_unix.Vat.bootstrap_ref server_vat in
+    let client_vat = Capnp_rpc_unix.client_only_vat () in
     Fmt.pr "Connecting to server at %a@." Capnp_rpc_unix.Sturdy_ref.pp_with_secrets sr;
-    Capnp_rpc_unix.connect sr >>= fun proxy_to_service ->
+    Capnp_rpc_unix.Vat.connect_exn client_vat sr >>= fun proxy_to_service ->
     run_client proxy_to_service
   end
 ```
@@ -446,7 +447,8 @@ Each client can access its "bootstrap" service, `Echo.local`.
 `sr` is a "sturdy ref" (you can think of it as a URL) that specifies how and where clients should connect
 to get a live reference (a `Capability.t`) to the bootstrap service.
 
-`Capnp_rpc_unix.connect` connects to the server socket and returns (a promise for) its bootstrap service.
+`Vat.connect_exn client_vat sr` returns a capability to the service at address `sr`,
+by connecting to the server socket and requesting its bootstrap service.
 
 For a real system you'd put the client and server parts in separate binaries.
 See the `test-bin/calc.ml` example file for how to do that.

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -129,9 +129,9 @@ module type VAT_NETWORK = sig
         The vat takes ownership of [bootstrap], and will release it when the switch is turned off.
         Turning off the switch will also disconnect any active connections. *)
 
-    val connect : t -> Endpoint.t -> CapTP.t
-    (** [connect t endpoint] runs the CapTP protocol over [endpoint], which is a
-        connection to another vat. *)
+    val add_connection : t -> Endpoint.t -> CapTP.t
+    (** [add_connection t endpoint] runs the CapTP protocol over [endpoint],
+        which is a connection to another vat. *)
 
     val public_address : t -> Network.Address.t option
     (** [public_address t] is the address that peers should use when connecting
@@ -146,8 +146,11 @@ module type VAT_NETWORK = sig
     (** [pp_bootstrap_uri] formats [bootstrap_ref] as a URI that clients can use
         (or formats a message explaining why there isn't one). *)
 
-    val live : t -> 'a Sturdy_ref.t -> ('a capability, [> `Msg of string]) result Lwt.t
-    (** [live t sr] creates and returns a live reference to the off-line capability [sr]. *)
+    val connect : t -> 'a Sturdy_ref.t -> ('a capability, [> `Msg of string]) result Lwt.t
+    (** [connect t sr] creates and returns a live reference to the off-line capability [sr]. *)
+
+    val connect_exn : t -> 'a Sturdy_ref.t -> 'a capability Lwt.t
+    (** [connect_exn] is a wrapper for [connect] that returns a failed Lwt thread on error. *)
 
     val dump : t Fmt.t
   end

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -39,7 +39,8 @@ let serve vat_config =
 
 let connect addr =
   Lwt_main.run begin
-    Capnp_rpc_unix.connect addr >>= fun calc ->
+    let vat = Capnp_rpc_unix.client_only_vat () in
+    Capnp_rpc_unix.Vat.connect_exn vat addr >>= fun calc ->
     Logs.info (fun f -> f "Evaluating expression...");
     let remote_add = Calc.getOperator calc `Add in
     let result = Calc.evaluate calc Calc.Expr.(Call (remote_add, [Float 40.0; Float 2.0])) in

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -32,10 +32,10 @@ let get_bootstrap ~switch cs =
   let server_socket, client_socket = Unix_flow.socketpair ~switch () in
   let _server =
     Tls_wrapper.connect_as_server ~switch server_socket cs.server_key >|*=
-    Vat.connect cs.server
+    Vat.add_connection cs.server
   in
   Tls_wrapper.connect_as_client ~switch client_socket auth >|*= fun ep ->
-  let conn = Vat.connect cs.client ep in
+  let conn = Vat.add_connection cs.client ep in
   CapTP.bootstrap conn
 
 module Utils = struct

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -33,7 +33,7 @@ let handle_connection ~secret_key vat client =
   Network.accept_connection ~switch ~secret_key raw_flow >|= function
   | Error (`Msg msg) -> Log.warn (fun f -> f "Rejecting new connection: %s" msg)
   | Ok ep ->
-    let _ : CapTP.t = Vat.connect vat ep in
+    let _ : CapTP.t = Vat.add_connection vat ep in
     ()
 
 let addr_of_host host =
@@ -87,13 +87,5 @@ let serve ?offer {Vat_config.backlog; secret_key; listen_address; public_address
   Lwt.async loop;
   Lwt.return vat
 
-let connect ?switch ?offer sr =
-  let switch =
-    match switch with
-    | None -> Lwt_switch.create ()
-    | Some x -> x
-  in
-  let vat = Vat.create ~switch ?bootstrap:offer () in
-  Vat.live vat sr >|= function
-  | Ok x -> x
-  | Error (`Msg msg) -> failwith msg
+let client_only_vat ?switch ?offer () =
+  Vat.create ?switch ?bootstrap:offer ()

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -53,12 +53,8 @@ val serve :
     as specified by [vat_config]. After connecting to it, clients can get
     access to the bootstrap service [offer]. *)
 
-val connect :
+val client_only_vat :
   ?switch:Lwt_switch.t ->
   ?offer:'a Capability.t ->
-  'b Sturdy_ref.t ->
-  'b Capability.t Lwt.t
-(** [connect addr] connects to the server at [addr] and returns its bootstrap object.
-    If [offer] is given, the client will also offer this service to the remote vat.
-    If [switch] is given then turning it off will disconnect,
-    and disconnecting will turn off the switch. *)
+  unit -> Vat.t
+(** [client_only_vat ()] is a new vat that does not listen for incoming connections. *)


### PR DESCRIPTION
Rename `Vat.connect` to `Vat.add_connection` and rename `Vat.live` to `Vat.connect`. This seems clearer.

Replace `Capnp_rpc_unix.connect` with `Capnp_rpc_unix.client_only_vat`, which just creates the client vat but doesn't connect it to anything. The user must then use the new `Vat.connect` function to connect to something.

This is more explicit and works better if the client needs to connect to multiple services, or to connect multiple times to a single service (in these cases, you only want to create a single vat).