### PR TITLE
Prepare 0.3.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+### v0.3.2
+
+- Update for various upstream API changes, switch to the opam 2 metadata
+  format, and convert from jbuilder to dune (@talex5, #152).
+
+- Adjust to mirage-stack / mirage-protocols changes (Nick Betteridge, #151).
+  * adjust to mirage-stack / mirage-protocols changes
+  * update mirage/network for upgraded Ipaddr
+  * update Dockerfile to use opam2, apt-get update, and newer opam-repository
+
+- Update dependencies from opam-repository (@talex5, #148).
+
+
 ### 0.3.1
 
 - Updates for new `x509` API and for OCaml 4.06 (#143).

--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -1,11 +1,15 @@
 opam-version: "2.0"
 synopsis:
   "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
 maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
 authors: "Thomas Leonard <thomas.leonard@docker.com>"
 license: "Apache"
 homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -1,11 +1,14 @@
 opam-version: "2.0"
 synopsis:
   "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
 maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
 authors: "Thomas Leonard <thomas.leonard@docker.com>"
 license: "Apache"
 homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp" {>= "3.1.0"}

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -1,11 +1,14 @@
 opam-version: "2.0"
 synopsis:
   "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
 maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
 authors: "Thomas Leonard <thomas.leonard@docker.com>"
 license: "Apache"
 homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp-rpc-lwt" {>= "0.3"}

--- a/capnp-rpc.opam
+++ b/capnp-rpc.opam
@@ -1,11 +1,16 @@
 opam-version: "2.0"
 synopsis:
   "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
 maintainer: "Thomas Leonard <thomas.leonard@docker.com>"
 authors: "Thomas Leonard <thomas.leonard@docker.com>"
 license: "Apache"
 homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "uint"


### PR DESCRIPTION
- Support dune-release:
  - Import opam descriptions from opam-repository.
  - Add `doc` fields to opam files.
- Update changelog.