### PR TITLE
Fix restorer and switchable ref-counting

### DIFF
--- a/capnp-rpc-lwt/restorer.ml
+++ b/capnp-rpc-lwt/restorer.ml
@@ -53,8 +53,10 @@ let single id cap =
   let id = Nocrypto.Hash.digest `SHA256 (Cstruct.of_string id) in
   fun requested_id ->
     let requested_id = Nocrypto.Hash.digest `SHA256 (Cstruct.of_string requested_id) in
-    if Cstruct.equal id requested_id then Lwt.return (Ok cap)
-    else Lwt.return unknown_service_id
+    if Cstruct.equal id requested_id then (
+      Core_types.inc_ref cap;
+      Lwt.return (Ok cap)
+    ) else Lwt.return unknown_service_id
 
 module Table = struct
   type digest = string

--- a/capnp-rpc/capTP.mli
+++ b/capnp-rpc/capTP.mli
@@ -8,7 +8,8 @@ module Make (EP : Message_types.ENDPOINT) : sig
   type restorer = ((EP.Core_types.cap, Exception.t) result -> unit) -> string -> unit
   (** A [restorer] is a function [f] for restoring saved capabilities.
       [f k object_id] must eventually call [k result] exactly once to respond
-      to the client's bootstrap message with [result]. *)
+      to the client's bootstrap message with [result]. [k] takes ownership of the
+      capability. *)
 
   val create : ?restore:restorer -> tags:Logs.Tag.set ->
     queue_send:([> EP.Out.t] -> unit) -> t

--- a/test/testbed/connection.ml
+++ b/test/testbed/connection.ml
@@ -77,7 +77,7 @@ module Endpoint (EP : Capnp_direct.ENDPOINT) = struct
   let restore_single = function
     | None -> None
     | Some bootstrap -> Some (fun k -> function
-        | "" -> k @@ Ok bootstrap
+        | "" -> Capnp_direct.Core_types.inc_ref bootstrap; k @@ Ok bootstrap
         | _ -> k @@ Error (Capnp_rpc.Exception.v "Only a main interface is available")
       )
 


### PR DESCRIPTION
`Restorer.single` didn't increment the ref-count; `CapTP.bootstrap` did it instead. Move the increment to the restorer, so that it works the same way as the table restorer.

Also, switchable didn't transfer its ref-count when resolved. That could lead to a leak if the user tried to shorten it.