### PR TITLE
Tidy the code ready for Mirage support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM ocaml/opam@sha256:5e8ebc171a90fb62209e67dcaeedafd02018bc43ebc1e3074a5d03f9789f0ca1
+FROM ocaml/opam@sha256:683543a56e30160a82778f1d2e795f23579a71e5b5554a4d36b2b44421629cdd
 #FROM ocaml/opam:debian-9_ocaml-4.05.0
-RUN cd opam-repository && git fetch && git reset --hard 3cad9b6baa95451f294008d0b791c2b0d54b0968 && opam update
+RUN cd opam-repository && git fetch && git reset --hard 5076ad3874e50af8cc47a4fb5c49b3f590010b76 && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
 RUN opam pin add -ny capnp-rpc.dev . && \
     opam pin add -ny capnp-rpc-lwt.dev . && \
     opam pin add -ny capnp-rpc-unix.dev . && \
     opam depext capnp-rpc-unix
-RUN opam install capnp-rpc-unix alcotest afl-persistent
+RUN opam install capnp-rpc-unix alcotest-lwt afl-persistent
 ADD . /home/opam/capnp-rpc
 RUN sudo chown -R opam /home/opam/capnp-rpc
 RUN opam config exec -- make all test

--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -24,6 +24,6 @@ depends: [
   "base64"
   "uri"
   "jbuilder" {build & >= "1.0+beta10" }
-  "alcotest" {test}
+  "alcotest-lwt" {test}
 ]
 available: [ocaml-version >= "4.03.0"]

--- a/capnp-rpc-lwt/capnp_address.ml
+++ b/capnp-rpc-lwt/capnp_address.ml
@@ -1,0 +1,87 @@
+open Astring
+
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
+
+let none_if_empty = function
+  | None | Some "" -> None
+  | Some _ as x -> x
+
+module Location = struct
+  type t = [
+    | `Unix of string
+    | `TCP of string * int
+  ]
+
+  let pp f = function
+    | `Unix path -> Fmt.pf f "unix:%s" path
+    | `TCP (host, port) -> Fmt.pf f "tcp:%s:%d" host port
+
+  let equal = ( = )
+end
+
+type t = Location.t * Auth.Digest.t
+
+let digest = snd
+
+let alphabet = B64.uri_safe_alphabet
+
+let b64encode s = B64.encode ~alphabet ~pad:false s
+
+let b64decode s =
+  try Ok (B64.decode ~alphabet s)
+  with ex -> error "Bad base64 digest %S: %a" s Fmt.exn ex
+
+let to_uri ((addr, auth), service_id) =
+  let service_id = b64encode service_id in
+  let uri =
+    match addr with
+    | `Unix path ->
+      let path = Printf.sprintf "%s/%s" path service_id in
+      Uri.make ~scheme:"capnp" ~path ()
+    | `TCP (host, port) ->
+      Uri.make ~scheme:"capnp" ~host ~port ~path:service_id ()
+  in
+  Auth.Digest.add_to_uri auth uri
+
+let pp f t =
+  Uri.pp_hum f (to_uri (t, ""))
+
+let ( >>= ) x f =
+  match x with
+  | Error _ as e -> e
+  | Ok y -> f y
+
+let strip_leading_slash s =
+  if String.is_prefix ~affix:"/" s then String.with_range ~first:1 s
+  else s
+
+let check_sheme uri =
+  match Uri.scheme uri with
+  | Some "capnp" -> Ok ()
+  | Some scheme -> error "Unknown scheme %S (expected 'capnp://...')" scheme
+  | None -> error "Missing scheme in %a (expected 'capnp://...')" Uri.pp_hum uri
+
+let parse_uri uri =
+  check_sheme uri >>= fun () ->
+  let host = Uri.host uri |> none_if_empty in
+  let port = Uri.port uri in
+  let path = Uri.path uri in
+  Auth.Digest.from_uri uri >>= fun auth ->
+  match host, port with
+  | Some host, Some port ->
+    b64decode (strip_leading_slash path) >>= fun service_id ->
+    Ok ((`TCP (host, port), auth), service_id)
+  | Some _,    None   -> error "Missing port in %a" Uri.pp_hum uri
+  | None,      Some _ -> error "Port without host in %a!" Uri.pp_hum uri
+  | None,      None   ->
+    match String.cut ~rev:true ~sep:"/" path with
+    | None -> Ok ((`Unix path, auth), "")
+    | Some (path, service_id) ->
+      b64decode service_id >>= fun service_id ->
+      Ok ((`Unix path, auth), service_id)
+
+let equal (addr, auth) (addr_b, auth_b) =
+  Location.equal addr addr_b &&
+  Auth.Digest.equal auth auth_b

--- a/capnp-rpc-lwt/capnp_address.mli
+++ b/capnp-rpc-lwt/capnp_address.mli
@@ -1,0 +1,16 @@
+(** Handling of capnp:// URI format addresses.
+    This code is shared between the unix and mirage networks. *)
+
+module Location : sig
+  type t = [
+    | `Unix of string
+    | `TCP of string * int
+  ]
+
+  val pp : t Fmt.t
+
+  val equal : t -> t -> bool
+end
+
+include S.ADDRESS with
+  type t = Location.t * Auth.Digest.t

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -79,6 +79,7 @@ module Networking (N : S.NETWORK) (F : Mirage_flow_lwt.S) = struct
   module CapTP = Vat.CapTP
 end
 
+module Capnp_address = Capnp_address
 module Persistence = Persistence
 module Two_party_network = Two_party_network
 module Auth = Auth

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -370,6 +370,8 @@ module Networking (N : S.NETWORK) (Flow : Mirage_flow_lwt.S) : S.VAT_NETWORK
        type service_id = Restorer.Id.t and
        type 'a sturdy_ref = 'a Sturdy_ref.t
 
+module Capnp_address = Capnp_address
+
 (**/**)
 
 module Untyped : sig

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -21,12 +21,15 @@ module type NETWORK = sig
     val pp : t Fmt.t
   end
 
+  type t
+
   val connect :
+    t ->
     switch:Lwt_switch.t ->
     secret_key:Auth.Secret_key.t Lazy.t ->
     Address.t ->
     (Endpoint.t, [> `Msg of string]) result Lwt.t
-  (** [connect ~switch ~secret_key address] connects to [address], proves ownership of
+  (** [connect t ~switch ~secret_key address] connects to [address], proves ownership of
       [secret_key] (if TLS is being used), and returns the resulting endpoint.
       Returns an error if no connection can be established or the target fails
       to authenticate itself.
@@ -96,8 +99,8 @@ module type VAT_NETWORK = sig
       ?restore:restorer ->
       ?address:Network.Address.t ->
       secret_key:Auth.Secret_key.t Lazy.t ->
-      unit -> t
-    (** [create ~switch ~restore ~address ~secret_key ()] is a new vat that
+      Network.t -> t
+    (** [create ~switch ~restore ~address ~secret_key network] is a new vat that
         uses [restore] to restore sturdy refs hosted at this vat to live
         capabilities for peers.
         The vat will suggest that other parties connect to it using [address].

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -1,25 +1,27 @@
 (** Module signatures. *)
 
+module type ADDRESS = sig
+  type t
+  (** A network address at which a vat can be reached. *)
+
+  val parse_uri : Uri.t -> ((t * string), [> `Msg of string]) result
+  (** [parse_uri uri] extracts from a URI the network address and service ID. *)
+
+  val to_uri : t * string -> Uri.t
+  (** [to_uri (t, service_id)] is a URI that can be parsed back into [(t, service_id)] by [parse_uri]. *)
+
+  val equal : t -> t -> bool
+
+  val digest : t -> Auth.Digest.t
+  (** How to verify that the correct address has been reached. *)
+
+  val pp : t Fmt.t
+end
+
 module type NETWORK = sig
   module Types : Capnp_rpc.S.NETWORK_TYPES
 
-  module Address : sig
-    type t
-    (** A network address at which a vat can be reached. *)
-
-    val parse_uri : Uri.t -> ((t * string), [> `Msg of string]) result
-    (** [parse_uri uri] extracts from a URI the network address and service ID. *)
-
-    val to_uri : t * string -> Uri.t
-    (** [to_uri (t, service_id)] is a URI that can be parsed back into [(t, service_id)] by [parse_uri]. *)
-
-    val equal : t -> t -> bool
-
-    val digest : t -> Auth.Digest.t
-    (** How to verify that the correct address has been reached. *)
-
-    val pp : t Fmt.t
-  end
+  module Address : ADDRESS
 
   type t
 

--- a/capnp-rpc-lwt/two_party_network.ml
+++ b/capnp-rpc-lwt/two_party_network.ml
@@ -18,6 +18,8 @@ module Address = struct
   let digest _ = assert false
 end
 
+type t = unit
+
 let parse_third_party_cap_id _ = `Two_party_only
 
-let connect ~switch:_ ~secret_key:_ _ = assert false
+let connect () ~switch:_ ~secret_key:_ _ = assert false

--- a/capnp-rpc-lwt/two_party_network.mli
+++ b/capnp-rpc-lwt/two_party_network.mli
@@ -1,3 +1,3 @@
 (** A network where the is only one other addressable party. *)
 
-include S.NETWORK
+include S.NETWORK with type t = unit

--- a/test-lwt/jbuild
+++ b/test-lwt/jbuild
@@ -2,7 +2,7 @@
 
 (executable (
   (name test)
-  (libraries (capnp-rpc-lwt capnp-rpc-unix alcotest examples logs.fmt testbed))
+  (libraries (capnp-rpc-lwt capnp-rpc-unix alcotest-lwt examples logs.fmt testbed))
 ))
 
 (alias

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -17,10 +17,10 @@ module Vat_config : sig
 
   val create :
     ?backlog:int ->
-    ?public_address:Network.Socket_address.t ->
+    ?public_address:Network.Location.t ->
     secret_key:[< `File of string | `PEM of string | `Ephemeral] ->
     ?serve_tls:bool ->
-    Network.Socket_address.t -> t
+    Network.Location.t -> t
   (** [create ~secret_key listen_address] is the configuration for a server vat that
       listens on address [listen_address].
       [secret_key] may be one of:

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -1,6 +1,25 @@
-open Astring
 module Log = Capnp_rpc.Debug.Log
 module Tls_wrapper = Capnp_rpc_lwt.Tls_wrapper.Make(Unix_flow)
+
+module Location = struct
+  include Capnp_rpc_lwt.Capnp_address.Location
+
+  let abs_path p =
+    if Filename.is_relative p then
+      Filename.concat (Sys.getcwd ()) p
+    else p
+
+  let validate_public = function
+    | `Unix path -> if Filename.is_relative path then Fmt.failwith "Path %S is relative!" path
+    | `TCP _ -> ()
+
+  let unix x = `Unix (abs_path x)
+  let tcp ~host ~port = `TCP (host, port)
+end
+
+module Address
+  : Capnp_rpc_lwt.S.ADDRESS with type t = Location.t * Capnp_rpc_lwt.Auth.Digest.t
+  = Capnp_rpc_lwt.Capnp_address
 
 module Types = struct
   type provision_id
@@ -11,107 +30,11 @@ end
 
 type t = unit
 
-let parse_third_party_cap_id _ = `Two_party_only
-
 let error fmt =
   fmt |> Fmt.kstrf @@ fun msg ->
   Error (`Msg msg)
 
-let none_if_empty = function
-  | None | Some "" -> None
-  | Some _ as x -> x
-
-module Socket_address = struct
-  type t = [
-    | `Unix of string
-    | `TCP of string * int
-  ]
-
-  let abs_path p =
-    if Filename.is_relative p then
-      Filename.concat (Sys.getcwd ()) p
-    else p
-
-  let unix x = `Unix (abs_path x)
-  let tcp ~host ~port = `TCP (host, port)
-
-  let pp f = function
-    | `Unix path -> Fmt.pf f "unix:%s" path
-    | `TCP (host, port) -> Fmt.pf f "tcp:%s:%d" host port
-
-  let validate_public = function
-    | `Unix path -> if Filename.is_relative path then Fmt.failwith "Path %S is relative!" path
-    | `TCP _ -> ()
-
-  let equal = ( = )
-end
-
-module Address = struct
-  type t = Socket_address.t * Capnp_rpc_lwt.Auth.Digest.t
-
-  let digest = snd
-
-  let alphabet = B64.uri_safe_alphabet
-
-  let b64encode s = B64.encode ~alphabet ~pad:false s
-
-  let b64decode s =
-    try Ok (B64.decode ~alphabet s)
-    with ex -> error "Bad base64 digest %S: %a" s Fmt.exn ex
-
-  let to_uri ((addr, auth), service_id) =
-    let service_id = b64encode service_id in
-    let uri =
-      match addr with
-      | `Unix path ->
-        let path = Printf.sprintf "%s/%s" path service_id in
-        Uri.make ~scheme:"capnp" ~path ()
-      | `TCP (host, port) ->
-        Uri.make ~scheme:"capnp" ~host ~port ~path:service_id ()
-    in
-    Capnp_rpc_lwt.Auth.Digest.add_to_uri auth uri
-
-  let pp f t =
-    Uri.pp_hum f (to_uri (t, ""))
-
-  let ( >>= ) x f =
-    match x with
-    | Error _ as e -> e
-    | Ok y -> f y
-
-  let strip_leading_slash s =
-    if String.is_prefix ~affix:"/" s then String.with_range ~first:1 s
-    else s
-
-  let check_sheme uri =
-    match Uri.scheme uri with
-    | Some "capnp" -> Ok ()
-    | Some scheme -> error "Unknown scheme %S (expected 'capnp://...')" scheme
-    | None -> error "Missing scheme in %a (expected 'capnp://...')" Uri.pp_hum uri
-
-  let parse_uri uri =
-    check_sheme uri >>= fun () ->
-    let host = Uri.host uri |> none_if_empty in
-    let port = Uri.port uri in
-    let path = Uri.path uri in
-    Capnp_rpc_lwt.Auth.Digest.from_uri uri >>= fun auth ->
-    match host, port with
-    | Some host, Some port ->
-      b64decode (strip_leading_slash path) >>= fun service_id ->
-      Ok ((`TCP (host, port), auth), service_id)
-    | Some _,    None   -> error "Missing port in %a" Uri.pp_hum uri
-    | None,      Some _ -> error "Port without host in %a!" Uri.pp_hum uri
-    | None,      None   ->
-      match String.cut ~rev:true ~sep:"/" path with
-      | None -> Ok ((`Unix path, auth), "")
-      | Some (path, service_id) ->
-        b64decode service_id >>= fun service_id ->
-        Ok ((`Unix path, auth), service_id)
-
-  let equal (addr, auth) (addr_b, auth_b) =
-    Socket_address.equal addr addr_b &&
-    Capnp_rpc_lwt.Auth.Digest.equal auth auth_b
-end
+let parse_third_party_cap_id _ = `Two_party_only
 
 let addr_of_host host =
   match Unix.gethostbyname host with
@@ -138,7 +61,7 @@ let connect_socket = function
 let connect () ~switch ~secret_key (addr, auth) =
   match connect_socket addr with
   | exception ex ->
-    Lwt.return @@ error "@[<v2>Network connection for %a failed:@,%a@]" Socket_address.pp addr Fmt.exn ex
+    Lwt.return @@ error "@[<v2>Network connection for %a failed:@,%a@]" Location.pp addr Fmt.exn ex
   | socket ->
     let flow = Unix_flow.connect ~switch (Lwt_unix.of_unix_file_descr socket) in
     Tls_wrapper.connect_as_client ~switch flow secret_key auth

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -9,6 +9,8 @@ module Types = struct
   type join_key_part
 end
 
+type t = unit
+
 let parse_third_party_cap_id _ = `Two_party_only
 
 let error fmt =
@@ -133,7 +135,7 @@ let connect_socket = function
     Unix.connect socket (Unix.ADDR_INET (addr_of_host host, port));
     socket
 
-let connect ~switch ~secret_key (addr, auth) =
+let connect () ~switch ~secret_key (addr, auth) =
   match connect_socket addr with
   | exception ex ->
     Lwt.return @@ error "@[<v2>Network connection for %a failed:@,%a@]" Socket_address.pp addr Fmt.exn ex

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -21,6 +21,7 @@ module Socket_address : sig
 end
 
 include Capnp_rpc_lwt.S.NETWORK with
+  type t = unit and
   type Address.t = Socket_address.t * Capnp_rpc_lwt.Auth.Digest.t
 
 val accept_connection :

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -1,6 +1,6 @@
 (** A network using TCP and Unix-domain sockets. *)
 
-module Socket_address : sig
+module Location : sig
   type t = [
     | `Unix of string
     | `TCP of string * int
@@ -22,7 +22,7 @@ end
 
 include Capnp_rpc_lwt.S.NETWORK with
   type t = unit and
-  type Address.t = Socket_address.t * Capnp_rpc_lwt.Auth.Digest.t
+  type Address.t = Location.t * Capnp_rpc_lwt.Auth.Digest.t
 
 val accept_connection :
   switch:Lwt_switch.t ->

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -4,7 +4,7 @@ module Auth = Capnp_rpc_lwt.Auth
 module Log = Capnp_rpc.Debug.Log
 
 module Listen_address = struct
-  include Network.Socket_address
+  include Network.Location
 
   let parse_tcp s =
     match String.cut ~sep:":" s with
@@ -47,8 +47,8 @@ type t = {
   backlog : int;
   secret_key : (Auth.Secret_key.t * Secret_hash.t) Lazy.t;
   serve_tls : bool;
-  listen_address : Network.Socket_address.t;
-  public_address : Network.Socket_address.t;
+  listen_address : Listen_address.t;
+  public_address : Network.Location.t;
 }
 
 let secret_key t = fst @@ Lazy.force t.secret_key
@@ -92,7 +92,7 @@ let create ?(backlog=5) ?public_address ~secret_key ?(serve_tls=true) listen_add
     | Some x -> x
     | None -> listen_address
   in
-  Network.Socket_address.validate_public public_address;
+  Network.Location.validate_public public_address;
   let secret_key = lazy (
     match secret_key with
     | `File path -> init_secret_key_file path
@@ -130,14 +130,14 @@ let pp f {backlog; secret_key; serve_tls; listen_address; public_address} =
     backlog
     (Auth.Secret_key.pp_fingerprint `SHA256) (fst @@ Lazy.force secret_key)
     serve_tls
-    Network.Socket_address.pp listen_address
-    Network.Socket_address.pp public_address
+    Listen_address.pp listen_address
+    Network.Location.pp public_address
 
 let equal {backlog; secret_key; serve_tls; listen_address; public_address} b =
   backlog = b.backlog &&
   serve_tls = serve_tls &&
-  Network.Socket_address.equal listen_address b.listen_address &&
-  Network.Socket_address.equal public_address b.public_address &&
+  Listen_address.equal listen_address b.listen_address &&
+  Network.Location.equal public_address b.public_address &&
   Auth.Secret_key.equal (fst @@ Lazy.force secret_key) (fst @@ Lazy.force b.secret_key)
 
 let public_address =


### PR DESCRIPTION
- Don't assume the network is a global; pass it as an argument.
- Simplify the tests with `Alcotest_lwt`.
- Move `capnp://` URI handling out of `unix` so that it can be shared.