### PR TITLE
Better way to get the client certificate from a TLS connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Note also a design choice here in the API: we could have made the `Echo.heartbea
 The advantage to doing it this way is that `main.ml` may one day want to pass a remote callback, as we'll see later.
 
 This still isn't very exciting, because we just stored an OCaml object pointer in a message and then pulled it out again.
-However, we can use the same code with the echo client and service in separate processes, commmunicating over the network...
+However, we can use the same code with the echo client and service in separate processes, communicating over the network...
 
 ### Networking
 
@@ -579,7 +579,7 @@ Callback got "foo"
 
 ### Pipelining
 
-Let's say the server also offers a logging service, which the client can get from the bootstrap service:
+Let's say the server also offers a logging service, which the client can get from the main echo service:
 
 ```capnp
 interface Echo {

--- a/capnp-rpc-lwt/auth.mli
+++ b/capnp-rpc-lwt/auth.mli
@@ -67,8 +67,13 @@ module Secret_key : sig
   val to_pem_data : t -> string
   (** [to_pem_data t] returns [t] as a PEM-encoded private key. *)
 
-  val certificates : t -> Tls.Config.own_cert
-  (** [certificates t] is the TLS certificate chain to use for a vat with secret key [t]. *)
+  val tls_client_config : t -> authenticator:X509.Authenticator.a -> Tls.Config.client
+  (** [tls_client_config t ~authenticator] is the TLS client configuration to
+      use for a vat with secret key [t], attempting to connect to a vat that
+      can be authenticated with [authenticator]. *)
+
+  val tls_server_config : t -> Tls.Config.server
+  (** [tls_server_config t] is the TLS server configuration to use for a vat with secret key [t]. *)
 
   val pp_fingerprint : hash -> t Fmt.t
   (** [pp_fingerprint hash] formats the hash of [t]'s public key. *)


### PR DESCRIPTION
Suggested by @hannesm in https://github.com/mirage/capnp-rpc/issues/126#issuecomment-331843320