### PR TITLE
Fix race when reconnecting

### DIFF
--- a/capnp-rpc-lwt/capTP_capnp.ml
+++ b/capnp-rpc-lwt/capTP_capnp.ml
@@ -89,6 +89,7 @@ module Make (Network : S.NETWORK) = struct
               f ~tags "<- %a" (Endpoint_types.In.pp_recv pp_msg) msg);
           begin match msg with
             | `Abort _ ->
+              t.disconnecting <- true;
               Conn.handle_msg t.conn msg;
               Endpoint.disconnect t.endpoint >>= fun () ->
               Lwt.return `Aborted
@@ -118,6 +119,8 @@ module Make (Network : S.NETWORK) = struct
     ) else (
       Lwt.return_unit
     )
+
+  let disconnecting t = t.disconnecting
 
   let connect ~restore ?(tags=Logs.Tag.empty) endpoint =
     let xmit_queue = Queue.create () in

--- a/capnp-rpc-lwt/capTP_capnp.mli
+++ b/capnp-rpc-lwt/capTP_capnp.mli
@@ -19,6 +19,9 @@ module Make (N : S.NETWORK) : sig
   val disconnect : t -> Capnp_rpc.Exception.t -> unit Lwt.t
   (** [disconnect t reason] releases all resources used by the connection. *)
 
+  val disconnecting : t -> bool
+  (** [disconnecting t] the connection is shutting down (or has shut down). *)
+
   val dump : t Fmt.t
   (** [dump] dumps the state of the connection, for debugging. *)
 end


### PR DESCRIPTION
We notify the user that the capability has broken while then old connection is still shutting down. If they immediately try to reconnect, we previously tried to reuse the old connection. Now, we wait for it to be removed.