### PR TITLE
Update Dockerfile to build using the new capnp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,10 @@
   format, and convert from jbuilder to dune (@talex5, #152).
 
 - Adjust to mirage-stack / mirage-protocols changes (Nick Betteridge, #151).
-  * adjust to mirage-stack / mirage-protocols changes
   * update mirage/network for upgraded Ipaddr
   * update Dockerfile to use opam2, apt-get update, and newer opam-repository
 
 - Update dependencies from opam-repository (@talex5, #148).
-
 
 ### 0.3.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ocaml/opam2@sha256:d76c296ff72d775c47b089555eca67b2a1d737498e4e5fdb8b73b6ba0630a1a4
 #FROM ocaml/opam2:debian-9-ocaml-4.07
 RUN sudo apt-get update
-RUN git fetch && git reset --hard fdea4dff37bc45a45472473b6fac82ac7989b997 && opam update
+RUN git fetch && git reset --hard 15fe01bbd69385c8103e22a60f1087d21068cc16 && opam update
 RUN opam depext -i capnp afl-persistent conf-capnproto tls mirage-flow-lwt mirage-kv-lwt mirage-clock ptime cmdliner mirage-dns
 ADD --chown=opam *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/


### PR DESCRIPTION
This is faster, as it avoids the `Core_kernel` dependency.