### PR TITLE
Fix connecting to our own sturdy ref

### DIFF
--- a/capnp-rpc-lwt/restorer.ml
+++ b/capnp-rpc-lwt/restorer.ml
@@ -55,7 +55,7 @@ let fn (r:t) =
           )
       )
 
-let restore f x = f x
+let restore (f:t) x = f x
 
 let none : t = fun _ ->
   Lwt.return @@ Error (Capnp_rpc.Exception.v "This vat has no restorer")


### PR DESCRIPTION
Previously, we made a network connection to ourself and then rejected it as a duplicate. Now, we detect this case and use our restorer directly.

Fixes #114.