### PR TITLE
Fix ref-counting bug in calculator example

### DIFF
--- a/examples/calc.ml
+++ b/examples/calc.ml
@@ -126,7 +126,7 @@ let pp_result_lwt f x =
 let rec eval ?(args=[||]) : _ -> Api.Reader.Calculator.Value.t Capability.t =
   let open Expr in function
   | Float f -> Value.local f
-  | Prev v -> v
+  | Prev v -> Capability.inc_ref v; v
   | Param p -> Value.local args.(p)
   | Call (f, params) ->
     let params = params |> Lwt_list.map_p (fun p ->

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -31,7 +31,7 @@ let reporter =
 
 let serve vat_config =
   Lwt_main.run begin
-    let service_id = Capnp_rpc_lwt.Restorer.Id.public "calculator" in
+    let service_id = Capnp_rpc_lwt.Restorer.Id.public "" in
     let restore = Capnp_rpc_lwt.Restorer.single service_id Examples.Calc.local in
     Capnp_rpc_unix.serve vat_config ~restore >>= fun vat ->
     let sr = Vat.sturdy_uri vat service_id in


### PR DESCRIPTION
Also, change service ID to match what the C++ client expects.

With these changes, the C++ tests pass:

```
$ ./calculator-client 127.0.0.1:7001
Evaluating a literal... PASS
Using add and subtract... PASS
Pipelining eval() calls... PASS
Defining functions... PASS
Using a callback... PASS
```