### PR TITLE
Add Capability.when_broken

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -19,7 +19,8 @@ module Capability = struct
   let dec_ref = Core_types.dec_ref
   let pp f x = x#pp f
 
-  let broken ex = Core_types.broken_cap ex
+  let broken = Core_types.broken_cap
+  let when_broken = Core_types.when_broken
   let problem x = x#problem
 
   let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) (req : 'a Request.t) =

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -39,6 +39,13 @@ module Capability : sig
   (** [broken ex] is a broken capability, with problem [ex].
       Any attempt to call methods on it will fail with [ex]. *)
 
+  val when_broken : (Capnp_rpc.Exception.t -> unit) -> 'a t -> unit
+  (** [when_broken fn x] calls [fn problem] when [x] becomes broken.
+      If [x] is already broken, [fn] is called immediately.
+      If [x] can never become broken (e.g. it is a near ref), this does nothing.
+      If [x]'s ref-count reaches zero without [fn] being called, it will never
+      be called. *)
+
   val problem : 'a t -> Capnp_rpc.Exception.t option
   (** [problem t] is [Some ex] if [t] is broken, or [None] if it is still
       believed to be healthy. Once a capability is broken, it will never

--- a/capnp-rpc/core_types.ml
+++ b/capnp-rpc/core_types.ml
@@ -301,4 +301,12 @@ module Make(Wire : S.WIRE) = struct
   let resolve_payload (r:#struct_resolver) (x:Response_payload.t or_error) = r#resolve (resolved x)
   let resolve_ok r msg = resolve_payload r (Ok msg)
   let resolve_exn r ex = resolve_payload r (Error (`Exception ex))
+
+  let rec when_broken fn (x:#cap) =
+    match x#problem with
+    | Some problem -> fn problem
+    | None ->
+      x#when_more_resolved @@ fun x ->
+      when_broken fn x;
+      dec_ref x
 end

--- a/capnp-rpc/s.ml
+++ b/capnp-rpc/s.ml
@@ -173,7 +173,8 @@ module type CORE_TYPES = sig
         Note that the new capability can be another promise.
         If [c] is already resolved to its final value, this does nothing.
         If [c] is a far-ref, [fn x] will be called when it breaks.
-        If [c] is forwarding to another cap, it will forward this call. *)
+        If [c] is forwarding to another cap, it will forward this call.
+        If [c] gets released before calling [fn], it will never call it. *)
 
     method when_released : (unit -> unit) -> unit
     (** [c#when_released fn] will call [fn ()] when [c]'s ref-count drops to zero.
@@ -296,6 +297,11 @@ module type CORE_TYPES = sig
 
   val resolve_exn : #struct_resolver -> Exception.t -> unit
   (** [resolve_exn r exn] is [resolve_payload r (Error (`Exception exn))]. *)
+
+  val when_broken : (Exception.t -> unit) -> cap -> unit
+  (** [when_broken fn x] calls [fn problem] when [x] becomes broken.
+      If [x] is already broken, [fn] is called immediately.
+      If [x] can never become broken (e.g. it is a near ref), this does nothing. *)
 end
 
 module type NETWORK_TYPES = sig


### PR DESCRIPTION
This is useful to detect when a reference to a remote resource becomes broken due to a network partition.

Closes #106.