### PR TITLE
Eliminate duplicate connections

### DIFF
--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "asetmap"
   "mirage-flow-lwt"
-  "tls"
+  "tls" { >= "0.8.0" }
   "mirage-kv-lwt"
   "mirage-clock"
   "base64"

--- a/capnp-rpc-lwt/auth.ml
+++ b/capnp-rpc-lwt/auth.ml
@@ -1,3 +1,5 @@
+open Asetmap
+
 module Log = Capnp_rpc.Debug.Log
 
 let default_rsa_key_bits = 2048
@@ -81,6 +83,11 @@ module Digest = struct
          other implementations use other names. *)
       let fingerprints = ["capnp", Cstruct.of_string digest] in
       Some (X509.Authenticator.server_key_fingerprint ~hash ~fingerprints ?time:None)
+
+  module Map = Map.Make(struct
+      type nonrec t = t
+      let compare = compare
+    end)
 end
 
 module Secret_key = struct

--- a/capnp-rpc-lwt/auth.mli
+++ b/capnp-rpc-lwt/auth.mli
@@ -37,6 +37,9 @@ module Digest : sig
       matches [t]. Returns [None] if [t] is [insecure].
       Note: it currently also requires the DN field to be "capnp". *)
 
+  val of_certificate : X509.t -> t
+  (** [of_certificate cert] is a digest of [cert]'s public key. *)
+
   val equal : t -> t -> bool
 
   val pp : t Fmt.t
@@ -67,19 +70,4 @@ module Secret_key : sig
   (** [pp_fingerprint hash] formats the hash of [t]'s public key. *)
 
   val equal : t -> t -> bool
-end
-
-module Tls_wrapper (Underlying : Mirage_flow_lwt.S) : sig
-  (** Make an [Endpoint] from an [Underlying.flow], using TLS if appropriate. *)
-
-  val connect_as_server :
-    switch:Lwt_switch.t -> Underlying.flow -> Secret_key.t option ->
-    (Endpoint.t, [> `Msg of string]) result Lwt.t
-
-  val connect_as_client :
-    switch:Lwt_switch.t -> Underlying.flow -> Secret_key.t Lazy.t -> Digest.t ->
-    (Endpoint.t, [> `Msg of string]) result Lwt.t
-  (** [connect_as_client ~switch underlying key digest] is an endpoint using flow [underlying].
-      If [digest] requires TLS, it performs a TLS handshake. It uses [key] as its private key
-      and checks that the server is the one required by [auth]. *)
 end

--- a/capnp-rpc-lwt/auth.mli
+++ b/capnp-rpc-lwt/auth.mli
@@ -1,3 +1,5 @@
+open Asetmap
+
 (** Vat-level authentication and encryption.
 
     Unless your network provides a secure mechanism for establishing connections
@@ -43,6 +45,8 @@ module Digest : sig
   val equal : t -> t -> bool
 
   val pp : t Fmt.t
+
+  module Map : Map.S with type key = t
 end
 
 module Secret_key : sig

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -6,18 +6,18 @@ module Make (N : S.NETWORK) : sig
   type t
   (** A Cap'n Proto RPC protocol handler. *)
 
-  val connect : restore:Restorer.t -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+  val connect : restore:Restorer.t -> ?tags:Logs.Tag.set -> Endpoint.t -> t
   (** [connect ~restore ~switch endpoint] is fresh CapTP protocol handler that sends and
       receives messages using [endpoint].
       [restore] is used to respond to "Bootstrap" messages.
-      If the connection fails then [switch] will be turned off, and turning off the switch
-      will release all resources used by the connection. *)
+      If the connection fails then [endpoint] will be disconnected. *)
 
   val bootstrap : t -> string -> cap
   (** [bootstrap t object_id] is the peer's bootstrap object [object_id], if any.
       Use [object_id = ""] for the main, public object. *)
 
   val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
+  (** [disconnect t reason] releases all resources used by the connection. *)
 
   val dump : t Fmt.t
   (** [dump] dumps the state of the connection, for debugging. *)

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -157,3 +157,4 @@ end
 
 module Two_party_network = Two_party_network
 module Auth = Auth
+module Tls_wrapper = Tls_wrapper

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -51,6 +51,18 @@ module Capability : sig
       believed to be healthy. Once a capability is broken, it will never
       work again and any calls made on it will fail with exception [ex]. *)
 
+  val wait_until_settled : 'a t -> unit Lwt.t
+  (** [wait_until_settled x] resolves once [x] is a "settled" (non-promise) reference.
+      If [x] is a near, far or broken reference, this returns immediately.
+      If it is currently a local or remote promise, it waits until it isn't.
+      [wait_until_settled] takes ownership of [x] until it returns (you must not
+      [dec_ref] it before then). *)
+
+  val equal : 'a t -> 'a t -> (bool, [`Unsettled]) result
+  (** [equal a b] indicates whether [a] and [b] designate the same settled service.
+      Returns [Error `Unsettled] if [a] or [b] is still a promise (and they therefore
+      may yet turn out to be equal when the promise resolves). *)
+
   module Request : sig
     type 'a t
     (** An ['a t] is a builder for the out-going request's payload. *)

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -189,6 +189,7 @@ module S = S
 module Endpoint = Endpoint
 module Two_party_network = Two_party_network
 module Auth = Auth
+module Tls_wrapper = Tls_wrapper
 
 module Restorer : sig
   module Id : sig

--- a/capnp-rpc-lwt/endpoint.ml
+++ b/capnp-rpc-lwt/endpoint.ml
@@ -13,12 +13,15 @@ type t = {
   flow : flow;
   decoder : Capnp.Codecs.FramedStream.t;
   switch : Lwt_switch.t;
+  peer_id : Auth.Digest.t;
 }
 
-let of_flow (type flow) ~switch (module F : Mirage_flow_lwt.S with type flow = flow) (flow:flow) =
+let peer_id t = t.peer_id
+
+let of_flow (type flow) ~switch ~peer_id (module F : Mirage_flow_lwt.S with type flow = flow) (flow:flow) =
   let generic_flow = Flow ((module F), flow) in
   let decoder = Capnp.Codecs.FramedStream.empty compression in
-  { flow = generic_flow; decoder; switch }
+  { flow = generic_flow; decoder; switch; peer_id }
 
 let dump_msg =
   let next = ref 0 in

--- a/capnp-rpc-lwt/endpoint.ml
+++ b/capnp-rpc-lwt/endpoint.ml
@@ -62,6 +62,9 @@ let rec recv t =
     | Error ex when Lwt_switch.is_on t.switch -> Capnp_rpc.Debug.failf "recv: %a" F.pp_error ex
     | Error _ -> Lwt.return (Error `Closed)
 
+let disconnect t =
+  Lwt_switch.turn_off t.switch
+
 let pp_error f = function
   | `Closed -> Fmt.string f "Connection closed"
   | `Msg m -> Fmt.string f m

--- a/capnp-rpc-lwt/endpoint.mli
+++ b/capnp-rpc-lwt/endpoint.mli
@@ -11,11 +11,16 @@ val recv : t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [> `Closed]) res
     It returns [Error `Closed] if the connection to the peer is lost
     (this will also happen if the switch is turned off). *)
 
-val of_flow : switch:Lwt_switch.t -> (module Mirage_flow_lwt.S with type flow = 'flow) -> 'flow -> t
-(** [of_flow ~switch (module F) flow] sends and receives on [flow].
+val of_flow : switch:Lwt_switch.t -> peer_id:Auth.Digest.t ->
+  (module Mirage_flow_lwt.S with type flow = 'flow) -> 'flow -> t
+(** [of_flow ~switch ~peer_id (module F) flow] sends and receives on [flow].
     The caller should arrange for [flow] to be closed when the switch is turned off.
     If the flow is closed, the switch will be turned off.
     If the flow returns an error when the switch is off, the endpoint will return [`Closed]
     instead of the underlying error. *)
+
+val peer_id : t -> Auth.Digest.t
+(** [peer_id t] is the fingerprint of the peer's public key,
+    or [None] TLS isn't being used. *)
 
 val pp_error : [< `Closed | `Msg of string] Fmt.t

--- a/capnp-rpc-lwt/endpoint.mli
+++ b/capnp-rpc-lwt/endpoint.mli
@@ -21,6 +21,9 @@ val of_flow : switch:Lwt_switch.t -> peer_id:Auth.Digest.t ->
 
 val peer_id : t -> Auth.Digest.t
 (** [peer_id t] is the fingerprint of the peer's public key,
-    or [None] TLS isn't being used. *)
+    or [Auth.Digest.insecure] TLS isn't being used. *)
+
+val disconnect : t -> unit Lwt.t
+(** [disconnect t] turns off [t]'s switch. *)
 
 val pp_error : [< `Closed | `Msg of string] Fmt.t

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -15,13 +15,22 @@ module type NETWORK = sig
 
     val equal : t -> t -> bool
 
+    val digest : t -> Auth.Digest.t
+    (** How to verify that the correct address has been reached. *)
+
     val pp : t Fmt.t
   end
 
   val connect :
+    switch:Lwt_switch.t ->
     secret_key:Auth.Secret_key.t Lazy.t ->
     Address.t ->
     (Endpoint.t, [> `Msg of string]) result Lwt.t
+  (** [connect ~switch ~secret_key address] connects to [address], proves ownership of
+      [secret_key] (if TLS is being used), and returns the resulting endpoint.
+      Returns an error if no connection can be established or the target fails
+      to authenticate itself.
+      If [switch] is turned off, the connection should be terminated. *)
 
   val parse_third_party_cap_id : Schema.Reader.pointer_t -> Types.third_party_cap_id
 end
@@ -96,12 +105,11 @@ module type VAT_NETWORK = sig
     type t
     (** A CapTP connection to a remote peer. *)
 
-    val connect : restore:restorer -> ?tags:Logs.Tag.set -> switch:Lwt_switch.t -> Endpoint.t -> t
+    val connect : restore:restorer -> ?tags:Logs.Tag.set -> Endpoint.t -> t
     (** [connect ~restore ~switch endpoint] is fresh CapTP protocol handler that sends and
         receives messages using [endpoint].
         [restore] is used to respond to "Bootstrap" messages.
-        If the connection fails then [switch] will be turned off, and turning off the switch
-        will release all resources used by the connection. *)
+        If the connection fails then [endpoint] will be disconnected. *)
 
     val bootstrap : t -> Sturdy_ref.service_id -> 'a capability
     (** [bootstrap t object_id] is the peer's bootstrap object [object_id], if any.
@@ -127,6 +135,7 @@ module type VAT_NETWORK = sig
 
     val create :
       ?switch:Lwt_switch.t ->
+      ?tags:Logs.Tag.set ->
       ?restore:restorer ->
       ?address:Network.Address.t ->
       secret_key:Auth.Secret_key.t Lazy.t ->
@@ -137,9 +146,14 @@ module type VAT_NETWORK = sig
         The vat will suggest that other parties connect to it using [address].
         Turning off the switch will disconnect any active connections. *)
 
-    val add_connection : t -> Endpoint.t -> CapTP.t
-    (** [add_connection t endpoint] runs the CapTP protocol over [endpoint],
-        which is a connection to another vat. *)
+    val add_connection : t -> switch:Lwt_switch.t -> mode:[`Accept|`Connect] -> Endpoint.t -> CapTP.t Lwt.t
+    (** [add_connection t ~switch ~mode endpoint] runs the CapTP protocol over [endpoint],
+        which is a connection to another vat.
+        When the connection ends, [switch] will be turned off, and turning off [switch] will
+        end the connection.
+        [mode] is used if two vats connect to each other at the same time to
+        decide which connection to drop. Use [`Connect] if [t] initiated the new
+        connection. Note that [add_connection] may return an existing connection. *)
 
     val public_address : t -> Network.Address.t option
     (** [public_address t] is the address that peers should use when connecting

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -18,7 +18,10 @@ module type NETWORK = sig
     val pp : t Fmt.t
   end
 
-  val connect : Address.t -> (Endpoint.t, [> `Msg of string]) result Lwt.t
+  val connect :
+    secret_key:Auth.Secret_key.t Lazy.t ->
+    Address.t ->
+    (Endpoint.t, [> `Msg of string]) result Lwt.t
 
   val parse_third_party_cap_id : Schema.Reader.pointer_t -> Types.third_party_cap_id
 end
@@ -126,9 +129,11 @@ module type VAT_NETWORK = sig
       ?switch:Lwt_switch.t ->
       ?restore:restorer ->
       ?address:Network.Address.t ->
+      secret_key:Auth.Secret_key.t Lazy.t ->
       unit -> t
-    (** [create ~switch ~restore ~address ()] is a new vat that uses [restore] to restore
-        sturdy refs hosted at this vat to live capabilities for peers.
+    (** [create ~switch ~restore ~address ~secret_key ()] is a new vat that
+        uses [restore] to restore sturdy refs hosted at this vat to live
+        capabilities for peers.
         The vat will suggest that other parties connect to it using [address].
         Turning off the switch will disconnect any active connections. *)
 

--- a/capnp-rpc-lwt/tls_wrapper.ml
+++ b/capnp-rpc-lwt/tls_wrapper.ml
@@ -1,0 +1,49 @@
+module Log = Capnp_rpc.Debug.Log
+
+open Lwt.Infix
+open Auth
+
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
+
+module Make (Underlying : Mirage_flow_lwt.S) = struct
+  module Flow = Tls_mirage.Make(Underlying)
+
+  let plain_endpoint ~switch flow =
+    Endpoint.of_flow ~switch ~peer_id:Auth.Digest.insecure (module Underlying) flow
+
+  let connect_as_server ~switch flow secret_key =
+    match secret_key with
+    | None -> Lwt.return @@ Ok (plain_endpoint ~switch flow)
+    | Some key ->
+      Log.info (fun f -> f "Doing TLS server-side handshake...");
+      let certificates = Secret_key.certificates key in
+      let client_cert = ref None in
+      let authenticator ?host:_ = function
+        | [] -> `Fail `EmptyCertificateChain
+        | client :: _ ->  (* First certificate is the client's own *)
+          client_cert := Some client;
+          `Ok None
+      in
+      let tls_config = Tls.Config.server ~certificates ~authenticator () in
+      Flow.server_of_flow tls_config flow >|= function
+      | Error e -> error "TLS connection failed: %a" Flow.pp_write_error e
+      | Ok flow ->
+        match !client_cert with
+        | None -> failwith "No client certificate after auth!"
+        | Some client_cert ->
+          let peer_id = Digest.of_certificate client_cert in
+          Ok (Endpoint.of_flow ~switch ~peer_id (module Flow) flow)
+
+  let connect_as_client ~switch flow secret_key auth =
+    match Digest.authenticator auth with
+    | None -> Lwt.return @@ Ok (plain_endpoint ~switch flow)
+    | Some authenticator ->
+      let certificates = Secret_key.certificates (Lazy.force secret_key) in
+      let tls_config = Tls.Config.client ~certificates ~authenticator () in
+      Log.info (fun f -> f "Doing TLS client-side handshake...");
+      Flow.client_of_flow tls_config flow >|= function
+      | Error e -> error "TLS connection failed: %a" Flow.pp_write_error e
+      | Ok flow -> Ok (Endpoint.of_flow ~switch ~peer_id:auth (module Flow) flow)
+end

--- a/capnp-rpc-lwt/tls_wrapper.mli
+++ b/capnp-rpc-lwt/tls_wrapper.mli
@@ -1,0 +1,17 @@
+open Auth
+
+module Make (Underlying : Mirage_flow_lwt.S) : sig
+  (** Make an [Endpoint] from an [Underlying.flow], using TLS if appropriate. *)
+
+  val connect_as_server :
+    switch:Lwt_switch.t -> Underlying.flow -> Auth.Secret_key.t option ->
+    (Endpoint.t, [> `Msg of string]) result Lwt.t
+
+  val connect_as_client :
+    switch:Lwt_switch.t -> Underlying.flow -> Auth.Secret_key.t Lazy.t -> Digest.t ->
+    (Endpoint.t, [> `Msg of string]) result Lwt.t
+  (** [connect_as_client ~switch underlying key digest] is an endpoint using flow [underlying].
+      If [digest] requires TLS, it performs a TLS handshake. It uses [key] as its private key
+      and checks that the server is the one required by [auth]. *)
+end
+

--- a/capnp-rpc-lwt/two_party_network.ml
+++ b/capnp-rpc-lwt/two_party_network.ml
@@ -14,8 +14,10 @@ module Address = struct
   let parse_uri _ = failwith "Can't use of_uri wih Two_party_network"
 
   let equal _ _ = assert false
+
+  let digest _ = assert false
 end
 
 let parse_third_party_cap_id _ = `Two_party_only
 
-let connect ~secret_key:_ _ = assert false
+let connect ~switch:_ ~secret_key:_ _ = assert false

--- a/capnp-rpc-lwt/two_party_network.ml
+++ b/capnp-rpc-lwt/two_party_network.ml
@@ -18,4 +18,4 @@ end
 
 let parse_third_party_cap_id _ = `Two_party_only
 
-let connect _ = assert false
+let connect ~secret_key:_ _ = assert false

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -8,7 +8,7 @@ module Test_utils = Testbed.Test_utils
 module Vat = Capnp_rpc_unix.Vat
 module CapTP = Capnp_rpc_unix.CapTP
 module Unix_flow = Capnp_rpc_unix.Unix_flow
-module Tls_wrapper = Capnp_rpc_lwt.Auth.Tls_wrapper(Unix_flow)
+module Tls_wrapper = Capnp_rpc_lwt.Tls_wrapper.Make(Unix_flow)
 module Exception = Capnp_rpc.Exception
 
 type cs = {

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -17,12 +17,8 @@ type cs = {
   client_key : Auth.Secret_key.t;
   server_key : Auth.Secret_key.t;
   serve_tls : bool;
+  server_switch : Lwt_switch.t;
 }
-
-let ( >|*= ) x f =
-  x >|= function
-  | Error (`Msg e) -> failwith e
-  | Ok y -> f y
 
 let expect_some msg = function
   | None -> Alcotest.fail msg
@@ -30,17 +26,10 @@ let expect_some msg = function
 
 (* Have the client ask the server for its bootstrap object, and return the
    resulting client-side proxy to it. *)
-let get_bootstrap ~switch cs =
-  let _address, auth = Vat.public_address cs.server |> expect_some "No public address!" in
-  let server_socket, client_socket = Unix_flow.socketpair ~switch () in
-  let _server =
-    let server_key = if cs.serve_tls then Some cs.server_key else None in
-    Tls_wrapper.connect_as_server ~switch server_socket server_key >|*=
-    Vat.add_connection cs.server
-  in
-  Tls_wrapper.connect_as_client ~switch client_socket (lazy cs.client_key) auth >|*= fun ep ->
-  let conn = Vat.add_connection cs.client ep in
-  CapTP.bootstrap conn (Restorer.Id.public "")
+let get_bootstrap cs =
+  let id = Restorer.Id.public "" in
+  let sr = Vat.sturdy_ref cs.server id in
+  Vat.connect_exn cs.client sr
 
 module Utils = struct
   [@@@ocaml.warning "-32"]
@@ -54,23 +43,27 @@ let server_key = Auth.Secret_key.generate ()
 let client_key = Auth.Secret_key.generate ()
 
 let make_vats ?(serve_tls=false) ~switch ~service () =
-  let auth =
-    if serve_tls then Capnp_rpc_lwt.Auth.Secret_key.digest server_key
-    else Capnp_rpc_lwt.Auth.Digest.insecure
+  let id = Restorer.Id.public "" in
+  let restore = Restorer.(single id) service in
+  let server_config =
+    let secret_key = `PEM (Auth.Secret_key.to_pem_data server_key) in
+    Capnp_rpc_unix.Vat_config.create ~secret_key ~serve_tls (`Unix "socket")
   in
-  let address = (`Unix "/tmp/socket", auth) in
-  let restore = Restorer.(single (Id.public "")) service in
+  let server_switch = Lwt_switch.create () in
+  Capnp_rpc_unix.serve ~switch:server_switch ~tags:Test_utils.server_tags ~restore server_config >>= fun server ->
+  Lwt_switch.add_hook (Some switch) (fun () -> Lwt_switch.turn_off server_switch);
   Lwt_switch.add_hook (Some switch) (fun () -> Capability.dec_ref service; Lwt.return_unit);
-  {
-    client = Vat.create ~switch ~secret_key:(lazy client_key) ();
-    server = Vat.create ~switch ~secret_key:(lazy server_key) ~restore ~address ();
+  Lwt.return {
+    client = Vat.create ~switch ~tags:Test_utils.client_tags ~secret_key:(lazy client_key) ();
+    server;
     client_key;
     server_key;
     serve_tls;
+    server_switch;
   }
 
 (* Generic Lwt running for Alcotest. *)
-let run_lwt fn () =
+let run_lwt ?(expected_warnings=0) fn () =
   let warnings_at_start = Logs.(err_count () + warn_count ()) in
   Logs.info (fun f -> f "Start test-case");
   let async_ex, async_waker = Lwt.wait () in
@@ -99,33 +92,37 @@ let run_lwt fn () =
   Lwt.wakeup_paused ();
   Gc.full_major ();
   let warnings_at_end = Logs.(err_count () + warn_count ()) in
-  Alcotest.(check int) "Check log for warnings" 0 (warnings_at_end - warnings_at_start)
+  Alcotest.(check int) "Check log for warnings" expected_warnings (warnings_at_end - warnings_at_start)
 
 let test_simple switch ~serve_tls =
-  let cs = make_vats ~switch ~serve_tls ~service:(Echo.local ()) () in
-  get_bootstrap ~switch cs >>= fun service ->
+  make_vats ~switch ~serve_tls ~service:(Echo.local ()) () >>= fun cs ->
+  get_bootstrap cs >>= fun service ->
   Echo.ping service "ping" >>= fun reply ->
   Alcotest.(check string) "Ping response" "got:0:ping" reply;
   Capability.dec_ref service;
   Lwt.return ()
 
 let test_bad_crypto switch =
-  let cs = make_vats ~switch ~serve_tls:true ~service:(Echo.local ()) () in
-  let cs = {cs with server_key = client_key; client_key = server_key} in (* (bad config) *)
-  Lwt.try_bind
-    (fun () -> get_bootstrap ~switch cs)
-    (fun _ -> Alcotest.fail "Wrong TLS key should have been rejected")
-    (function
-      | Failure msg ->
-        assert (String.is_prefix ~affix:"TLS connection failed: authentication failure" msg);
-        Lwt.return ()
-      | ex ->
-        Lwt.fail ex
-    )
+  make_vats ~switch ~serve_tls:true ~service:(Echo.local ()) () >>= fun cs ->
+  let id = Restorer.Id.public "" in
+  let (addr, _digest) = Vat.public_address cs.server |> expect_some "Has address" in
+  let address = (addr, Auth.Secret_key.digest ~hash:`SHA256 client_key) in (* (should be server_key) *)
+  let sr = Capnp_rpc_unix.Sturdy_ref.v ~address ~service:id in
+  let old_warnings = Logs.warn_count () in
+  Vat.connect cs.client sr >>= function
+  | Ok _ -> Alcotest.fail "Wrong TLS key should have been rejected"
+  | Error (`Msg msg) ->
+    assert (String.is_prefix ~affix:"TLS connection failed: authentication failure" msg);
+    (* Wait for server to log warning *)
+    let rec wait () =
+      if Logs.warn_count () = old_warnings then Lwt.pause () >>= wait
+      else Lwt.return_unit
+    in
+    wait ()
 
 let test_parallel switch =
-  let cs = make_vats ~switch ~service:(Echo.local ()) () in
-  get_bootstrap ~switch cs >>= fun service ->
+  make_vats ~switch ~service:(Echo.local ()) () >>= fun cs ->
+  get_bootstrap cs >>= fun service ->
   let reply1 = Echo.ping service ~slow:true "ping1" in
   Echo.ping service "ping2" >|= Alcotest.(check string) "Ping2 response" "got:1:ping2" >>= fun () ->
   assert (Lwt.state reply1 = Lwt.Sleep);
@@ -136,8 +133,8 @@ let test_parallel switch =
 
 let test_registry switch =
   let registry_impl = Registry.local () in
-  let cs = make_vats ~switch ~service:registry_impl () in
-  get_bootstrap ~switch cs >>= fun registry ->
+  make_vats ~switch ~service:registry_impl () >>= fun cs ->
+  get_bootstrap cs >>= fun registry ->
   let echo_service = Registry.echo_service registry in
   Registry.unblock registry >>= fun () ->
   Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
@@ -148,8 +145,8 @@ let test_registry switch =
 let test_embargo switch =
   let registry_impl = Registry.local () in
   let local_echo = Echo.local () in
-  let cs = make_vats ~switch ~service:registry_impl () in
-  get_bootstrap ~switch cs >>= fun registry ->
+  make_vats ~switch ~service:registry_impl () >>= fun cs ->
+  get_bootstrap cs >>= fun registry ->
   Registry.set_echo_service registry local_echo >>= fun () ->
   Capability.dec_ref local_echo;
   let echo_service = Registry.echo_service registry in
@@ -167,8 +164,8 @@ let test_embargo switch =
 let test_resolve switch =
   let registry_impl = Registry.local () in
   let local_echo = Echo.local () in
-  let cs = make_vats ~switch ~service:registry_impl () in
-  get_bootstrap ~switch cs >>= fun registry ->
+  make_vats ~switch ~service:registry_impl () >>= fun cs ->
+  get_bootstrap cs >>= fun registry ->
   Registry.set_echo_service registry local_echo >>= fun () ->
   Capability.dec_ref local_echo;
   let echo_service = Registry.echo_service_promise registry in
@@ -184,8 +181,8 @@ let test_resolve switch =
   Lwt.return ()
 
 let test_cancel switch =
-  let cs = make_vats ~switch ~service:(Echo.local ()) () in
-  get_bootstrap ~switch cs >>= fun service ->
+  make_vats ~switch ~service:(Echo.local ()) () >>= fun cs ->
+  get_bootstrap cs >>= fun service ->
   let reply1 = Echo.ping service ~slow:true "ping1" in
   assert (Lwt.state reply1 = Lwt.Sleep);
   Lwt.cancel reply1;
@@ -204,8 +201,8 @@ let float = Alcotest.testable Fmt.float (=)
 
 let test_calculator switch =
   let open Calc in
-  let cs = make_vats ~switch ~service:Calc.local () in
-  get_bootstrap ~switch cs >>= fun c ->
+  make_vats ~switch ~service:Calc.local () >>= fun cs ->
+  get_bootstrap cs >>= fun c ->
   Calc.evaluate c (Float 1.) |> Value.final_read >|= Alcotest.check float "Simple calc" 1. >>= fun () ->
   let local_add = Calc.Fn.add in
   let expr = Expr.(Call (local_add, [Float 1.; Float 2.])) in
@@ -220,8 +217,8 @@ let test_calculator switch =
 
 let test_indexing switch =
   let registry_impl = Registry.local () in
-  let cs = make_vats ~switch ~service:registry_impl () in
-  get_bootstrap ~switch cs >>= fun registry ->
+  make_vats ~switch ~service:registry_impl () >>= fun cs ->
+  get_bootstrap cs >>= fun registry ->
   let echo_service, version = Registry.complex registry in
   Echo.ping echo_service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
   Registry.Version.read version >|= Alcotest.(check string) "Version response" "0.1" >>= fun () ->
@@ -294,7 +291,14 @@ let test_sturdy_ref () =
   let sr = Sturdy_ref.v ~address:(`Unix "/sock", auth) ~service:public_main in
   check "Secure Unix" "capnp://sha-256:s16WV4JeGusAL_nTjvICiQOFqm3LqYrDj3K-HXdMi8s@/sock/bWFpbg" sr
 
-let cap = Alcotest.testable Capability.pp (=)
+let cap_equal_exn a b =
+  match Capability.equal a b with
+  | Ok x -> x
+  | Error `Unsettled -> Alcotest.failf "Can't compare %a and %a: not settled!"
+                          Capability.pp a
+                          Capability.pp b
+
+let cap = Alcotest.testable Capability.pp cap_equal_exn
 
 let expect_non_exn = function
   | Ok x -> x
@@ -399,18 +403,19 @@ let test_fn_restorer _switch =
   Lwt.return_unit
 
 let test_broken switch =
-  let cs = make_vats ~switch ~service:(Echo.local ()) () in
-  let connection_switch = Lwt_switch.create () in
-  get_bootstrap ~switch:connection_switch cs >>= fun service ->
+  make_vats ~switch ~service:(Echo.local ()) () >>= fun cs ->
+  get_bootstrap cs >>= fun service ->
   Echo.ping service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
-  let problem = ref None in
-  Capability.when_broken (fun x -> problem := Some x) service;
+  let problem, set_problem = Lwt.wait () in
+  Capability.when_broken (fun x -> Lwt.wakeup set_problem x) service;
   Alcotest.check (Alcotest.option except) "Still OK" None @@ Capability.problem service;
-  assert (!problem = None);
-  Lwt_switch.turn_off connection_switch >>= fun () ->
+  assert (Lwt.state problem = Lwt.Sleep);
+  Logs.info (fun f -> f "Turning off server...");
+  Lwt_switch.turn_off cs.server_switch >>= fun () ->
+  problem >>= fun problem ->
+  let expected = Exception.v ~ty:`Disconnected "Vat shut down" in
+  Alcotest.check except "Broken callback ran" expected problem;
   assert (Capability.problem service <> None);
-  let expected = Some (Exception.v ~ty:`Disconnected "CapTP switch turned off") in
-  Alcotest.check (Alcotest.option except) "Broken callback ran" expected !problem;
   Lwt.catch
     (fun () -> Echo.ping service "ping" >|= fun _ -> Alcotest.fail "Should have failed!")
     (fun _ -> Lwt.return ())
@@ -444,10 +449,74 @@ let test_broken4 () =
   Capability.dec_ref promise;
   Alcotest.check (Alcotest.option except) "Released, not called" None !problem
 
+let test_parallel_connect switch =
+  make_vats ~switch ~serve_tls:true ~service:(Echo.local ()) () >>= fun cs ->
+  let service = get_bootstrap cs in
+  let service2 = get_bootstrap cs in
+  service >>= fun service ->
+  service2 >>= fun service2 ->
+  Capability.wait_until_settled service >>= fun () ->
+  Capability.wait_until_settled service2 >>= fun () ->
+  Alcotest.check cap "Shared connection" service service2;
+  Capability.dec_ref service;
+  Capability.dec_ref service2;
+  Lwt.return_unit
+
+let test_parallel_fails switch =
+  make_vats ~switch ~serve_tls:true ~service:(Echo.local ()) () >>= fun cs ->
+  let service = get_bootstrap cs in
+  let service2 = get_bootstrap cs in
+  service >>= fun service ->
+  service2 >>= fun service2 ->
+  Lwt_switch.turn_off cs.server_switch >>= fun () ->
+  Capability.wait_until_settled service >>= fun () ->
+  Capability.wait_until_settled service2 >>= fun () ->
+  Alcotest.check cap "Shared failure" service service2;
+  Capability.dec_ref service;
+  Capability.dec_ref service2;
+  (* Restart server (ignore new client) *)
+  Lwt.pause () >>= fun () ->
+  make_vats ~switch ~serve_tls:true ~service:(Echo.local ()) () >>= fun _cs2 ->
+  get_bootstrap cs >>= fun service ->
+  Echo.ping service "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
+  Capability.dec_ref service;
+  Lwt.return_unit
+
+let test_crossed_calls switch =
+  (* Would be good to control the ordering here, to test the various cases.
+     Currently, it's not certain which path is actually tested. *)
+  let id = Restorer.Id.public "" in
+  let make_vat ~secret_key ~tags addr =
+    let service = Echo.local () in
+    let restore = Restorer.(single id) service in
+    let config =
+      let secret_key = `PEM (Auth.Secret_key.to_pem_data secret_key) in
+      Capnp_rpc_unix.Vat_config.create ~secret_key (`Unix addr)
+    in
+    Capnp_rpc_unix.serve ~switch ~tags ~restore config >>= fun vat ->
+    Lwt_switch.add_hook (Some switch) (fun () -> Capability.dec_ref service; Lwt.return_unit);
+    Lwt.return vat
+  in
+  make_vat ~secret_key:client_key ~tags:Test_utils.client_tags "client" >>= fun client ->
+  make_vat ~secret_key:server_key ~tags:Test_utils.server_tags "server" >>= fun server ->
+  let sr_to_client = Capnp_rpc_unix.Vat.sturdy_ref client id in
+  let sr_to_server = Capnp_rpc_unix.Vat.sturdy_ref server id in
+  let to_client = Capnp_rpc_unix.Vat.connect_exn server sr_to_client in
+  let to_server = Capnp_rpc_unix.Vat.connect_exn client sr_to_server in
+  to_client >>= fun to_client ->
+  to_server >>= fun to_server ->
+  Logs.info (fun f -> f ~tags:Test_utils.client_tags "%a" Capnp_rpc_unix.Vat.dump client);
+  Logs.info (fun f -> f ~tags:Test_utils.server_tags "%a" Capnp_rpc_unix.Vat.dump server);
+  Echo.ping to_client "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
+  Echo.ping to_server "ping" >|= Alcotest.(check string) "Ping response" "got:0:ping" >>= fun () ->
+  Capability.dec_ref to_client;
+  Capability.dec_ref to_server;
+  Lwt.return_unit
+
 let rpc_tests = [
   "Simple",     `Quick, run_lwt (test_simple ~serve_tls:false);
   "Crypto",     `Quick, run_lwt (test_simple ~serve_tls:true);
-  "Bad crypto", `Quick, run_lwt test_bad_crypto;
+  "Bad crypto", `Quick, run_lwt test_bad_crypto ~expected_warnings:1;
   "Parallel",   `Quick, run_lwt test_parallel;
   "Embargo",    `Quick, run_lwt test_embargo;
   "Resolve",    `Quick, run_lwt test_resolve;
@@ -463,6 +532,9 @@ let rpc_tests = [
   "Broken ref 2", `Quick, test_broken2;
   "Broken ref 3", `Quick, test_broken3;
   "Broken ref 4", `Quick, test_broken4;
+  "Parallel connect", `Quick, run_lwt test_parallel_connect;
+  "Parallel fails", `Quick, run_lwt test_parallel_fails;
+  "Crossed calls", `Quick, run_lwt test_crossed_calls;
 ]
 
 let () =

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -102,6 +102,8 @@ val sturdy_ref : unit -> 'a Sturdy_ref.t Cmdliner.Arg.conv
 (** A cmdliner argument converter for parsing "capnp://" URIs. *)
 
 val serve :
+  ?switch:Lwt_switch.t ->
+  ?tags:Logs.Tag.set ->
   ?restore:Restorer.t ->
   Vat_config.t ->
   Vat.t Lwt.t
@@ -111,6 +113,7 @@ val serve :
 
 val client_only_vat :
   ?switch:Lwt_switch.t ->
+  ?tags:Logs.Tag.set ->
   ?restore:Restorer.t ->
   unit -> Vat.t
 (** [client_only_vat ()] is a new vat that does not listen for incoming connections. *)

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -112,14 +112,14 @@ let connect_socket = function
     Unix.connect socket (Unix.ADDR_INET (addr_of_host host, port));
     socket
 
-let connect (addr, auth) =
+let connect ~secret_key (addr, auth) =
   match connect_socket addr with
   | exception ex ->
     Lwt.return @@ error "@[<v2>Network connection for %a failed:@,%a@]" Socket_address.pp addr Fmt.exn ex
   | socket ->
     let switch = Lwt_switch.create () in
     let flow = Unix_flow.connect ~switch (Lwt_unix.of_unix_file_descr socket) in
-    Tls_wrapper.connect_as_client ~switch flow auth
+    Tls_wrapper.connect_as_client ~switch flow secret_key auth
 
 let accept_connection ~switch ~secret_key flow =
   Tls_wrapper.connect_as_server ~switch flow secret_key

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -1,6 +1,6 @@
 open Astring
 module Log = Capnp_rpc.Debug.Log
-module Tls_wrapper = Capnp_rpc_lwt.Auth.Tls_wrapper(Unix_flow)
+module Tls_wrapper = Capnp_rpc_lwt.Tls_wrapper.Make(Unix_flow)
 
 module Types = struct
   type provision_id

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -35,6 +35,8 @@ end
 module Address = struct
   type t = Socket_address.t * Capnp_rpc_lwt.Auth.Digest.t
 
+  let digest = snd
+
   let alphabet = B64.uri_safe_alphabet
 
   let b64encode s = B64.encode ~alphabet ~pad:false s
@@ -112,12 +114,11 @@ let connect_socket = function
     Unix.connect socket (Unix.ADDR_INET (addr_of_host host, port));
     socket
 
-let connect ~secret_key (addr, auth) =
+let connect ~switch ~secret_key (addr, auth) =
   match connect_socket addr with
   | exception ex ->
     Lwt.return @@ error "@[<v2>Network connection for %a failed:@,%a@]" Socket_address.pp addr Fmt.exn ex
   | socket ->
-    let switch = Lwt_switch.create () in
     let flow = Unix_flow.connect ~switch (Lwt_unix.of_unix_file_descr socket) in
     Tls_wrapper.connect_as_client ~switch flow secret_key auth
 


### PR DESCRIPTION
To do this, we now also send client X.509 certificates. The server "authenticator" records the fingerprint (and always accepts).

- If we try to resolve a sturdy ref when we already have a connection, use that.

- If we try to resolve a sturdy ref when we're already trying to make a connection, wait for the first connection attempt to complete.

- If two vats try to connect to each other at the same time, reject one of the connections. To make sure that both vats reject the same connection, we always keep the one initiated by the peer with the highest vat ID.

For now, only the `sha-256` hash is allowed. If we want to support others, the logic will need extending to cope with the possibility that two fingerprints with different hashes might still refer to the same vat.

For non-TLS connections, we just keep a list of connections and don't prevent duplicates.

Add `Capability.wait_until_settled` and `Capability.equal`.

Fixes #94.