### PR TITLE
Add support for the persistence spec

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -79,6 +79,7 @@ module Networking (N : S.NETWORK) (F : Mirage_flow_lwt.S) = struct
   module CapTP = Vat.CapTP
 end
 
+module Persistence = Persistence
 module Two_party_network = Two_party_network
 module Auth = Auth
 module Tls_wrapper = Tls_wrapper

--- a/capnp-rpc-lwt/jbuild
+++ b/capnp-rpc-lwt/jbuild
@@ -12,3 +12,8 @@
  ((targets (rpc_schema.ml rpc_schema.mli))
   (deps (rpc_schema.capnp))
   (action  (run capnpc -o ocaml ${<}))))
+
+(rule
+ ((targets (persistent.ml persistent.mli))
+  (deps (persistent.capnp))
+  (action  (run capnpc -o ocaml ${<}))))

--- a/capnp-rpc-lwt/persistence.ml
+++ b/capnp-rpc-lwt/persistence.ml
@@ -1,0 +1,56 @@
+open Lwt.Infix
+
+module Api = Persistent.Make(Capnp.BytesMessage)
+
+class type ['a] persistent = object
+  method save : ('a Sturdy_ref.t, Capnp_rpc.Exception.t) result Lwt.t
+end
+
+let with_persistence
+    (persistent:'b #persistent)
+    (_:(#Service.generic as 'a) -> 'b Capability.t)
+    (impl : 'a) =
+  (* We ignore the second argument. It's just to force the user to prove that [impl]
+     really does have type ['a]. *)
+  let dispatch_persistent method_id _params release_params =
+    if method_id = Capnp.RPC.MethodID.method_id Api.Client.Persistent.Save.method_id then (
+      let open Api.Service.Persistent.Save in
+      release_params ();
+      Service.return_lwt @@ fun () ->
+      persistent#save >|= function
+      | Error e -> Error (`Exception e)
+      | Ok sr ->
+        let resp, results = Service.Response.create Results.init_pointer in
+        Sturdy_ref.builder Results.sturdy_ref_get results sr;
+        Ok resp
+    ) else (
+      release_params ();
+      Service.fail ~ty:`Unimplemented "Unknown persistence method %d" method_id
+    )
+  in
+  let wrapper = object (_ : #Service.generic)
+    method release = impl#release
+    method pp = impl#pp
+    method dispatch ~interface_id ~method_id =
+      if interface_id = Api.Service.Persistent.interface_id then dispatch_persistent method_id
+      else impl#dispatch ~interface_id ~method_id
+  end in
+  Service.local wrapper
+
+let with_sturdy_ref sr local impl =
+  let persistent = object
+    method save = Lwt.return (Ok sr)
+  end in
+  with_persistence persistent local impl
+
+let save cap =
+  let open Api.Client.Persistent.Save in
+  let request = Capability.Request.create_no_args () in
+  Capability.call_for_value cap method_id request >|= function
+  | Error _ as e -> e
+  | Ok response -> Ok (Sturdy_ref.reader Results.sturdy_ref_get response)
+
+let save_exn cap =
+  save cap >>= function
+  | Error e -> Lwt.fail_with (Fmt.to_to_string Capnp_rpc.Error.pp e)
+  | Ok x -> Lwt.return x

--- a/capnp-rpc-lwt/persistent.capnp
+++ b/capnp-rpc-lwt/persistent.capnp
@@ -1,0 +1,139 @@
+# Copyright (c) 2014 Sandstorm Development Group, Inc. and contributors
+# Licensed under the MIT License:
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+@0xb8630836983feed7;
+
+#$import "/capnp/c++.capnp".namespace("capnp");
+
+interface Persistent@0xc8cb212fcd9f5691(SturdyRef, Owner) {
+  # Interface implemented by capabilities that outlive a single connection. A client may save()
+  # the capability, producing a SturdyRef. The SturdyRef can be stored to disk, then later used to
+  # obtain a new reference to the capability on a future connection.
+  #
+  # The exact format of SturdyRef depends on the "realm" in which the SturdyRef appears. A "realm"
+  # is an abstract space in which all SturdyRefs have the same format and refer to the same set of
+  # resources. Every vat is in exactly one realm. All capability clients within that vat must
+  # produce SturdyRefs of the format appropriate for the realm.
+  #
+  # Similarly, every VatNetwork also resides in a particular realm. Usually, a vat's "realm"
+  # corresponds to the realm of its main VatNetwork. However, a Vat can in fact communicate over
+  # a VatNetwork in a different realm -- in this case, all SturdyRefs need to be transformed when
+  # coming or going through said VatNetwork. The RPC system has hooks for registering
+  # transformation callbacks for this purpose.
+  #
+  # Since the format of SturdyRef is realm-dependent, it is not defined here. An application should
+  # choose an appropriate realm for itself as part of its design. Note that under Sandstorm, every
+  # application exists in its own realm and is therefore free to define its own SturdyRef format;
+  # the Sandstorm platform handles translating between realms.
+  #
+  # Note that whether a capability is persistent is often orthogonal to its type. In these cases,
+  # the capability's interface should NOT inherit `Persistent`; instead, just perform a cast at
+  # runtime. It's not type-safe, but trying to be type-safe in these cases will likely lead to
+  # tears. In cases where a particular interface only makes sense on persistent capabilities, it
+  # still should not explicitly inherit Persistent because the `SturdyRef` and `Owner` types will
+  # vary between realms (they may even be different at the call site than they are on the
+  # implementation). Instead, mark persistent interfaces with the $persistent annotation (defined
+  # below).
+  #
+  # Sealing
+  # -------
+  #
+  # As an added security measure, SturdyRefs may be "sealed" to a particular owner, such that
+  # if the SturdyRef itself leaks to a third party, that party cannot actually restore it because
+  # they are not the owner. To restore a sealed capability, you must first prove to its host that
+  # you are the rightful owner. The precise mechanism for this authentication is defined by the
+  # realm.
+  #
+  # Sealing is a defense-in-depth mechanism meant to mitigate damage in the case of catastrophic
+  # attacks. For example, say an attacker temporarily gains read access to a database full of
+  # SturdyRefs: it would be unfortunate if it were then necessary to revoke every single reference
+  # in the database to prevent the attacker from using them.
+  #
+  # In general, an "owner" is a course-grained identity. Because capability-based security is still
+  # the primary mechanism of security, it is not necessary nor desirable to have a separate "owner"
+  # identity for every single process or object; that is exactly what capabilities are supposed to
+  # avoid! Instead, it makes sense for an "owner" to literally identify the owner of the machines
+  # where the capability is stored. If untrusted third parties are able to run arbitrary code on
+  # said machines, then the sandbox for that code should be designed using Distributed Confinement
+  # such that the third-party code never sees the bits of the SturdyRefs and cannot directly
+  # exercise the owner's power to restore refs. See:
+  #
+  #     http://www.erights.org/elib/capability/dist-confine.html
+  #
+  # Resist the urge to represent an Owner as a simple public key. The whole point of sealing is to
+  # defend against leaked-storage attacks. Such attacks can easily result in the owner's private
+  # key being stolen as well. A better solution is for `Owner` to contain a simple globally unique
+  # identifier for the owner, and for everyone to separately maintain a mapping of owner IDs to
+  # public keys. If an owner's private key is compromised, then humans will need to communicate
+  # and agree on a replacement public key, then update the mapping.
+  #
+  # As a concrete example, an `Owner` could simply contain a domain name, and restoring a SturdyRef
+  # would require signing a request using the domain's private key. Authenticating this key could
+  # be accomplished through certificate authorities or web-of-trust techniques.
+
+  save @0 SaveParams -> SaveResults;
+  # Save a capability persistently so that it can be restored by a future connection.  Not all
+  # capabilities can be saved -- application interfaces should define which capabilities support
+  # this and which do not.
+
+  struct SaveParams {
+    sealFor @0 :Owner;
+    # Seal the SturdyRef so that it can only be restored by the specified Owner. This is meant
+    # to mitigate damage when a SturdyRef is leaked. See comments above.
+    #
+    # Leaving this value null may or may not be allowed; it is up to the realm to decide. If a
+    # realm does allow a null owner, this should indicate that anyone is allowed to restore the
+    # ref.
+  }
+  struct SaveResults {
+    sturdyRef @0 :SturdyRef;
+  }
+}
+
+interface RealmGateway(InternalRef, ExternalRef, InternalOwner, ExternalOwner) {
+  # Interface invoked when a SturdyRef is about to cross realms. The RPC system supports providing
+  # a RealmGateway as a callback hook when setting up RPC over some VatNetwork.
+
+  import @0 (cap :Persistent(ExternalRef, ExternalOwner),
+             params :Persistent(InternalRef, InternalOwner).SaveParams)
+         -> Persistent(InternalRef, InternalOwner).SaveResults;
+  # Given an external capability, save it and return an internal reference. Used when someone
+  # inside the realm tries to save a capability from outside the realm.
+
+  export @1 (cap :Persistent(InternalRef, InternalOwner),
+             params :Persistent(ExternalRef, ExternalOwner).SaveParams)
+         -> Persistent(ExternalRef, ExternalOwner).SaveResults;
+  # Given an internal capability, save it and return an external reference. Used when someone
+  # outside the realm tries to save a capability from inside the realm.
+}
+
+annotation persistent(interface, field) :Void;
+# Apply this annotation to interfaces for objects that will always be persistent, instead of
+# extending the Persistent capability, since the correct type parameters to Persistent depend on
+# the realm, which is orthogonal to the interface type and therefore should not be defined
+# along-side it.
+#
+# You may also apply this annotation to a capability-typed field which will always contain a
+# persistent capability, but where the capability's interface itself is not already marked
+# persistent.
+#
+# Note that absence of the $persistent annotation doesn't mean a capability of that type isn't
+# persistent; it just means not *all* such capabilities are persistent.

--- a/capnp-rpc-lwt/sturdy_ref.ml
+++ b/capnp-rpc-lwt/sturdy_ref.ml
@@ -12,5 +12,7 @@ let connect_exn t =
 let reader fn s =
   fn s |> Schema.ReaderOps.string_of_pointer |> Uri.of_string
 
-let builder fn (s : 'a Capnp.BytesMessage.StructStorage.builder_t) sr =
+let builder fn (s : 'a Capnp.BytesMessage.StructStorage.builder_t) (sr : 'a t) =
   sr#to_uri_with_secrets |> Uri.to_string |> Schema.BuilderOps.write_string (fn s)
+
+let cast t = t

--- a/examples/test_api.capnp
+++ b/examples/test_api.capnp
@@ -27,12 +27,9 @@ struct Bar {
   version @1 :Version;
 }
 
-using SturdyRef = AnyPointer;
-
 interface File {
   set @0 (data :Text) -> ();
   get @1 () -> (data :Text);
-  save @2 () -> (sr :SturdyRef);
 }
 
 interface Store {

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -319,7 +319,8 @@ let expect_non_exn = function
 let except = Alcotest.testable Capnp_rpc.Exception.pp (=)
 
 let test_table_restorer _switch =
-  let table = Restorer.Table.create () in
+  let make_sturdy id = Uri.make ~path:(Restorer.Id.to_string id) () in
+  let table = Restorer.Table.create make_sturdy in
   let echo_id = Restorer.Id.public "echo" in
   let registry_id = Restorer.Id.public "registry" in
   let broken_id = Restorer.Id.public "broken" in
@@ -559,7 +560,7 @@ let test_store switch =
   (* Try creating a file *)
   let file = Store.create_file store in
   Store.File.set file "Hello" >>= fun () ->
-  Store.File.save file >>= fun file_sr ->
+  Persistence.save_exn file >>= fun file_sr ->
   let file_sr = Vat.import_exn client file_sr in (* todo: get rid of this step *)
   (* Shut down server *)
   Lwt_switch.turn_off server_switch >>= fun () ->


### PR DESCRIPTION
`Persistence.with_persistence` can be used to extend any service implementation with persistence support. `Persistence.with_sturdy_ref` provides a simple wrapper for this for the common case where a service knows its sturdy ref at the start.

`Persistence.save` or `save_exn` can be used to request a sturdy ref.

Added `Restorer.Table.sturdy_ref` to get a sturdy ref for a service in the table. `Restorer.Table.create` now takes a function for generating URIs from IDs so that in-memory-only tables can also support this.

Added `Sturdy_ref.cast`. This is needed when implementing a loader, since the restorer doesn't know the type of the sturdy ref that it passes in.

Closes #107.