### PR TITLE
Update uint.uint32 to uint

### DIFF
--- a/capnp-rpc/dune
+++ b/capnp-rpc/dune
@@ -1,4 +1,4 @@
 (library
  (name capnp_rpc)
  (public_name capnp-rpc)
- (libraries astring fmt logs uint.uint32 asetmap))
+ (libraries astring fmt logs uint asetmap))


### PR DESCRIPTION
`uint.uint32` has been [deprecated](https://github.com/andrenth/ocaml-uint/commit/2a7e248e1131724e0807b8f265e179342ff132dd) in place of just `uint` as a library. This pull request updates this dune file to reflect this.

