### PR TITLE
Add Mirage support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ WORKDIR /home/opam/capnp-rpc/
 RUN opam pin add -ny capnp-rpc.dev . && \
     opam pin add -ny capnp-rpc-lwt.dev . && \
     opam pin add -ny capnp-rpc-unix.dev . && \
-    opam depext capnp-rpc-unix
-RUN opam install capnp-rpc-unix alcotest-lwt afl-persistent
+    opam pin add -ny capnp-rpc-mirage.dev . && \
+    opam depext capnp-rpc-unix capnp-rpc-mirage
+RUN opam install capnp-rpc-unix capnp-rpc-mirage alcotest-lwt afl-persistent io-page-unix tcpip mirage-vnetif
 ADD . /home/opam/capnp-rpc
 RUN sudo chown -R opam /home/opam/capnp-rpc
 RUN opam config exec -- make all test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: test build-fuzz
 
 all:
-	jbuilder build --dev @install test/test.bc test-lwt/test.bc test-bin/calc.exe
+	jbuilder build --dev @install test/test.bc test-lwt/test.bc test-bin/calc.exe test-mirage/test.bc
 	rm -rf _build/_tests
 	jbuilder runtest --dev --no-buffer -j 1
 
@@ -19,7 +19,7 @@ clean:
 
 test:
 	rm -rf _build/_tests
-	jbuilder build --dev test/test.bc test-lwt/test.bc test-bin/calc.bc
+	jbuilder build --dev test/test.bc test-lwt/test.bc test-bin/calc.bc test-mirage/test.bc
 	#./_build/default/test/test.bc test core -ev 36
 	#./_build/default/test-lwt/test.bc test lwt -ev 3
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/capnp-rpc-lwt/capnp_rpc_lwt.ml
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.ml
@@ -67,12 +67,14 @@ module S = S
 
 module Restorer = Restorer
 
+module type VAT_NETWORK = S.VAT_NETWORK with
+  type 'a capability := 'a Capability.t and
+  type restorer := Restorer.t and
+  type service_id := Restorer.Id.t and
+  type 'a sturdy_ref := 'a Sturdy_ref.t
+
 module Networking (N : S.NETWORK) (F : Mirage_flow_lwt.S) = struct
   type flow = F.flow
-  type 'a capability = 'a Capability.t
-  type restorer = Restorer.t
-  type service_id = Restorer.Id.t
-  class type [+'a] sturdy_ref = ['a] Sturdy_ref.t
 
   module Network = N
   module Vat = Vat.Make (N) (F)

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -362,13 +362,15 @@ module Restorer : sig
       You don't normally need to call this directly, as the Vat will do it automatically. *)
 end
 
-module Networking (N : S.NETWORK) (Flow : Mirage_flow_lwt.S) : S.VAT_NETWORK
-  with module Network = N and
-       type flow = Flow.flow and
-       type 'a capability = 'a Capability.t and
-       type restorer = Restorer.t and
-       type service_id = Restorer.Id.t and
-       type 'a sturdy_ref = 'a Sturdy_ref.t
+module type VAT_NETWORK = S.VAT_NETWORK with
+  type 'a capability := 'a Capability.t and
+  type restorer := Restorer.t and
+  type service_id := Restorer.Id.t and
+  type 'a sturdy_ref := 'a Sturdy_ref.t
+
+module Networking (N : S.NETWORK) (Flow : Mirage_flow_lwt.S) : VAT_NETWORK with
+  module Network = N and
+  type flow = Flow.flow
 
 module Capnp_address = Capnp_address
 

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+maintainer:   "Thomas Leonard <thomas.leonard@docker.com>"
+authors:      "Thomas Leonard <thomas.leonard@docker.com>"
+license:      "Apache"
+homepage:     "https://github.com/mirage/capnp-rpc"
+bug-reports:  "https://github.com/mirage/capnp-rpc/issues"
+dev-repo:     "https://github.com/mirage/capnp-rpc.git"
+
+build: ["jbuilder" "build" "-p" name "-j" jobs]
+build-test: ["jbuilder" "runtest" "-p" name]
+
+depends: [
+  "capnp-rpc-lwt" { >= "0.2" }
+  "astring"
+  "fmt"
+  "logs"
+  "mirage-dns"
+  "mirage-stack-lwt"
+  "alcotest-lwt" {test}
+  "io-page-unix" {test}
+  "tcpip" {test}
+  "mirage-vnetif" {test}
+  "jbuilder" {build & >= "1.0+beta10" }
+]
+available: [ocaml-version >= "4.03.0"]

--- a/mirage/capnp_rpc_mirage.ml
+++ b/mirage/capnp_rpc_mirage.ml
@@ -10,14 +10,9 @@ module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) = struct
   module Vat_network = Capnp_rpc_lwt.Networking(Network)(Stack.TCPV4)
 
   type flow = Stack.TCPV4.flow
-  type 'a capability = 'a Capnp_rpc_lwt.Capability.t
-  type restorer = Capnp_rpc_lwt.Restorer.t
 
   module CapTP = Vat_network.CapTP
   module Vat = Vat_network.Vat
-
-  type service_id = Capnp_rpc_lwt.Restorer.Id.t
-  type 'a sturdy_ref = 'a Capnp_rpc_lwt.Sturdy_ref.t
 
   let network ~dns stack = {Network.dns; stack}
 

--- a/mirage/capnp_rpc_mirage.ml
+++ b/mirage/capnp_rpc_mirage.ml
@@ -1,0 +1,57 @@
+open Lwt.Infix
+
+module Log = Capnp_rpc.Debug.Log
+
+module Location = Network.Location
+
+module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) = struct
+  module Network = Network.Make(Stack)(Dns)
+  module Vat_config = Vat_config.Make(Network)
+  module Vat_network = Capnp_rpc_lwt.Networking(Network)(Stack.TCPV4)
+
+  type flow = Stack.TCPV4.flow
+  type 'a capability = 'a Capnp_rpc_lwt.Capability.t
+  type restorer = Capnp_rpc_lwt.Restorer.t
+
+  module CapTP = Vat_network.CapTP
+  module Vat = Vat_network.Vat
+
+  type service_id = Capnp_rpc_lwt.Restorer.Id.t
+  type 'a sturdy_ref = 'a Capnp_rpc_lwt.Sturdy_ref.t
+
+  let network ~dns stack = {Network.dns; stack}
+
+  let handle_connection ?tags ~secret_key vat flow =
+    let switch = Lwt_switch.create () in
+    Network.accept_connection ~switch ~secret_key flow >>= function
+    | Error (`Msg msg) ->
+      Log.warn (fun f -> f ?tags "Rejecting new connection: %s" msg);
+      Lwt.return_unit
+    | Ok ep ->
+      Vat.add_connection vat ~switch ~mode:`Accept ep >|= fun (_ : CapTP.t) ->
+      ()
+
+  let serve ?switch ?tags ?restore t config =
+    let {Vat_config.secret_key = _; serve_tls; listen_address; public_address} = config in
+    let vat =
+      let auth = Vat_config.auth config in
+      let secret_key = lazy (fst (Lazy.force config.secret_key)) in
+      Vat.create ?switch ?tags ?restore ~address:(public_address, auth) ~secret_key t
+    in
+    match listen_address with
+    | `TCP port ->
+      Stack.listen_tcpv4 t.stack ~port (fun flow ->
+          Logs.info (fun f -> f ?tags "Accepting new connection");
+          let secret_key = if serve_tls then Some (Vat_config.secret_key config) else None in
+          Lwt.async (fun () -> handle_connection ?tags ~secret_key vat flow);
+          Lwt.return_unit
+        );
+      Logs.info (fun f -> f ?tags "Waiting for %s connections on %a"
+                    (if serve_tls then "(encrypted)" else "UNENCRYPTED")
+                    Vat_config.Listen_address.pp listen_address);
+      Lwt.return vat
+
+  let client_only_vat ?switch ?tags ?restore t =
+    let secret_key = lazy (Capnp_rpc_lwt.Auth.Secret_key.generate ()) in
+    Vat.create ?switch ?tags ?restore ~secret_key t
+end

--- a/mirage/capnp_rpc_mirage.mli
+++ b/mirage/capnp_rpc_mirage.mli
@@ -1,0 +1,76 @@
+(** Helpers for using {!Capnp_rpc_lwt} with MirageOS. *)
+
+open Capnp_rpc_lwt
+
+module Location = Network.Location
+
+module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) : sig
+  include Capnp_rpc_lwt.S.VAT_NETWORK with
+    type flow = Stack.TCPV4.flow and
+    type 'a capability = 'a Capability.t and
+    type restorer = Restorer.t and
+    type service_id = Restorer.Id.t and
+    type 'a sturdy_ref = 'a Sturdy_ref.t and
+    module Network = Network.Make(Stack)(Dns)
+
+  module Vat_config : sig
+    module Listen_address : sig
+      type t = [`TCP of int]
+      val pp : t Fmt.t
+    end
+
+    type t
+
+    val create :
+      public_address:Location.t ->
+      secret_key:[< `PEM of string | `Ephemeral] ->
+      ?serve_tls:bool ->
+      Listen_address.t -> t
+    (** [create ~public_address ~secret_key listen_address] is the configuration for a server vat that
+        listens on address [listen_address].
+        [secret_key] may be one of:
+        - [`PEM data]: the given PEM-encoded data is used as the key.
+        - [`Ephemeral]: a new key is generated (if needed) and not saved anywhere.
+        If [serve_tls] is [false] then the vat accepts unencrypted incoming connections.
+        If [true] (the default), the vat performs a server TLS handshake, using
+        [secret_key] to prove its identity to clients.
+        The vat will suggest that others connect to it at [public_address]. *)
+
+    val secret_key : t -> Auth.Secret_key.t
+    (** [secret_key t] returns the vat's secret yet, generating it if this is the first time
+        it has been used. *)
+
+    val hashed_secret : t -> string
+    (** [hashed_secret t] is the SHA256 digest of the secret key file.
+        This is useful as an input to {!Restorer.Id.derived}. *)
+
+    val derived_id : t -> string -> Restorer.Id.t
+    (** [derived_id t name] is a secret service ID derived from name and the
+        vat's secret key (using {!Restorer.Id.derived}). It won't change
+        (unless the vat's key changes). *)
+
+    val sturdy_uri : t -> Restorer.Id.t -> Uri.t
+    (** [sturdy_uri t id] is a sturdy URI for [id] at the vat that would be
+        created by [t]. *)
+  end
+
+  val network : dns:Dns.t -> Stack.t -> Network.t
+
+  val serve :
+    ?switch:Lwt_switch.t ->
+    ?tags:Logs.Tag.set ->
+    ?restore:Restorer.t ->
+    Network.t ->
+    Vat_config.t ->
+    Vat.t Lwt.t
+  (** [serve ~restore net vat_config] is a new vat that is listening for new connections
+      as specified by [vat_config]. After connecting to it, clients can get access
+      to services using [restore]. *)
+
+  val client_only_vat :
+    ?switch:Lwt_switch.t ->
+    ?tags:Logs.Tag.set ->
+    ?restore:Restorer.t ->
+    Network.t -> Vat.t
+  (** [client_only_vat net] is a new vat that does not listen for incoming connections. *)
+end

--- a/mirage/capnp_rpc_mirage.mli
+++ b/mirage/capnp_rpc_mirage.mli
@@ -5,12 +5,8 @@ open Capnp_rpc_lwt
 module Location = Network.Location
 
 module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) : sig
-  include Capnp_rpc_lwt.S.VAT_NETWORK with
+  include Capnp_rpc_lwt.VAT_NETWORK with
     type flow = Stack.TCPV4.flow and
-    type 'a capability = 'a Capability.t and
-    type restorer = Restorer.t and
-    type service_id = Restorer.Id.t and
-    type 'a sturdy_ref = 'a Sturdy_ref.t and
     module Network = Network.Make(Stack)(Dns)
 
   module Vat_config : sig

--- a/mirage/jbuild
+++ b/mirage/jbuild
@@ -1,0 +1,7 @@
+(jbuild_version 1)
+
+(library (
+  (name capnp_rpc_mirage)
+  (public_name capnp-rpc-mirage)
+  (libraries (capnp-rpc-lwt capnp-rpc fmt logs mirage-stack-lwt mirage-dns))
+))

--- a/mirage/network.ml
+++ b/mirage/network.ml
@@ -1,0 +1,86 @@
+open Lwt.Infix
+module Log = Capnp_rpc.Debug.Log
+
+let error fmt =
+  fmt |> Fmt.kstrf @@ fun msg ->
+  Error (`Msg msg)
+
+module Location = struct
+  type t = [
+    | `TCP of string * int
+  ]
+
+  let tcp ~host ~port = `TCP (host, port)
+
+  let pp f x = Capnp_rpc_lwt.Capnp_address.(Location.pp f (x :> Location.t))
+
+  let equal = ( = )
+end
+
+module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) = struct
+  module Tls_wrapper = Capnp_rpc_lwt.Tls_wrapper.Make(Stack.TCPV4)
+
+  module Address = struct
+    module Full = Capnp_rpc_lwt.Capnp_address
+
+    type t = Location.t * Capnp_rpc_lwt.Auth.Digest.t
+
+    let digest t = Full.digest (t :> Full.t)
+    let to_uri (t, id) = Full.to_uri ((t :> Full.t), id)
+    let pp f t = Full.pp f (t :> Full.t)
+
+    let parse_uri uri =
+      match Full.parse_uri uri with
+      | Error _ as e -> e
+      | Ok ((`TCP _, _), _ as x) -> Ok x
+      | Ok ((`Unix x, _), _) ->
+        error "Unix-domain addresses are not available with Mirage networking (%S)" x
+
+    let equal (addr, auth) (addr_b, auth_b) =
+      Location.equal addr addr_b &&
+      Capnp_rpc_lwt.Auth.Digest.equal auth auth_b
+  end
+
+  module Types = struct
+    type provision_id
+    type recipient_id
+    type third_party_cap_id = [`Two_party_only]
+    type join_key_part
+  end
+
+  let parse_third_party_cap_id _ = `Two_party_only
+
+  type t = {
+    stack : Stack.t;
+    dns : Dns.t;
+  }
+
+  let addr_of_host dns host =
+    Dns.gethostbyname dns host >|= function
+    | [] -> error "Unknown host %S" host
+    | addrs ->
+      let rec loop = function
+        | [] -> error "No IPv4 addresses found for %S" host
+        | Ipaddr.V4 x :: _ -> Ok x
+        | Ipaddr.V6 _ :: xs -> loop xs
+      in
+      loop addrs
+
+  let ( >>*= ) x f =
+    x >>= function
+    | Error _ as e -> Lwt.return e
+    | Ok y -> f y
+
+  let connect t ~switch ~secret_key (addr, auth) =
+    match addr with
+    | `TCP (host, port) ->
+      Logs.info (fun f -> f "Connecting to %s:%d..." host port);
+      addr_of_host t.dns host >>*= fun addr ->
+      let tcp = Stack.tcpv4 t.stack in
+      Stack.TCPV4.create_connection tcp (addr, port) >>= function
+      | Error e -> Lwt.return @@ error "Failed to connect to %S:%d: %a" host port Stack.TCPV4.pp_error e
+      | Ok flow -> Tls_wrapper.connect_as_client ~switch flow secret_key auth
+
+  let accept_connection ~switch ~secret_key flow =
+    Tls_wrapper.connect_as_server ~switch flow secret_key
+end

--- a/mirage/network.mli
+++ b/mirage/network.mli
@@ -1,0 +1,35 @@
+(** A capnp network build from a Mirage network stack. *)
+
+module Location : sig
+  type t = [
+    | `TCP of string * int
+  ]
+
+  val pp : t Fmt.t
+
+  val equal : t -> t -> bool
+
+  val tcp : host:string -> port:int -> t
+  (** [tcp ~host port] is [`TCP (host, port)]. *)
+end
+
+module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) : sig
+
+  type t = {
+    stack : Stack.t;
+    dns : Dns.t;
+  }
+
+  include Capnp_rpc_lwt.S.NETWORK with
+    type t := t and
+    type Address.t = Location.t * Capnp_rpc_lwt.Auth.Digest.t
+
+  val accept_connection :
+    switch:Lwt_switch.t ->
+    secret_key:Capnp_rpc_lwt.Auth.Secret_key.t option ->
+    Stack.TCPV4.flow ->
+    (Capnp_rpc_lwt.Endpoint.t, [> `Msg of string]) result Lwt.t
+  (** [accept_connection ~switch ~secret_key flow] is a new endpoint for [flow].
+      If [secret_key] is not [None], it is used to perform a TLS server-side handshake.
+      Otherwise, the connection is not encrypted. *)
+end

--- a/mirage/vat_config.ml
+++ b/mirage/vat_config.ml
@@ -1,0 +1,57 @@
+module Auth = Capnp_rpc_lwt.Auth
+module Log = Capnp_rpc.Debug.Log
+
+module Secret_hash : sig
+  type t
+
+  val of_pem_data : string -> t
+  val to_string : t -> string
+end = struct
+  type t = string
+
+  let of_pem_data data = Nocrypto.Hash.SHA256.digest (Cstruct.of_string data) |> Cstruct.to_string
+  let to_string x = x
+end
+
+module Make (N : Capnp_rpc_lwt.S.NETWORK with type Address.t = Network.Location.t * Auth.Digest.t) = struct
+  module Listen_address = struct
+    type t = [`TCP of int]
+
+    let pp f (`TCP port) =
+      Fmt.pf f "tcp:%d" port
+  end
+
+  type t = {
+    secret_key : (Auth.Secret_key.t * Secret_hash.t) Lazy.t;
+    serve_tls : bool;
+    listen_address : Listen_address.t;
+    public_address : Network.Location.t;
+  }
+
+  let secret_key t = fst @@ Lazy.force t.secret_key
+
+  let hashed_secret t = Secret_hash.to_string @@ snd @@ Lazy.force t.secret_key
+
+  let create ~public_address ~secret_key ?(serve_tls=true) listen_address =
+    let secret_key = lazy (
+      match secret_key with
+      | `PEM data -> (Auth.Secret_key.of_pem_data data, Secret_hash.of_pem_data data)
+      | `Ephemeral ->
+        let key = Auth.Secret_key.generate () in
+        let data = Auth.Secret_key.to_pem_data key in
+        (key, Secret_hash.of_pem_data data)
+    ) in
+    { secret_key; serve_tls; listen_address; public_address }
+
+  let derived_id t name =
+    let secret = hashed_secret t in
+    Capnp_rpc_lwt.Restorer.Id.derived ~secret name
+
+  let auth t =
+    if t.serve_tls then Capnp_rpc_lwt.Auth.Secret_key.digest (secret_key t)
+    else Capnp_rpc_lwt.Auth.Digest.insecure
+
+  let sturdy_uri t service =
+    let address = (t.public_address, auth t) in
+    N.Address.to_uri (address, Capnp_rpc_lwt.Restorer.Id.to_string service)
+end

--- a/test-mirage/jbuild
+++ b/test-mirage/jbuild
@@ -1,0 +1,15 @@
+(jbuild_version 1)
+
+(executable (
+  (name test)
+  (libraries (io-page-unix capnp-rpc-lwt capnp-rpc-mirage alcotest-lwt examples
+	      logs.fmt testbed tcpip.ipv4 tcpip.stack-direct mirage-vnetif
+	      tcpip.ethif tcpip.arpv4 tcpip.tcp tcpip.icmpv4))
+))
+
+(alias
+  ((name runtest)
+   (package capnp-rpc-mirage)
+   (deps (test.bc))
+   (action (run ${<})))
+)

--- a/test-mirage/test.ml
+++ b/test-mirage/test.ml
@@ -1,0 +1,146 @@
+open Lwt.Infix
+open Capnp_rpc_lwt
+open Examples
+
+module Time = struct
+  type 'a io = 'a Lwt.t
+  let sleep_ns ns = Lwt_unix.sleep (Duration.to_f ns)
+
+  type t = unit
+
+  let period_ns () = None
+  let elapsed_ns () = 0L
+  let disconnect () = Lwt.return_unit
+end
+
+module Random = struct
+  type g = unit
+  type buffer = Cstruct.t
+
+  let generate ?g n = ignore g; Cstruct.create n
+end
+
+module Stack = struct
+  module B = Basic_backend.Make
+  module V = Vnetif.Make(B)
+  module E = Ethif.Make(V)
+  module A = Arpv4.Make(E)(Time)(Time)
+  module I = Static_ipv4.Make(E)(A)
+  module U = Udp.Make(I)(Random)
+  module T = Tcp.Flow.Make(I)(Time)(Time)(Random)
+  module Icmp = Icmpv4.Make(I)
+  include Tcpip_stack_direct.Make(Time)(Random)(V)(E)(A)(I)(Icmp)(U)(T)
+
+  let create_network () = B.create ~use_async_readers:true ~yield:Lwt_unix.yield ()
+
+  let create_interface backend ip =
+    V.connect backend >>= fun v ->
+    E.connect v >>= fun e ->
+    A.connect e () >>= fun a ->
+    I.connect ~ip ~network:Ipaddr.V4.Prefix.private_10 e a >>= fun i ->
+    U.connect i >>= fun u ->
+    T.connect i () >>= fun t ->
+    Icmp.connect i >>= fun icmp ->
+    let config = { Mirage_stack_lwt.name = "test-stack"; interface = v } in
+    connect config e a i icmp u t
+end
+module Mirage = Capnp_rpc_mirage.Make(Stack)(Dns_resolver_mirage.Static)
+module Vat = Mirage.Vat
+
+type cs = {
+  client : Vat.t;
+  server : Vat.t;
+  client_key : Auth.Secret_key.t;
+  server_key : Auth.Secret_key.t;
+  serve_tls : bool;
+  server_switch : Lwt_switch.t;
+}
+
+(* Have the client ask the server for its bootstrap object, and return the
+   resulting client-side proxy to it. *)
+let get_bootstrap cs =
+  let id = Restorer.Id.public "" in
+  let sr = Vat.sturdy_uri cs.server id |> Vat.import_exn cs.client in
+  Sturdy_ref.connect_exn sr
+
+let dns =
+  let names = Hashtbl.create 7 in
+  let rev = Hashtbl.create 7 in
+  let add name ip =
+    Hashtbl.add names name (Ipaddr.of_string_exn ip);
+    Hashtbl.add rev (Ipaddr.V4.of_string_exn ip) name
+  in
+  add "server" "10.0.0.1";
+  add "client" "10.0.0.2";
+  let dns_entries = {Dns_resolver_mirage.names; rev} in
+  Dns_resolver_mirage.Static.create dns_entries
+
+let create_iface network ip =
+  Stack.create_interface network (Ipaddr.V4.of_string_exn ip) >|= fun stack ->
+  Mirage.network ~dns stack
+
+let () = Nocrypto_entropy_unix.initialize ()
+let server_key = Auth.Secret_key.generate ()
+let client_key = Auth.Secret_key.generate ()
+
+let server_pem = `PEM (Auth.Secret_key.to_pem_data server_key)
+
+let make_vats ?(serve_tls=false) ~switch ~service () =
+  let id = Restorer.Id.public "" in
+  let restore = Restorer.single id service in
+  let server_config =
+    Mirage.Vat_config.create ~secret_key:server_pem ~serve_tls ~public_address:(`TCP ("server", 7000)) (`TCP 7000)
+  in
+  let net = Stack.create_network () in
+  create_iface net "10.0.0.1" >>= fun server_net ->
+  create_iface net "10.0.0.2" >>= fun client_net ->
+  let server_switch = Lwt_switch.create () in
+  Mirage.serve ~switch:server_switch ~tags:Testbed.Test_utils.server_tags ~restore server_net server_config >>= fun server ->
+  Lwt_switch.add_hook (Some switch) (fun () -> Lwt_switch.turn_off server_switch);
+  Lwt_switch.add_hook (Some switch) (fun () -> Capability.dec_ref service; Lwt.return_unit);
+  Lwt.return {
+    client = Vat.create ~switch ~tags:Testbed.Test_utils.client_tags ~secret_key:(lazy client_key) client_net;
+    server;
+    client_key;
+    server_key;
+    serve_tls;
+    server_switch;
+  }
+
+(* Generic Lwt running for Alcotest. *)
+let run_lwt name ?(expected_warnings=0) fn =
+  Alcotest_lwt.test_case name `Quick @@ fun sw () ->
+  let warnings_at_start = Logs.(err_count () + warn_count ()) in
+  Logs.info (fun f -> f "Start test-case");
+  let finished = ref false in
+  Lwt_switch.add_hook (Some sw) (fun () ->
+      if not !finished then !Lwt.async_exception_hook (Failure "Switch turned off early");
+      Lwt.return_unit
+    );
+  fn sw >>= fun () -> finished := true;
+  Lwt_switch.turn_off sw >|= fun () ->
+  Gc.full_major ();
+  Lwt.wakeup_paused ();
+  Gc.full_major ();
+  Lwt.wakeup_paused ();
+  Gc.full_major ();
+  let warnings_at_end = Logs.(err_count () + warn_count ()) in
+  Alcotest.(check int) "Check log for warnings" expected_warnings (warnings_at_end - warnings_at_start)
+
+let test_simple switch ~serve_tls =
+  make_vats ~switch ~serve_tls ~service:(Echo.local ()) () >>= fun cs ->
+  get_bootstrap cs >>= fun service ->
+  Echo.ping service "ping" >>= fun reply ->
+  Alcotest.(check string) "Ping response" "got:0:ping" reply;
+  Capability.dec_ref service;
+  Lwt.return ()
+
+let rpc_tests = [
+  run_lwt "Simple" (test_simple ~serve_tls:false);
+  run_lwt "TLS"    (test_simple ~serve_tls:true);
+]
+
+let () =
+  Alcotest.run ~and_exit:false "capnp-rpc" [
+    "mirage", rpc_tests;
+  ]

--- a/test-mirage/test.mli
+++ b/test-mirage/test.mli
@@ -1,0 +1,1 @@
+(* (no public API) *)

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -7,17 +7,12 @@ module Unix_flow = Unix_flow
 let () = Nocrypto_entropy_unix.initialize ()
 
 type flow = Unix_flow.flow
-type 'a capability = 'a Capnp_rpc_lwt.Capability.t
-type restorer = Capnp_rpc_lwt.Restorer.t
 
 module CapTP = Vat_network.CapTP
 module Vat = Vat_network.Vat
 module Network = Network
 module Vat_config = Vat_config
 module File_store = File_store
-
-type service_id = Capnp_rpc_lwt.Restorer.Id.t
-type 'a sturdy_ref = 'a Capnp_rpc_lwt.Sturdy_ref.t
 
 let error fmt =
   fmt |> Fmt.kstrf @@ fun msg ->

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -4,12 +4,8 @@ open Capnp_rpc_lwt
 
 module Unix_flow = Unix_flow
 
-include Capnp_rpc_lwt.S.VAT_NETWORK with
+include Capnp_rpc_lwt.VAT_NETWORK with
   type flow = Unix_flow.flow and
-  type 'a capability = 'a Capability.t and
-  type restorer = Restorer.t and
-  type service_id = Restorer.Id.t and
-  type 'a sturdy_ref = 'a Sturdy_ref.t and
   module Network = Network
 
 module Vat_config : sig


### PR DESCRIPTION
The new `capnp-rpc-mirage` package provides an alternative to the `-unix` one, for use in Mirage unikernels.

Note: this won't work on Xen, as `capnp` currently still depends on `Core_kernel`.