### PR TITLE
Secrets in sturdy refs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam@sha256:374934a4a512f1adf96f0a2858ef68d27719af96b7d0c28e5206f207edd98b6d
-#FROM ocaml/opam:debian-9_ocaml-4.04.0
-RUN cd opam-repository && git fetch && git reset --hard d991b129d7e5834a73ee8d45e700955ecbc2e444 && opam update
+FROM ocaml/opam@sha256:5e8ebc171a90fb62209e67dcaeedafd02018bc43ebc1e3074a5d03f9789f0ca1
+#FROM ocaml/opam:debian-9_ocaml-4.05.0
+RUN cd opam-repository && git fetch && git reset --hard 3cad9b6baa95451f294008d0b791c2b0d54b0968 && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
 RUN opam pin add -ny capnp-rpc . && \

--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -104,10 +104,11 @@ module Make (Network : S.NETWORK) = struct
     in
     loop ()
 
-  let connect ?offer ?(tags=Logs.Tag.empty) ~switch endpoint =
+  let connect ~restore ?(tags=Logs.Tag.empty) ~switch endpoint =
     let xmit_queue = Queue.create () in
     let queue_send msg = queue_send ~switch ~xmit_queue endpoint (Serialise.message msg) in
-    let conn = Conn.create ?bootstrap:offer ~tags ~queue_send in
+    let restore = Restorer.fn restore in
+    let conn = Conn.create ~restore ~tags ~queue_send in
     Lwt_switch.add_hook (Some switch) (fun () ->
         Conn.disconnect conn (Capnp_rpc.Exception.v ~ty:`Disconnected "CapTP switch turned off");
         Lwt.return_unit

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -6,15 +6,16 @@ module Make (N : S.NETWORK) : sig
   type t
   (** A Cap'n Proto RPC protocol handler. *)
 
-  val connect : ?offer:cap -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
-  (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
+  val connect : restore:Restorer.t -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+  (** [connect ~restore ~switch endpoint] is fresh CapTP protocol handler that sends and
       receives messages using [endpoint].
-      If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
+      [restore] is used to respond to "Bootstrap" messages.
       If the connection fails then [switch] will be turned off, and turning off the switch
       will release all resources used by the connection. *)
 
-  val bootstrap : t -> cap
-  (** [bootstrap t] is the peer's public bootstrap object, if any. *)
+  val bootstrap : t -> string -> cap
+  (** [bootstrap t object_id] is the peer's bootstrap object [object_id], if any.
+      Use [object_id = ""] for the main, public object. *)
 
   val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
 

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -140,9 +140,12 @@ module Endpoint = Endpoint
 
 module S = S
 
+module Restorer = Restorer
+
 module Networking (N : S.NETWORK) (F : Mirage_flow_lwt.S) = struct
   type flow = F.flow
   type 'a capability = 'a Capability.t
+  type restorer = Restorer.t
 
   module Network = N
   module Vat = Vat.Make (N) (F)

--- a/capnp-rpc-lwt/parse.ml
+++ b/capnp-rpc-lwt/parse.ml
@@ -107,10 +107,19 @@ module Make_basic
     in
     `Call (aid, target, msg, descs, results_to)
 
+  let string_of_pointer = function
+    | None -> ""
+    | Some ptr ->
+      let open Capnp.BytesMessage in
+      let data = { ptr with Slice.len = 0 } in
+      let ss = StructStorage.v ~data ~pointers:ptr in
+      Schema.ReaderOps.get_text ~default:"" (Some ss) 0
+
   let parse_bootstrap boot =
     let open Reader in
     let qid = Bootstrap.question_id_get boot |> AnswerId.of_uint32 in
-    `Bootstrap qid
+    let object_id = Bootstrap.deprecated_object_id_get boot |> string_of_pointer in
+    `Bootstrap (qid, object_id)
 
   let parse_disembargo x =
     let open Reader in

--- a/capnp-rpc-lwt/restorer.ml
+++ b/capnp-rpc-lwt/restorer.ml
@@ -1,0 +1,50 @@
+module Core_types = Capnp_core.Core_types
+module Log = Capnp_rpc.Debug.Log
+
+module Id = struct
+  type t = string
+
+  let generate () =
+    Nocrypto.Rng.generate 20 |> Cstruct.to_string
+
+  let public x = x
+
+  let derived ~secret name =
+    Nocrypto.Hash.mac `SHA256 ~key:(Cstruct.of_string secret) (Cstruct.of_string name)
+    |> Cstruct.to_string
+end
+
+type resolution = (Core_types.cap, Capnp_rpc.Exception.t) result
+
+type t = Id.t -> resolution Lwt.t
+
+let grant x = Ok x
+let reject ex = Error ex
+
+let unknown_service_id = reject (Capnp_rpc.Exception.v "Unknown persistent service ID")
+
+let fn (r:t) =
+  fun k object_id ->
+    Lwt.async (fun () ->
+        Lwt.try_bind
+          (fun () -> r object_id)
+          (fun r -> k r; Lwt.return_unit)
+          (fun ex ->
+             Log.err (fun f -> f "Uncaught exception restoring object: %a" Fmt.exn ex);
+             k (reject (Capnp_rpc.Exception.v "Internal error restoring object"));
+             Lwt.return_unit
+          )
+      )
+
+let restore f x = f x
+
+let none : t = fun _ ->
+  Lwt.return @@ Error (Capnp_rpc.Exception.v "This vat has no restorer")
+
+let single id cap =
+  (* Hash the ID to prevent timing attacks. *)
+  let id = Nocrypto.Hash.digest `SHA256 (Cstruct.of_string id) in
+  fun requested_id ->
+    let requested_id = Nocrypto.Hash.digest `SHA256 (Cstruct.of_string requested_id) in
+    if Cstruct.equal id requested_id then Lwt.return (Ok cap)
+    else Lwt.return unknown_service_id

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -7,10 +7,11 @@ module type NETWORK = sig
     type t
     (** A network address at which a vat can be reached. *)
 
-    val parse_uri : Uri.t -> (t, [> `Msg of string]) result
-    (** [parse_uri uri] extracts from a URI the network address. *)
+    val parse_uri : Uri.t -> ((t * string), [> `Msg of string]) result
+    (** [parse_uri uri] extracts from a URI the network address and service ID. *)
 
-    val to_uri : t -> Uri.t
+    val to_uri : t -> string -> Uri.t
+    (** [to_uri t service_id] is a URI that can be parsed back into [(t, service_id)] by [parse_uri]. *)
 
     val equal : t -> t -> bool
 
@@ -32,6 +33,9 @@ module type VAT_NETWORK = sig
   type flow
   (** A bi-directional byte-stream. *)
 
+  type restorer
+  (** A function for restoring persistent capabilities from sturdy ref service IDs. *)
+
   module Network : NETWORK
 
   module Sturdy_ref : sig
@@ -46,22 +50,20 @@ module type VAT_NETWORK = sig
         Note that a sturdy ref often contains secrets.
       *)
 
-    type service = [
-      | `Bootstrap
-    ]
+    type service_id
     (** Identifies a service within the hosting vat.
-        todo: other targets *)
+        This is typically a long, unguessable string. *)
 
     type +'a t
     (** A persistent capability reference that can be restored after contact to the target vat is interrupted. *)
 
-    val v : address:Network.Address.t -> service:service -> 'a t
+    val v : address:Network.Address.t -> service:service_id -> 'a t
     (** Create a new sturdy ref. *)
 
     val address : 'a t -> Network.Address.t
     (** Where and how to connect to access this service's vat. *)
 
-    val service : 'a t -> service
+    val service : 'a t -> service_id
     (** Which service within the vat to select. *)
 
     val cast : _ t -> _ t
@@ -91,15 +93,16 @@ module type VAT_NETWORK = sig
     type t
     (** A CapTP connection to a remote peer. *)
 
-    val connect : ?offer:'a capability -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
-    (** [connect ?offer ~switch endpoint] is fresh CapTP protocol handler that sends and
+    val connect : restore:restorer -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+    (** [connect ~restore ~switch endpoint] is fresh CapTP protocol handler that sends and
         receives messages using [endpoint].
-        If [offer] is given, the peer can use the "Bootstrap" message to get access to it.
+        [restore] is used to respond to "Bootstrap" messages.
         If the connection fails then [switch] will be turned off, and turning off the switch
         will release all resources used by the connection. *)
 
-    val bootstrap : t -> 'a capability
-    (** [bootstrap t] is the peer's public bootstrap object, if any. *)
+    val bootstrap : t -> Sturdy_ref.service_id -> 'a capability
+    (** [bootstrap t object_id] is the peer's bootstrap object [object_id], if any.
+        Use [object_id = ""] for the main, public object. *)
 
     val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
     (** [disconnect reason] closes the connection, sending [reason] to the peer to explain why.
@@ -121,13 +124,13 @@ module type VAT_NETWORK = sig
 
     val create :
       ?switch:Lwt_switch.t ->
-      ?bootstrap:'a capability ->
+      ?restore:restorer ->
       ?address:Network.Address.t ->
       unit -> t
-    (** [create ~switch ~bootstrap ~address ()] is a new vat that offers [bootstrap] to its peers.
+    (** [create ~switch ~restore ~address ()] is a new vat that uses [restore] to restore
+        sturdy refs hosted at this vat to live capabilities for peers.
         The vat will suggest that other parties connect to it using [address].
-        The vat takes ownership of [bootstrap], and will release it when the switch is turned off.
-        Turning off the switch will also disconnect any active connections. *)
+        Turning off the switch will disconnect any active connections. *)
 
     val add_connection : t -> Endpoint.t -> CapTP.t
     (** [add_connection t endpoint] runs the CapTP protocol over [endpoint],
@@ -137,14 +140,9 @@ module type VAT_NETWORK = sig
     (** [public_address t] is the address that peers should use when connecting
         to this vat to locate and authenticate it. *)
 
-    val bootstrap_ref : t -> 'a Sturdy_ref.t
-    (** [bootstrap_ref t] is a sturdy ref that can be used to connect to the
-        vat's bootstrap object. Fails if this vat does not accept incoming
-        connections. *)
-
-    val pp_bootstrap_uri : t Fmt.t
-    (** [pp_bootstrap_uri] formats [bootstrap_ref] as a URI that clients can use
-        (or formats a message explaining why there isn't one). *)
+    val sturdy_ref : t -> Sturdy_ref.service_id -> 'a Sturdy_ref.t
+    (** [sturdy_ref t object_id] is a sturdy ref for [object_id], hosted at this vat.
+        Fails if this vat does not accept incoming connections. *)
 
     val connect : t -> 'a Sturdy_ref.t -> ('a capability, [> `Msg of string]) result Lwt.t
     (** [connect t sr] creates and returns a live reference to the off-line capability [sr]. *)

--- a/capnp-rpc-lwt/serialise.ml
+++ b/capnp-rpc-lwt/serialise.ml
@@ -2,6 +2,7 @@ module EmbargoId = Capnp_rpc.Message_types.EmbargoId
 module Log = Capnp_rpc.Debug.Log
 module Builder = Schema.Builder
 module RO_array = Capnp_rpc.RO_array
+module BuilderOps = Capnp.Runtime.BuilderInc.Make(Capnp.RPC.None(Capnp.BytesMessage))
 
 module Make (EP : Capnp_core.ENDPOINT) = struct
   open EP.Table
@@ -57,6 +58,12 @@ module Make (EP : Capnp_core.ENDPOINT) = struct
     type_set b ty;
     reason_set b ex.Capnp_rpc.Exception.reason
 
+  let write_string ptr s =
+    let open Capnp.BytesMessage in
+    let data = { ptr with Slice.len = 0 } in
+    let ss = StructStorage.v ~data ~pointers:ptr in
+    BuilderOps.BA_.set_text ss 0 s
+
   let message : EP.Out.t -> _ =
     let open Builder in
     function
@@ -64,10 +71,11 @@ module Make (EP : Capnp_core.ENDPOINT) = struct
       let b = Message.init_root () in
       write_exn (Message.abort_init b) ex;
       Message.to_message b
-    | `Bootstrap qid ->
+    | `Bootstrap (qid, object_id) ->
       let b = Message.init_root () in
       let boot = Message.bootstrap_init b in
       Bootstrap.question_id_set boot (QuestionId.uint32 qid);
+      write_string (Bootstrap.deprecated_object_id_get boot) object_id;
       Message.to_message b
     | `Call (qid, target, request, descs, results_to) ->
       let c = Msg.Request.writable request in

--- a/capnp-rpc/message_types.ml
+++ b/capnp-rpc/message_types.ml
@@ -89,7 +89,7 @@ module Make (Core_types : S.CORE_TYPES) (Network : S.NETWORK_TYPES) (T : TABLE_T
 
   type t = [
     | `Abort of Exception.t
-    | `Bootstrap of QuestionId.t
+    | `Bootstrap of QuestionId.t * string
     | `Call of QuestionId.t * message_target * Request.t * desc RO_array.t * send_results_to
     | `Finish of (QuestionId.t * bool)      (* bool is release-caps *)
     | `Release of ImportId.t * int
@@ -102,7 +102,7 @@ module Make (Core_types : S.CORE_TYPES) (Network : S.NETWORK_TYPES) (T : TABLE_T
 
   let with_qid_tag tags : t -> _ = function
     | `Finish (qid, _)
-    | `Bootstrap qid
+    | `Bootstrap (qid, _)
     | `Call (qid, _, _, _, _)
     | `Disembargo_request (`Loopback (`ReceiverAnswer (qid, _), _))
     | `Disembargo_reply (`ReceiverAnswer (qid, _), _) ->

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -30,8 +30,11 @@ let reporter =
 
 let serve vat_config =
   Lwt_main.run begin
-    Capnp_rpc_unix.serve vat_config ~offer:Examples.Calc.local >>= fun vat ->
-    Fmt.pr "Waiting for incoming connections at:@.%a@." Capnp_rpc_unix.Vat.pp_bootstrap_uri vat;
+    let service_id = Capnp_rpc_lwt.Restorer.Id.public "calculator" in
+    let restore = Capnp_rpc_lwt.Restorer.single service_id Examples.Calc.local in
+    Capnp_rpc_unix.serve vat_config ~restore >>= fun vat ->
+    let sr = Capnp_rpc_unix.Vat.sturdy_ref vat service_id in
+    Fmt.pr "Waiting for incoming connections at:@.%a@." Capnp_rpc_unix.Sturdy_ref.pp_with_secrets sr;
     fst @@ Lwt.wait ()
   end
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -1372,8 +1372,7 @@ module Level0 = struct
     let to_server = Queue.create () in
     let c = { from_server; to_server } in
     let s = S.create ~tags:Test_utils.server_tags from_server to_server ~bootstrap in
-    dec_ref bootstrap;
-    send c @@ `Bootstrap (qid_of_int 0);
+    send c @@ `Bootstrap (qid_of_int 0, "");
     S.handle_msg s ~expect:"bootstrap";
     send c @@ `Finish (qid_of_int 0, false);
     S.handle_msg s ~expect:"finish";
@@ -1396,7 +1395,7 @@ module Level0 = struct
   let expect_bs t =
     let bs_request = Queue.pop t.from_server in
     match bs_request with
-    | `Bootstrap qid -> qid
+    | `Bootstrap (qid, "") -> qid
     | _ -> Alcotest.fail (Fmt.strf "Expecting bootstrap, got %s" (Testbed.Connection.summary_of_msg bs_request))
 
   let expect_call t expected =

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -1,3 +1,4 @@
+open Astring
 module Log = Capnp_rpc.Debug.Log
 module Tls_wrapper = Capnp_rpc_lwt.Auth.Tls_wrapper(Unix_flow)
 
@@ -34,21 +35,37 @@ end
 module Address = struct
   type t = Socket_address.t * Capnp_rpc_lwt.Auth.Digest.t
 
-  let to_uri (addr, auth) =
+  let alphabet = B64.uri_safe_alphabet
+
+  let b64encode s = B64.encode ~alphabet ~pad:false s
+
+  let b64decode s =
+    try Ok (B64.decode ~alphabet s)
+    with ex -> error "Bad base64 digest %S: %a" s Fmt.exn ex
+
+  let to_uri (addr, auth) service_id =
+    let service_id = b64encode service_id in
     let uri =
       match addr with
-      | `Unix path -> Uri.make ~scheme:"capnp" ~path ()
-      | `TCP (host, port) -> Uri.make ~scheme:"capnp" ~host ~port ()
+      | `Unix path ->
+        let path = Printf.sprintf "%s/%s" path service_id in
+        Uri.make ~scheme:"capnp" ~path ()
+      | `TCP (host, port) ->
+        Uri.make ~scheme:"capnp" ~host ~port ~path:service_id ()
     in
     Capnp_rpc_lwt.Auth.Digest.add_to_uri auth uri
 
-  let pp f (addr, auth) =
-    Fmt.pf f "%a@%a" Capnp_rpc_lwt.Auth.Digest.pp auth Socket_address.pp addr
+  let pp f t =
+    Uri.pp_hum f (to_uri t "")
 
   let ( >>= ) x f =
     match x with
     | Error _ as e -> e
     | Ok y -> f y
+
+  let strip_leading_slash s =
+    if String.is_prefix ~affix:"/" s then String.with_range ~first:1 s
+    else s
 
   let parse_uri uri =
     let host = Uri.host uri |> none_if_empty in
@@ -56,11 +73,17 @@ module Address = struct
     let path = Uri.path uri in
     Capnp_rpc_lwt.Auth.Digest.from_uri uri >>= fun auth ->
     match host, port with
-    | Some host, Some port when path = "" -> Ok (`TCP (host, port), auth)
-    | Some _,    Some _ -> error "Unexpected path component %S in %a" path Uri.pp_hum uri
+    | Some host, Some port ->
+      b64decode (strip_leading_slash path) >>= fun service_id ->
+      Ok ((`TCP (host, port), auth), service_id)
     | Some _,    None   -> error "Missing port in %a" Uri.pp_hum uri
     | None,      Some _ -> error "Port without host in %a!" Uri.pp_hum uri
-    | None,      None   -> Ok (`Unix path, auth)
+    | None,      None   ->
+      match String.cut ~rev:true ~sep:"/" path with
+      | None -> Ok ((`Unix path, auth), "")
+      | Some (path, service_id) ->
+        b64decode service_id >>= fun service_id ->
+        Ok ((`Unix path, auth), service_id)
 
   let equal (addr, auth) (addr_b, auth_b) =
     Socket_address.equal addr addr_b &&

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -36,15 +36,29 @@ module Listen_address = struct
     Arg.(required @@ opt (some addr_conv) None i)
 end
 
+module Secret_hash : sig
+  type t
+
+  val of_pem_data : string -> t
+  val to_string : t -> string
+end = struct
+  type t = string
+
+  let of_pem_data data = Nocrypto.Hash.SHA256.digest (Cstruct.of_string data) |> Cstruct.to_string
+  let to_string x = x
+end
+
 type t = {
   backlog : int;
-  secret_key : Auth.Secret_key.t Lazy.t;
+  secret_key : (Auth.Secret_key.t * Secret_hash.t) Lazy.t;
   serve_tls : bool;
   listen_address : Network.Socket_address.t;
   public_address : Network.Socket_address.t;
 }
 
-let secret_key t = Lazy.force t.secret_key
+let secret_key t = fst @@ Lazy.force t.secret_key
+
+let hashed_secret t = Secret_hash.to_string @@ snd @@ Lazy.force t.secret_key
 
 let secret_key_file =
   let open Cmdliner in
@@ -67,12 +81,14 @@ let write_whole_file path data =
 let init_secret_key_file key_file =
   if Sys.file_exists key_file then (
     Log.info (fun f -> f "Restoring saved secret key from existing file %S" key_file);
-    Auth.Secret_key.of_pem_data (read_whole_file key_file)
+    let data = read_whole_file key_file in
+    (Auth.Secret_key.of_pem_data data, Secret_hash.of_pem_data data)
   ) else (
     Log.info (fun f -> f "Generating new secret key to store in %S" key_file);
     let secret_key = Auth.Secret_key.generate () in
-    write_whole_file key_file (Auth.Secret_key.to_pem_data secret_key);
-    secret_key
+    let data = Auth.Secret_key.to_pem_data secret_key in
+    write_whole_file key_file data;
+    (secret_key, Secret_hash.of_pem_data data)
   )
 
 let create ?(backlog=5) ?public_address ~secret_key ?(serve_tls=true) listen_address =
@@ -84,8 +100,11 @@ let create ?(backlog=5) ?public_address ~secret_key ?(serve_tls=true) listen_add
   let secret_key = lazy (
     match secret_key with
     | `File path -> init_secret_key_file path
-    | `PEM data -> Auth.Secret_key.of_pem_data data
-    | `Ephemeral -> Auth.Secret_key.generate ()
+    | `PEM data -> (Auth.Secret_key.of_pem_data data, Secret_hash.of_pem_data data)
+    | `Ephemeral ->
+      let key = Auth.Secret_key.generate () in
+      let data = Auth.Secret_key.to_pem_data key in
+      (key, Secret_hash.of_pem_data data)
   ) in
   { backlog; secret_key; serve_tls; listen_address; public_address }
 
@@ -96,12 +115,16 @@ let secret_key_term =
   in
   Cmdliner.Term.(pure get $ secret_key_file)
 
+let derived_id ?(name="main") t =
+  let secret = hashed_secret t in
+  Capnp_rpc_lwt.Restorer.Id.derived ~secret name
+
 open Cmdliner
 
 let pp f {backlog; secret_key; serve_tls; listen_address; public_address} =
   Fmt.pf f "{backlog=%d; fingerprint=%a; serve_tls=%b; listen_address=%a; public_address=%a}"
     backlog
-    (Auth.Secret_key.pp_fingerprint `SHA256) (Lazy.force secret_key)
+    (Auth.Secret_key.pp_fingerprint `SHA256) (fst @@ Lazy.force secret_key)
     serve_tls
     Network.Socket_address.pp listen_address
     Network.Socket_address.pp public_address
@@ -111,7 +134,7 @@ let equal {backlog; secret_key; serve_tls; listen_address; public_address} b =
   serve_tls = serve_tls &&
   Network.Socket_address.equal listen_address b.listen_address &&
   Network.Socket_address.equal public_address b.public_address &&
-  Auth.Secret_key.equal (Lazy.force secret_key) (Lazy.force b.secret_key)
+  Auth.Secret_key.equal (fst @@ Lazy.force secret_key) (fst @@ Lazy.force b.secret_key)
 
 let public_address =
   let i = Arg.info ["public-address"] ~docv:"ADDR" ~doc:"Address to tell others to connect on." in


### PR DESCRIPTION
Sturdy refs now include a service ID component, which is passed in the Cap'n Proto `Bootstrap` message. This field is marked as "deprecated" in the spec, but there doesn't seem to be a replacement yet, it does what we need, and the other libraries still use it.

Service IDs can be generated randomly or derived from another secret (e.g. the vat's private key). The user can also supply a string manually, e.g. for interoperability with systems with non-secret IDs.

Instead of passing an `~offer` argument with the public service, use `~restore` to pass a `Restorer.t`.

Use `Vat.sturdy_ref` instead of `Vat.bootstrap_ref` or `Vat.pp_bootstrap_uri`.

This system is intended to be extended later to support the persistence system.

Also, add a TOC to README.

Closes #92.