### PR TITLE
Require base64 >= 3.0.0 for capnp-rpc-mirage too

### DIFF
--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -19,6 +19,7 @@ depends: [
   "arp-mirage"
   "mirage-dns"
   "mirage-stack-lwt"
+  "base64" {>= "3.0.0"}
   "alcotest-lwt" {with-test}
   "io-page-unix" {with-test}
   "tcpip" {with-test}


### PR DESCRIPTION
We can't rely on capnp-rpc-lwt to choose the right version because we might get a different version of that.