### PR TITLE
Add build dependency on conf-capnproto

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ See [LICENSE.md](LICENSE.md) for details.
 ## Contents
 
 <!-- vim-markdown-toc GFM -->
-
 * [Overview](#overview)
 * [Status](#status)
 * [Installing](#installing)
@@ -80,7 +79,7 @@ Until that is implemented, Carol can ask Bob for a persistent reference (sturdy 
 
 To install, you will need a platform with the capnproto package available (e.g. Debian >= 9). Then:
 
-    opam depext -i capnp-rpc-unix
+    opam depext -i capnp-rpc-unix conf-capnproto
 
 ## Structure of the library
 
@@ -253,7 +252,7 @@ If you're building with jbuilder, here's a suitable `jbuild` file:
 The service is now usable:
 
 ```bash
-$ opam install capnp-rpc-unix
+$ opam install capnp-rpc-unix conf-capnproto
 $ jbuilder build --dev main.exe
 $ ./_build/default/main.exe
 Got reply "echo:foo"

--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -10,6 +10,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 build-test: ["jbuilder" "runtest" "-p" name]
 
 depends: [
+  "conf-capnproto" {build}
   "capnp" { >= "3.0.0" }
   "capnp-rpc" { >= "0.2" }
   "lwt"


### PR DESCRIPTION
The next capnp release will not pull this in automatically.