### PR TITLE
Make capnp-rpc-mirage depend on capnp >= 3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam@sha256:683543a56e30160a82778f1d2e795f23579a71e5b5554a4d36b2b44421629cdd
 #FROM ocaml/opam:debian-9_ocaml-4.05.0
-RUN cd opam-repository && git fetch && git reset --hard 5076ad3874e50af8cc47a4fb5c49b3f590010b76 && opam update
+RUN cd opam-repository && git fetch && git reset --hard d5ce018037a55826950c426b8d915ed7b17134a0 && opam update
 ADD *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
 RUN opam pin add -ny capnp-rpc.dev . && \

--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,20 @@ Note that calling `wait_forever` prevents further use of the session, however.
 
 ### How can I use this with Mirage?
 
+`capnp` uses the `uint` library, which has C stubs and does not work on most Mirage backends.
+As a quick hack, you can do:
+
+```
+opam pin add uint 'https://github.com/talex5/ocaml-uint.git#dummy'
+```
+
+This allows it to compile and run as a unikernel, by defining `type Uint64.t = Int64.t`, etc.
+However, this changes the behaviour of unsigned integers, so you should be careful with it.
+In particular, OCaml's built-in polymorphic comparison operators (`>`, etc) may give incorrect
+results.
+Ideally, someone would add proper Mirage support to the `uint` library.
+<https://github.com/ocaml/ocaml/pull/1201#issuecomment-333941042> explains why OCaml doesn't have unsigned integer support.
+
 Here is a suitable `config.ml`:
 
 ```ocaml
@@ -1102,9 +1116,6 @@ module Make (Time : Mirage_time_lwt.S) (Stack : Mirage_stack_lwt.V4) = struct
     Lwt.wait () |> fst
 end
 ```
-
-Note that only `mirage configure -t unix` works currently.
-This is because the `capnp` runtime library currently depends on `Unix` and `Core_kernel`.
 
 ## Contributing
 

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -10,6 +10,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
+  "capnp" { >= "3.1.0" }
   "capnp-rpc-lwt" { >= "0.2" }
   "astring"
   "fmt"


### PR DESCRIPTION
This allows it to work with other mirage targets (e.g. Xen).