### PR TITLE
Implement persistence support

### DIFF
--- a/capnp-rpc-lwt/service.ml
+++ b/capnp-rpc-lwt/service.ml
@@ -30,7 +30,9 @@ let local (s:#generic) =
 
     method! pp f = Fmt.pf f "%t(%t)" s#pp super#pp_refcount
 
-    method! private release = s#release
+    method! private release =
+      super#release;
+      s#release
 
     method call results msg =
       let open Schema.Reader in

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -175,6 +175,12 @@ module type CORE_TYPES = sig
         If [c] is a far-ref, [fn x] will be called when it breaks.
         If [c] is forwarding to another cap, it will forward this call. *)
 
+    method when_released : (unit -> unit) -> unit
+    (** [c#when_released fn] will call [fn ()] when [c]'s ref-count drops to zero.
+        This is used for caches, to remove entries when they become invalid.
+        For promises, [fn] will be transferred to the resolution if resolved.
+        For broken caps, this method does nothing (exceptions are never released). *)
+
     method problem : Exception.t option
     (** [c#problem] is the exception for a broken reference, or [None] if it is not known to be broken. *)
 
@@ -256,6 +262,7 @@ module type CORE_TYPES = sig
     method shortest : cap
     method private release : unit
     method when_more_resolved : (cap -> unit) -> unit
+    method when_released : (unit -> unit) -> unit
     method problem : Exception.t option
   end
   (** A convenience base class for creating local services.

--- a/unix/file_store.ml
+++ b/unix/file_store.ml
@@ -1,0 +1,58 @@
+open Capnp_rpc_lwt
+
+module ReaderOps = Capnp.Runtime.ReaderInc.Make(Capnp_rpc_lwt)
+
+type 'a t = {
+  dir : string;
+  hash : Capnp_rpc_lwt.Auth.hash;
+  vat_config : Vat_config.t;
+}
+
+let create ~dir ~hash vat_config =
+  { dir; hash; vat_config }
+
+let path_of_digest t digest =
+  let filename = B64.encode ~alphabet:B64.uri_safe_alphabet ~pad:false digest in
+  Filename.concat t.dir filename
+
+let segments_of_reader = function
+  | None -> []
+  | Some ss -> Message.to_storage ss.StructStorage.data.Slice.msg
+
+let update t ~digest data =
+  let path = path_of_digest t digest in
+  let tmp_path = path ^ ".new" in
+  let ch = open_out tmp_path in
+  let segments = segments_of_reader data in
+  segments |> List.iter (fun {Message.segment; bytes_consumed} ->
+      output ch segment 0 bytes_consumed
+    );
+  close_out ch;
+  Unix.rename tmp_path path
+
+let save t data =
+  let id = Restorer.Id.generate () in
+  let digest = Restorer.Id.digest t.hash id in
+  update t ~digest data;
+  Vat_config.sturdy_ref t.vat_config id
+
+let remove t ~digest =
+  let path = path_of_digest t digest in
+  Unix.unlink path
+
+let load t ~digest =
+  let path = path_of_digest t digest in
+  if Sys.file_exists path then (
+    let ch = open_in path in
+    let len = in_channel_length ch in
+    let segment = really_input_string ch len in
+    close_in ch;
+    let msg = Message.of_storage [segment] in
+    let reader = ReaderOps.get_root_struct (Message.readonly msg) in
+    Some reader
+  ) else (
+    Logs.info (fun f -> f "File %S not found" path);
+    None
+  )
+
+let hash t = t.hash

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -119,6 +119,14 @@ let derived_id ?(name="main") t =
   let secret = hashed_secret t in
   Capnp_rpc_lwt.Restorer.Id.derived ~secret name
 
+let auth t =
+  if t.serve_tls then Capnp_rpc_lwt.Auth.Secret_key.digest (secret_key t)
+  else Capnp_rpc_lwt.Auth.Digest.insecure
+
+let sturdy_ref t service =
+  let address = (t.public_address, auth t) in
+  Vat_network.Sturdy_ref.v ~address ~service
+
 open Cmdliner
 
 let pp f {backlog; secret_key; serve_tls; listen_address; public_address} =

--- a/unix/vat_network.ml
+++ b/unix/vat_network.ml
@@ -1,0 +1,1 @@
+include Capnp_rpc_lwt.Networking (Network) (Unix_flow)


### PR DESCRIPTION
Use the new `Table.of_loader` to create a services table that dynamically loads capabilities from persistent storage (filesystem, database, etc).

The new `Vat_config.sturdy_ref` allows making sturdy refs before the vat itself has been initialised. This is useful if you need to create a main service that can create new sturdy refs.

See the tutorial changes for how to use the new APIs.

The tutorial now also explains how to run the client and server in separate processes, as it's hard to demonstrate persistence without this.

Closes #101.