### PR TITLE
Make Sturdy_ref independent of network

### DIFF
--- a/capnp-rpc-lwt/capnp_core.ml
+++ b/capnp-rpc-lwt/capnp_core.ml
@@ -17,3 +17,8 @@ module Cap_proxy = Capnp_rpc.Cap_proxy.Make(Core_types)
 
 module type ENDPOINT = Capnp_rpc.Message_types.ENDPOINT with
   module Core_types = Core_types
+
+class type sturdy_ref = object
+  method connect : (Core_types.cap, Capnp_rpc.Exception.t) result Lwt.t
+  method to_uri_with_secrets : Uri.t
+end

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -15,6 +15,8 @@ module StructRef = struct
   let dec_ref = Core_types.dec_ref
 end
 
+module Sturdy_ref = Sturdy_ref
+
 module Untyped = struct
   let struct_field t i =
     (* todo: would be better to have a separate type for this *)
@@ -69,10 +71,11 @@ module Networking (N : S.NETWORK) (F : Mirage_flow_lwt.S) = struct
   type flow = F.flow
   type 'a capability = 'a Capability.t
   type restorer = Restorer.t
+  type service_id = Restorer.Id.t
+  class type [+'a] sturdy_ref = ['a] Sturdy_ref.t
 
   module Network = N
   module Vat = Vat.Make (N) (F)
-  module Sturdy_ref = Vat.Sturdy_ref
   module CapTP = Vat.CapTP
 end
 

--- a/capnp-rpc-lwt/parse.ml
+++ b/capnp-rpc-lwt/parse.ml
@@ -107,18 +107,10 @@ module Make_basic
     in
     `Call (aid, target, msg, descs, results_to)
 
-  let string_of_pointer = function
-    | None -> ""
-    | Some ptr ->
-      let open Capnp.BytesMessage in
-      let data = { ptr with Slice.len = 0 } in
-      let ss = StructStorage.v ~data ~pointers:ptr in
-      Schema.ReaderOps.get_text ~default:"" (Some ss) 0
-
   let parse_bootstrap boot =
     let open Reader in
     let qid = Bootstrap.question_id_get boot |> AnswerId.of_uint32 in
-    let object_id = Bootstrap.deprecated_object_id_get boot |> string_of_pointer in
+    let object_id = Bootstrap.deprecated_object_id_get boot |> Schema.ReaderOps.string_of_pointer in
     `Bootstrap (qid, object_id)
 
   let parse_disembargo x =

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -10,8 +10,8 @@ module type NETWORK = sig
     val parse_uri : Uri.t -> ((t * string), [> `Msg of string]) result
     (** [parse_uri uri] extracts from a URI the network address and service ID. *)
 
-    val to_uri : t -> string -> Uri.t
-    (** [to_uri t service_id] is a URI that can be parsed back into [(t, service_id)] by [parse_uri]. *)
+    val to_uri : t * string -> Uri.t
+    (** [to_uri (t, service_id)] is a URI that can be parsed back into [(t, service_id)] by [parse_uri]. *)
 
     val equal : t -> t -> bool
 
@@ -39,7 +39,7 @@ module type VAT_NETWORK = sig
   (** Stretching capability references across a network link.
       Note: see {!module:Capnp_rpc_unix} for a higher-level wrapper for this API. *)
 
-  type 'a capability
+  type +'a capability
   (** An ['a capability] is a capability reference to a service of type ['a]. *)
 
   type flow
@@ -48,56 +48,13 @@ module type VAT_NETWORK = sig
   type restorer
   (** A function for restoring persistent capabilities from sturdy ref service IDs. *)
 
+  type +'a sturdy_ref
+  (** An off-line (persistent) capability. *)
+
+  type service_id
+  (** A (secret) token that identifies a persistent service within a vat and grants access to it. *)
+
   module Network : NETWORK
-
-  module Sturdy_ref : sig
-    (** An off-line reference to a capability.
-
-        A sturdy ref contains all the information necessary to get a live reference to the capability:
-
-        - The network address of the hosting vat (e.g. TCP host and port)
-        - A way to authenticate the hosting vat (e.g. a fingerprint of the vat's public key)
-        - A way to identify the target service within the vat and prove access to it (e.g. a Swiss number)
-
-        Note that a sturdy ref often contains secrets.
-      *)
-
-    type service_id
-    (** Identifies a service within the hosting vat.
-        This is typically a long, unguessable string. *)
-
-    type +'a t
-    (** A persistent capability reference that can be restored after contact to the target vat is interrupted. *)
-
-    val v : address:Network.Address.t -> service:service_id -> 'a t
-    (** Create a new sturdy ref. *)
-
-    val address : 'a t -> Network.Address.t
-    (** Where and how to connect to access this service's vat. *)
-
-    val service : 'a t -> service_id
-    (** Which service within the vat to select. *)
-
-    val cast : _ t -> _ t
-    (** Treat this as a reference to service with a different type. *)
-
-    val of_uri : Uri.t -> ('a t, [> `Msg of string]) result
-    (** [of_uri x] constructs a sturdy ref from a URI of the form "capnp://AUTH@...".
-        AUTH is HASH-TYPE@DIGEST for connections using TLS, or "insecure" for connections without.
-        The rest of the URI is parsed using [Network.Address.parse_uri]. *)
-
-    val to_uri_with_secrets : 'a t -> Uri.t
-    (** [to_uri_with_secrets t] is a "capnp://" URI which can be converted back to [t] using [of_uri]. *)
-
-    val pp_with_secrets : 'a t Fmt.t
-    (** [pp_with_secrets] formats a sturdy ref as a URI, including any secret tokens. *)
-
-    val pp_address : 'a t Fmt.t
-    (** [pp_address] formats just the (public) address part of a [t]. *)
-
-    val equal : 'a t -> 'a t -> bool
-    (** [equal a b] is [true] iff [a] and [b] have the same address, server fingerprint and service. *)
-  end
 
   module CapTP : sig
     (** Sharing capabilities over a network link. *)
@@ -111,7 +68,7 @@ module type VAT_NETWORK = sig
         [restore] is used to respond to "Bootstrap" messages.
         If the connection fails then [endpoint] will be disconnected. *)
 
-    val bootstrap : t -> Sturdy_ref.service_id -> 'a capability
+    val bootstrap : t -> service_id -> 'a capability
     (** [bootstrap t object_id] is the peer's bootstrap object [object_id], if any.
         Use [object_id = ""] for the main, public object. *)
 
@@ -159,15 +116,21 @@ module type VAT_NETWORK = sig
     (** [public_address t] is the address that peers should use when connecting
         to this vat to locate and authenticate it. *)
 
-    val sturdy_ref : t -> Sturdy_ref.service_id -> 'a Sturdy_ref.t
-    (** [sturdy_ref t object_id] is a sturdy ref for [object_id], hosted at this vat.
+    val sturdy_ref : t -> service_id -> 'a sturdy_ref
+    (** [sturdy_ref t service_id] is a sturdy ref for [service_id], hosted at this vat.
         Fails if this vat does not accept incoming connections. *)
 
-    val connect : t -> 'a Sturdy_ref.t -> ('a capability, Capnp_rpc.Exception.t) result Lwt.t
-    (** [connect t sr] creates and returns a live reference to the off-line capability [sr]. *)
+    val export : t -> 'a sturdy_ref -> Uri.t
+    (** [export t sr] turns [sr] into a URI, which can be displayed and imported into another vat. *)
 
-    val connect_exn : t -> 'a Sturdy_ref.t -> 'a capability Lwt.t
-    (** [connect_exn] is a wrapper for [connect] that returns a failed Lwt thread on error. *)
+    val sturdy_uri : t -> service_id -> Uri.t
+    (** [sturdy_uri t id] is [sturdy_ref t id |> export t]. *)
+
+    val import : t -> Uri.t -> ('a sturdy_ref, [`Msg of string]) result
+    (** [import t uri] parses [uri] as a "capnp://" URI. *)
+
+    val import_exn : t -> Uri.t -> 'a sturdy_ref
+    (** [import_exn] is a wrapper for [import] that raises an exception if it fails. *)
 
     val dump : t Fmt.t
   end

--- a/capnp-rpc-lwt/schema.ml
+++ b/capnp-rpc-lwt/schema.ml
@@ -1,2 +1,23 @@
 include Rpc_schema.Make(Capnp.BytesMessage)
-module ReaderOps = Capnp.Runtime.ReaderInc.Make(Capnp.RPC.None(Capnp.BytesMessage))
+
+module ReaderOps = struct
+  include Capnp.Runtime.ReaderInc.Make(Capnp.RPC.None(Capnp.BytesMessage))
+
+  let string_of_pointer = function
+    | None -> ""
+    | Some ptr ->
+      let open Capnp.BytesMessage in
+      let data = { ptr with Slice.len = 0 } in
+      let ss = StructStorage.v ~data ~pointers:ptr in
+      get_text ~default:"" (Some ss) 0
+end
+
+module BuilderOps = struct
+  include Capnp.Runtime.BuilderInc.Make(Capnp.RPC.None(Capnp.BytesMessage))
+
+  let write_string ptr s =
+    let open Capnp.BytesMessage in
+    let data = { ptr with Slice.len = 0 } in
+    let ss = StructStorage.v ~data ~pointers:ptr in
+    BA_.set_text ss 0 s
+end

--- a/capnp-rpc-lwt/serialise.ml
+++ b/capnp-rpc-lwt/serialise.ml
@@ -2,7 +2,6 @@ module EmbargoId = Capnp_rpc.Message_types.EmbargoId
 module Log = Capnp_rpc.Debug.Log
 module Builder = Schema.Builder
 module RO_array = Capnp_rpc.RO_array
-module BuilderOps = Capnp.Runtime.BuilderInc.Make(Capnp.RPC.None(Capnp.BytesMessage))
 
 module Make (EP : Capnp_core.ENDPOINT) = struct
   open EP.Table
@@ -58,12 +57,6 @@ module Make (EP : Capnp_core.ENDPOINT) = struct
     type_set b ty;
     reason_set b ex.Capnp_rpc.Exception.reason
 
-  let write_string ptr s =
-    let open Capnp.BytesMessage in
-    let data = { ptr with Slice.len = 0 } in
-    let ss = StructStorage.v ~data ~pointers:ptr in
-    BuilderOps.BA_.set_text ss 0 s
-
   let message : EP.Out.t -> _ =
     let open Builder in
     function
@@ -75,7 +68,7 @@ module Make (EP : Capnp_core.ENDPOINT) = struct
       let b = Message.init_root () in
       let boot = Message.bootstrap_init b in
       Bootstrap.question_id_set boot (QuestionId.uint32 qid);
-      write_string (Bootstrap.deprecated_object_id_get boot) object_id;
+      Schema.BuilderOps.write_string (Bootstrap.deprecated_object_id_get boot) object_id;
       Message.to_message b
     | `Call (qid, target, request, descs, results_to) ->
       let c = Msg.Request.writable request in

--- a/capnp-rpc-lwt/sturdy_ref.ml
+++ b/capnp-rpc-lwt/sturdy_ref.ml
@@ -1,45 +1,16 @@
-let error fmt =
-  fmt |> Fmt.kstrf @@ fun msg ->
-  Error (`Msg msg)
+open Lwt.Infix
 
-let ( >>= ) x f =
-  match x with
-  | Ok y -> f y
-  | Error _ as e -> e
+class type [+'a] t = Capnp_core.sturdy_ref
 
-module Make (N : S.NETWORK) = struct
-  type service_id = string
+let connect t = t#connect
 
-  type 'a t = {
-    address : N.Address.t;
-    service : service_id;
-  }
+let connect_exn t =
+  connect t >>= function
+  | Ok x -> Lwt.return x
+  | Error e -> Lwt.fail_with (Fmt.to_to_string Capnp_rpc.Exception.pp e)
 
-  let v ~address ~service = {address; service}
+let reader fn s =
+  fn s |> Schema.ReaderOps.string_of_pointer |> Uri.of_string
 
-  let equal {address; service} b =
-    N.Address.equal address b.address &&
-    service = b.service
-
-  let address t = t.address
-  let service t = t.service
-  let cast t = (t :> _ t)
-
-  let to_uri_with_secrets {address; service} =
-    N.Address.to_uri address service
-
-  let pp_with_secrets f t = Uri.pp_hum f (to_uri_with_secrets t)
-
-  let pp_address f t =
-    Fmt.pf f "<SturdyRef at %a>" N.Address.pp t.address
-
-  let parse_capnp_uri uri =
-    N.Address.parse_uri uri >>= fun (address, service) ->
-    Ok (v ~address ~service)
-
-  let of_uri uri =
-    match Uri.scheme uri with
-    | Some "capnp" -> parse_capnp_uri uri
-    | Some scheme -> error "Unknown scheme %S (expected 'capnp://...')" scheme
-    | None -> error "Missing scheme in %a (expected 'capnp://...')" Uri.pp_hum uri
-end
+let builder fn (s : 'a Capnp.BytesMessage.StructStorage.builder_t) sr =
+  sr#to_uri_with_secrets |> Uri.to_string |> Schema.BuilderOps.write_string (fn s)

--- a/examples/store.ml
+++ b/examples/store.ml
@@ -1,0 +1,141 @@
+(** A store of persistent files.
+    The user can create a new file, get and set its contents, and get a sturdy ref to it.
+    See [test_store] for an example using this. *)
+
+open Lwt.Infix
+open Capnp_rpc_lwt
+
+type digest = string
+
+module DB : sig
+  type t
+  (** An in-memory data-store. *)
+
+  val hash : Auth.hash
+  (** [hash] is the algorithm used to calculate digests. *)
+
+  val create : unit -> t
+  (** [create ()] is a new empty database. *)
+
+  val add : t -> Restorer.Id.t
+  (** [add t] returns the ID of a new empty file. *)
+
+  val set : t -> digest -> string -> unit
+  val get : t -> digest -> string
+  val mem : t -> digest -> bool
+end = struct
+  let hash : Capnp_rpc_lwt.Auth.hash = `SHA256
+
+  type t = (digest, string) Hashtbl.t
+
+  let digest = Restorer.Id.digest hash
+
+  let create () =
+    Hashtbl.create 7
+
+  let add t =
+    let id = Restorer.Id.generate () in
+    Hashtbl.add t (digest id) "";
+    id
+
+  let get t digest =
+    Hashtbl.find t digest
+
+  let set t digest data =
+    Hashtbl.replace t digest data
+
+  let mem t digest =
+    Hashtbl.mem t digest
+end
+
+module File = struct
+  let set t data =
+    let open Api.Client.File.Set in
+    let request, params = Capability.Request.create Params.init_pointer in
+    Params.data_set params data;
+    Capability.call_for_unit_exn t method_id request
+
+  let get t =
+    let open Api.Client.File.Get in
+    let request = Capability.Request.create_no_args () in
+    Capability.call_for_value_exn t method_id request >|= Results.data_get
+
+  let save t =
+    let open Api.Client.File.Save in
+    let request = Capability.Request.create_no_args () in
+    Capability.call_for_value_exn t method_id request >|= Sturdy_ref.reader Results.sr_get
+
+  let local (db:DB.t) sr digest =
+    let module File = Api.Service.File in
+    File.local @@ object
+      inherit File.service
+
+      method get_impl _ release_params =
+        let open File.Get in
+        release_params ();
+        let resp, results = Service.Response.create Results.init_pointer in
+        Results.data_set results (DB.get db digest);
+        Service.return resp
+
+      method set_impl params release_params =
+        let open File.Set in
+        let data = Params.data_get params in
+        release_params ();
+        DB.set db digest data;
+        Service.return_empty ()
+
+      method save_impl _ release_params =
+        release_params ();
+        let open File.Save in
+        let resp, results = Service.Response.create Results.init_pointer in
+        Sturdy_ref.builder Results.sr_get results sr;
+        Service.return resp
+    end
+
+  module Loader = struct
+    type t = {
+      db : DB.t;
+      make_sturdy : Restorer.Id.t -> Uri.t;
+    }
+
+    let hash _ = DB.hash
+
+    let make_sturdy t = t.make_sturdy
+
+    let load t sr digest =
+      if DB.mem t.db digest then
+        Lwt.return @@ Restorer.grant @@ local t.db sr digest
+      else
+        Lwt.return Restorer.unknown_service_id
+  end
+
+  let table ~make_sturdy db =
+    Restorer.Table.of_loader (module Loader) {Loader.db; make_sturdy}
+end
+
+let create_file t =
+  let open Api.Client.Store.CreateFile in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_caps t method_id request Results.file_get_pipelined
+
+(* The main store service. *)
+let local ~restore db =
+  let module Store = Api.Service.Store in
+  Store.local @@ object
+    inherit Store.service
+
+    (* Allows the user to add a new file to [db], uses [restore] to instantiate a
+       service for it, and returns a capability reference to the service. *)
+    method create_file_impl _ release_params =
+      let open Store.CreateFile in
+      release_params ();
+      let id = DB.add db in
+      Service.return_lwt @@ fun () ->
+      Restorer.restore restore id >|= function
+      | Error e -> Error (`Exception e)
+      | Ok x ->
+        let resp, results = Service.Response.create Results.init_pointer in
+        Results.file_set results (Some x);
+        Capability.dec_ref x;
+        Ok resp
+  end

--- a/examples/test_api.capnp
+++ b/examples/test_api.capnp
@@ -26,3 +26,15 @@ struct Bar {
   f @0 :Foo;
   version @1 :Version;
 }
+
+using SturdyRef = AnyPointer;
+
+interface File {
+  set @0 (data :Text) -> ();
+  get @1 () -> (data :Text);
+  save @2 () -> (sr :SturdyRef);
+}
+
+interface Store {
+  createFile @0 () -> (file :File);
+}

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -11,22 +11,24 @@ type restorer = Capnp_rpc_lwt.Restorer.t
 
 module CapTP = Vat_network.CapTP
 module Vat = Vat_network.Vat
-module Sturdy_ref = Vat_network.Sturdy_ref
 module Network = Network
 module Vat_config = Vat_config
 module File_store = File_store
+
+type service_id = Capnp_rpc_lwt.Restorer.Id.t
+type 'a sturdy_ref = 'a Capnp_rpc_lwt.Sturdy_ref.t
 
 let error fmt =
   fmt |> Fmt.kstrf @@ fun msg ->
   Error (`Msg msg)
 
-let sturdy_ref () =
+let sturdy_uri =
   let of_string s =
     match Uri.of_string s with
     | exception ex -> error "Failed to parse URI %S: %a" s Fmt.exn ex
-    | uri -> Sturdy_ref.of_uri uri
+    | uri -> Ok uri
   in
-  Cmdliner.Arg.conv (of_string, Sturdy_ref.pp_with_secrets)
+  Cmdliner.Arg.conv (of_string, Uri.pp_hum)
 
 let handle_connection ?tags ~secret_key vat client =
   let switch = Lwt_switch.create () in

--- a/unix/unix_flow.ml
+++ b/unix/unix_flow.ml
@@ -11,7 +11,7 @@ type flow = {
   mutable current_read : int Lwt.t option;
   mutable closed : bool;
 }
-type error = [`Closed | `Exception of exn]
+type error = [`Exception of exn]
 type write_error = [`Closed | `Exception of exn]
 type 'a io = 'a Lwt.t
 

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -119,9 +119,9 @@ let auth t =
   if t.serve_tls then Capnp_rpc_lwt.Auth.Secret_key.digest (secret_key t)
   else Capnp_rpc_lwt.Auth.Digest.insecure
 
-let sturdy_ref t service =
+let sturdy_uri t service =
   let address = (t.public_address, auth t) in
-  Vat_network.Sturdy_ref.v ~address ~service
+  Network.Address.to_uri (address, Capnp_rpc_lwt.Restorer.Id.to_string service)
 
 open Cmdliner
 


### PR DESCRIPTION
It should be possible to write services and clients without caring about the specific network type.

There is a new `Capnp_rpc_lwt.Sturdy_ref` module that provides access to the unprivileged operations on sturdy refs: add one to a message, read one from a message, or active one.

`Loader.load` now gets passed a sturdy ref for the service being loaded. The service can use this to hand out a sturdy ref to itself to its clients.

The new `Vat.import` and `Vat.export` functions allow for converting between sturdy refs and URIs.

`Capnp_rpc_unix.File_store`'s API has been simplified, as the table API now handles making sturdy refs. This works better with the Cap'n Proto persistence protocol, where you first return a capability and then let the user get the sturdy ref from that.

Closes #105.