### PR TITLE
Make derived_id's name argument non-optional

### DIFF
--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -39,10 +39,10 @@ module Vat_config : sig
   (** [hashed_secret t] is the SHA256 digest of the secret key file.
       This is useful as an input to {!Restorer.Id.derived}. *)
 
-  val derived_id : ?name:string -> t -> Restorer.Id.t
-  (** [derived_id t] is a secret service ID derived from the vat's secret key
-      (using {!Restorer.Id.derived}). It won't change (unless the vat's key
-      changes). [name] defaults to ["main"]. *)
+  val derived_id : t -> string -> Restorer.Id.t
+  (** [derived_id t name] is a secret service ID derived from name and the
+      vat's secret key (using {!Restorer.Id.derived}). It won't change
+      (unless the vat's key changes). *)
 
   val sturdy_uri : t -> Restorer.Id.t -> Uri.t
   (** [sturdy_uri t id] is a sturdy URI for [id] at the vat that would be

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -111,7 +111,7 @@ let secret_key_term =
   in
   Cmdliner.Term.(pure get $ secret_key_file)
 
-let derived_id ?(name="main") t =
+let derived_id t name =
   let secret = hashed_secret t in
   Capnp_rpc_lwt.Restorer.Id.derived ~secret name
 


### PR DESCRIPTION
This is a bit clearer, and makes the Unix API match the Mirage one.