### PR TITLE
Code clean-ups

### DIFF
--- a/capnp-rpc-lwt/capability.ml
+++ b/capnp-rpc-lwt/capability.ml
@@ -1,0 +1,109 @@
+open Lwt.Infix
+open Capnp_core
+
+module Log = Capnp_rpc.Debug.Log
+module StructStorage = Capnp.BytesMessage.StructStorage
+
+type 'a t = Core_types.cap
+type 'a capability_t = 'a t
+type ('t, 'a, 'b) method_t = ('t, 'a, 'b) Capnp.RPC.MethodID.t
+
+module Request = Request
+
+let inc_ref = Core_types.inc_ref
+let dec_ref = Core_types.dec_ref
+let pp f x = x#pp f
+
+let broken = Core_types.broken_cap
+let when_broken = Core_types.when_broken
+let problem x = x#problem
+
+let wait_until_settled x =
+  let result, set_result = Lwt.wait () in
+  let rec aux x =
+    if x#blocker = None then (
+      Lwt.wakeup set_result ()
+    ) else (
+      x#when_more_resolved (fun x ->
+          Core_types.dec_ref x;
+          aux x
+        )
+    )
+  in
+  aux x;
+  result
+
+let equal a b =
+  match a#blocker, b#blocker with
+  | None, None ->
+    let a = a#shortest in
+    let b = b#shortest in
+    begin match a#problem, b#problem with
+    | None, None -> Ok (a = b)
+    | Some a, Some b -> Ok (a = b)
+    | _ -> Ok false
+    end
+  | _ -> Error `Unsettled
+
+let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) (req : 'a Request.t) =
+  Log.info (fun f -> f "Calling %a" Capnp.RPC.MethodID.pp m);
+  let msg = Request.finish m req in
+  let results, resolver = Local_struct_promise.make () in
+  target#call resolver msg;
+  results
+
+let call_and_wait cap (m : ('t, 'a, 'b StructStorage.reader_t) method_t) req =
+  let p, r = Lwt.task () in
+  let result = call cap m req in
+  let finish = lazy (Core_types.dec_ref result) in
+  Lwt.on_cancel p (fun () -> Lazy.force finish);
+  result#when_resolved (function
+      | Error _ as e -> Lwt.wakeup r e
+      | Ok resp ->
+        Lazy.force finish;
+        let payload = Msg.Response.readable resp in
+        let release_response_caps () = Core_types.Response_payload.release resp in
+        let contents = Schema.Reader.Payload.content_get payload |> Schema.Reader.of_pointer in
+        Lwt.wakeup r @@ Ok (contents, release_response_caps)
+    );
+  p
+
+let call_for_value cap m req =
+  call_and_wait cap m req >|= function
+  | Error _ as response -> response
+  | Ok (response, release_response_caps) ->
+    release_response_caps ();
+    Ok response
+
+let call_for_value_exn cap m req =
+  call_for_value cap m req >>= function
+  | Ok x -> Lwt.return x
+  | Error e ->
+    let msg = Fmt.strf "Error calling %t(%a): %a"
+        cap#pp
+        Capnp.RPC.MethodID.pp m
+        Capnp_rpc.Error.pp e in
+    Lwt.fail (Failure msg)
+
+let call_for_unit cap m req =
+  call_for_value cap m req >|= function
+  | Ok _ -> Ok ()
+  | Error _ as e -> e
+
+let call_for_unit_exn cap m req = call_for_value_exn cap m req >|= ignore
+
+let call_for_caps cap m req fn =
+  let q = call cap m req in
+  match fn q with
+  | r -> Core_types.dec_ref q; r
+  | exception ex -> Core_types.dec_ref q; raise ex
+
+type 'a resolver = Cap_proxy.resolver_cap
+
+let promise () =
+  let cap = Cap_proxy.local_promise () in
+  (cap :> Core_types.cap), (cap :> 'a resolver)
+
+let resolve_ok r x = r#resolve x
+
+let resolve_exn r ex = r#resolve (Core_types.broken_cap ex)

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -1,4 +1,3 @@
-open Lwt.Infix
 open Capnp_core
 
 include Capnp.Message.BytesMessage
@@ -8,112 +7,7 @@ type 'a or_error = ('a, Capnp_rpc.Error.t) result
 module Log = Capnp_rpc.Debug.Log
 module RO_array = Capnp_rpc.RO_array
 
-module Capability = struct
-  type 'a t = Core_types.cap
-  type 'a capability_t = 'a t
-  type ('t, 'a, 'b) method_t = ('t, 'a, 'b) Capnp.RPC.MethodID.t
-
-  module Request = Request
-
-  let inc_ref = Core_types.inc_ref
-  let dec_ref = Core_types.dec_ref
-  let pp f x = x#pp f
-
-  let broken = Core_types.broken_cap
-  let when_broken = Core_types.when_broken
-  let problem x = x#problem
-
-  let wait_until_settled x =
-    let result, set_result = Lwt.wait () in
-    let rec aux x =
-      if x#blocker = None then (
-        Lwt.wakeup set_result ()
-      ) else (
-        x#when_more_resolved (fun x ->
-            Core_types.dec_ref x;
-            aux x
-          )
-      )
-    in
-    aux x;
-    result
-
-  let equal a b =
-    match a#blocker, b#blocker with
-    | None, None ->
-      let a = a#shortest in
-      let b = b#shortest in
-      begin match a#problem, b#problem with
-      | None, None -> Ok (a = b)
-      | Some a, Some b -> Ok (a = b)
-      | _ -> Ok false
-      end
-    | _ -> Error `Unsettled
-
-  let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) (req : 'a Request.t) =
-    Log.info (fun f -> f "Calling %a" Capnp.RPC.MethodID.pp m);
-    let msg = Request.finish m req in
-    let results, resolver = Local_struct_promise.make () in
-    target#call resolver msg;
-    results
-
-  let call_and_wait cap (m : ('t, 'a, 'b StructStorage.reader_t) method_t) req =
-    let p, r = Lwt.task () in
-    let result = call cap m req in
-    let finish = lazy (Core_types.dec_ref result) in
-    Lwt.on_cancel p (fun () -> Lazy.force finish);
-    result#when_resolved (function
-        | Error _ as e -> Lwt.wakeup r e
-        | Ok resp ->
-          Lazy.force finish;
-          let payload = Msg.Response.readable resp in
-          let release_response_caps () = Core_types.Response_payload.release resp in
-          let contents = Schema.Reader.Payload.content_get payload |> Schema.Reader.of_pointer in
-          Lwt.wakeup r @@ Ok (contents, release_response_caps)
-      );
-    p
-
-  let call_for_value cap m req =
-    call_and_wait cap m req >|= function
-    | Error _ as response -> response
-    | Ok (response, release_response_caps) ->
-      release_response_caps ();
-      Ok response
-
-  let call_for_value_exn cap m req =
-    call_for_value cap m req >>= function
-    | Ok x -> Lwt.return x
-    | Error e ->
-      let msg = Fmt.strf "Error calling %t(%a): %a"
-          cap#pp
-          Capnp.RPC.MethodID.pp m
-          Capnp_rpc.Error.pp e in
-      Lwt.fail (Failure msg)
-
-  let call_for_unit cap m req =
-    call_for_value cap m req >|= function
-    | Ok _ -> Ok ()
-    | Error _ as e -> e
-
-  let call_for_unit_exn cap m req = call_for_value_exn cap m req >|= ignore
-
-  let call_for_caps cap m req fn =
-    let q = call cap m req in
-    match fn q with
-    | r -> Core_types.dec_ref q; r
-    | exception ex -> Core_types.dec_ref q; raise ex
-
-  type 'a resolver = Cap_proxy.resolver_cap
-
-  let promise () =
-    let cap = Cap_proxy.local_promise () in
-    (cap :> Core_types.cap), (cap :> 'a resolver)
-
-  let resolve_ok r x = r#resolve x
-
-  let resolve_exn r ex = r#resolve (Core_types.broken_cap ex)
-end
-
+module Capability = Capability
 module StructRef = struct
   type 'a t = Core_types.struct_ref
 

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -163,7 +163,7 @@ module type VAT_NETWORK = sig
     (** [sturdy_ref t object_id] is a sturdy ref for [object_id], hosted at this vat.
         Fails if this vat does not accept incoming connections. *)
 
-    val connect : t -> 'a Sturdy_ref.t -> ('a capability, [> `Msg of string]) result Lwt.t
+    val connect : t -> 'a Sturdy_ref.t -> ('a capability, Capnp_rpc.Exception.t) result Lwt.t
     (** [connect t sr] creates and returns a live reference to the off-line capability [sr]. *)
 
     val connect_exn : t -> 'a Sturdy_ref.t -> 'a capability Lwt.t

--- a/capnp-rpc-lwt/tls_wrapper.ml
+++ b/capnp-rpc-lwt/tls_wrapper.ml
@@ -11,6 +11,11 @@ module Make (Underlying : Mirage_flow_lwt.S) = struct
   module Flow = struct
     include Tls_mirage.Make(Underlying)
 
+    let read flow =
+      read flow >|= function
+      | Error (`Write `Closed) -> Ok `Eof (* This can happen, despite being a write error on a read! *)
+      | x -> x
+
     let writev flow bufs =
       writev flow bufs >|= function
       | Error (`Write `Closed) -> Error `Closed

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -111,8 +111,9 @@ let test_bad_crypto switch =
   let old_warnings = Logs.warn_count () in
   Vat.connect cs.client sr >>= function
   | Ok _ -> Alcotest.fail "Wrong TLS key should have been rejected"
-  | Error (`Msg msg) ->
-    assert (String.is_prefix ~affix:"TLS connection failed: authentication failure" msg);
+  | Error e ->
+    let msg = Fmt.to_to_string Capnp_rpc.Exception.pp e in
+    assert (String.is_prefix ~affix:"Failed: TLS connection failed: authentication failure" msg);
     (* Wait for server to log warning *)
     let rec wait () =
       if Logs.warn_count () = old_warnings then Lwt.pause () >>= wait

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -25,9 +25,21 @@ module Socket_address = struct
     | `TCP of string * int
   ]
 
+  let abs_path p =
+    if Filename.is_relative p then
+      Filename.concat (Sys.getcwd ()) p
+    else p
+
+  let unix x = `Unix (abs_path x)
+  let tcp ~host ~port = `TCP (host, port)
+
   let pp f = function
     | `Unix path -> Fmt.pf f "unix:%s" path
     | `TCP (host, port) -> Fmt.pf f "tcp:%s:%d" host port
+
+  let validate_public = function
+    | `Unix path -> if Filename.is_relative path then Fmt.failwith "Path %S is relative!" path
+    | `TCP _ -> ()
 
   let equal = ( = )
 end

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -6,9 +6,18 @@ module Socket_address : sig
     | `TCP of string * int
   ]
 
+  val validate_public : t -> unit
+  (** Raises an exception if [t] is not a valid public address (e.g. the Unix path is relative) *)
+
   val pp : t Fmt.t
 
   val equal : t -> t -> bool
+
+  val unix : string -> t
+  (** [unix path] is a Unix-domain socket address. [path] is made absolute if it isn't already. *)
+
+  val tcp : host:string -> port:int -> t
+  (** [tcp ~host port] is [`TCP (host, port)]. *)
 end
 
 include Capnp_rpc_lwt.S.NETWORK with


### PR DESCRIPTION
* Move Capability module to its own file
* Cope with TLS read returning a write error
* Return sturdy-ref errors as Cap'n Proto exceptions
* Check that public addresses for Unix-domain sockets are absolute paths