### PR TITLE
Add command-line support for reading URIs from files

### DIFF
--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -84,7 +84,7 @@ module File_store : sig
 end
 
 val sturdy_uri : Uri.t Cmdliner.Arg.conv
-(** A cmdliner argument converter for "capnp://" URIs. *)
+(** A cmdliner argument converter for a "capnp://" URI (or the path of a file containing such a URI). *)
 
 val serve :
   ?switch:Lwt_switch.t ->


### PR DESCRIPTION
As an alternative to passing a `capnp://` URI on the command-line, you can now also pass the path of a file containing such a URL.

Closes #104.