### PR TITLE
[Tracking] Detect race resolving a promise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ clean:
 test:
 	rm -rf _build/_tests
 	jbuilder build --dev test/test.bc test-lwt/test.bc test-bin/calc.bc test-mirage/test.bc
-	#./_build/default/test/test.bc test core -ev 36
+	#./_build/default/test/test.bc test core -ev 12
 	#./_build/default/test-lwt/test.bc test lwt -ev 3
 	jbuilder build @runtest --dev --no-buffer -j 1

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -218,7 +218,12 @@ module Make (C : S.CORE_TYPES) = struct
         ~unresolved:(fun _ ->
             match blocker with
             | None -> Some (self :> base_ref)
-            | Some x -> x#blocker
+            | Some x ->
+              match x#blocker with
+              | Some _ as b -> b
+              | None -> 
+                Debug.invariant_broken @@ fun f ->
+                Fmt.pf f "Proxy %t is blocked on non-blocked cap %t!" self#pp x#pp
           )
         ~forwarding:(fun x -> x#blocker)
 


### PR DESCRIPTION
We sometimes don't unset the blocker flag quickly enough, and perform other processing first. This can make us briefly think that a promise is resolved when it isn't. The new test shows a case where this matters: we incorrectly export a capability as `SenderHosted` (settled) before the status gets updated. When we later try to resolve the promise, the remote side complains.

Add an assert to detect and report the problem earlier. This also triggers on existing test cases.

This PR only detects the bug; it does not fix it.

Bug found by AFL.