### PR TITLE
Add Restorer.Table

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -19,6 +19,7 @@ module Capability = struct
   let dec_ref = Core_types.dec_ref
   let pp f x = x#pp f
 
+  let broken ex = Core_types.broken_cap ex
   let problem x = x#problem
 
   let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) (req : 'a Request.t) =

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -35,6 +35,10 @@ module Capability : sig
   type +'a t
   (** An ['a t] is a capability reference to a service of type ['a]. *)
 
+  val broken : Capnp_rpc.Exception.t -> 'a t
+  (** [broken ex] is a broken capability, with problem [ex].
+      Any attempt to call methods on it will fail with [ex]. *)
+
   val problem : 'a t -> Capnp_rpc.Exception.t option
   (** [problem t] is [Some ex] if [t] is broken, or [None] if it is still
       believed to be healthy. Once a capability is broken, it will never

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -215,6 +215,26 @@ module Restorer : sig
   (** [single id cap] is a restorer that responds to [id] with [cap] and
       rejects everything else. *)
 
+  module Table : sig
+    type t
+    (** A restorer that keeps a hashtable mapping IDs to capabilities in memory. *)
+
+    val create : unit -> t
+    (** [create ()] is a new in-memory table. *)
+
+    val add : t -> Id.t -> 'a Capability.t -> unit
+    (** [add t id cap] adds a mapping to [t].
+        It takes ownership of [cap] (it will call [Capability.dec_ref cap] on [clear]). *)
+
+    val remove : t -> Id.t -> unit
+    (** [remove t id] removes [id] from [t], decrementing the capability's ref count. *)
+
+    val clear : t -> unit
+    (** [clear t] clears the table, dropping all references. *)
+  end
+
+  val of_table : Table.t -> t
+
   val restore : t -> Id.t -> ('a Capability.t, Capnp_rpc.Exception.t) result Lwt.t
   (** [restore t id] restores [id] using [t].
       You don't normally need to call this directly, as the Vat will do it automatically. *)

--- a/capnp-rpc-lwt/restorer.ml
+++ b/capnp-rpc-lwt/restorer.ml
@@ -12,6 +12,11 @@ module Id = struct
   let derived ~secret name =
     Nocrypto.Hash.mac `SHA256 ~key:(Cstruct.of_string secret) (Cstruct.of_string name)
     |> Cstruct.to_string
+
+  let digest alg t =
+    let alg = (alg :> Nocrypto.Hash.hash) in
+    Nocrypto.Hash.digest alg (Cstruct.of_string t)
+    |> Cstruct.to_string
 end
 
 type resolution = (Core_types.cap, Capnp_rpc.Exception.t) result
@@ -48,3 +53,39 @@ let single id cap =
     let requested_id = Nocrypto.Hash.digest `SHA256 (Cstruct.of_string requested_id) in
     if Cstruct.equal id requested_id then Lwt.return (Ok cap)
     else Lwt.return unknown_service_id
+
+module Table = struct
+  type t = (string, Core_types.cap) Hashtbl.t
+
+  let create () = Hashtbl.create 7
+
+  let hash = Id.digest `SHA256
+
+  let add t id cap =
+    let id = hash id in
+    assert (not (Hashtbl.mem t id));
+    Hashtbl.add t id cap
+
+  let remove t id =
+    let id = hash id in
+    match Hashtbl.find t id with
+    | exception Not_found -> failwith "Service ID not in restorer table"
+    | cap ->
+      Core_types.dec_ref cap;
+      Hashtbl.remove t id
+
+  let clear t =
+    Hashtbl.iter (fun _ c -> Core_types.dec_ref c) t;
+    Hashtbl.clear t
+
+  let restorer t =
+    fun id ->
+      let id = hash id in
+      match Hashtbl.find t id with
+      | exception Not_found -> Lwt.return unknown_service_id
+      | cap ->
+        Core_types.inc_ref cap;
+        Lwt.return @@ Ok cap
+end
+
+let of_table = Table.restorer


### PR DESCRIPTION
This is a simple in-memory table mapping IDs to services.

This is useful if you want to export several interfaces, e.g. "admin", "user", etc.

It can also be used for persistence, although it gets inefficient if the number of services is large as they must all be restored at start-up.

This PR also adds the missing `Capability.broken` function.