### PR TITLE
Prefix all options with capnp

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ based on command-line arguments provided by the user.
 To test, start the server running:
 
 ```
-$ ./_build/default/main.exe serve --secret-key-file=key.pem --listen-address tcp:127.0.0.1:7000
+$ ./_build/default/main.exe serve --capnp-secret-key-file=key.pem --capnp-listen-address tcp:127.0.0.1:7000
 echo service running at: capnp://sha-256:_FNMlR9cf1maixDAM6Y1pwwZ-aikqa_DP8P7RCVr1k4@127.0.0.1:7000/JL_hRxzrTSbLNcb0Tqp2f0N_sh5znvY2ym9KMVzLtcQ
 ```
 
@@ -1251,8 +1251,8 @@ Start the server with:
 
 ```
 $ ./_build/default/test-bin/calc.bc serve \
-    --listen-address unix:/tmp/calc.socket \
-    --secret-key-file=key.pem
+    --capnp-listen-address unix:/tmp/calc.socket \
+    --capnp-secret-key-file=key.pem
 Waiting for incoming connections at:
 capnp://sha-256:LPp-7l74zqvGcRgcP8b7-kdSpwwzxlA555lYC8W8prc@/tmp/calc.socket
 ```
@@ -1265,7 +1265,7 @@ In another terminal, run the client and connect to the address displayed by the 
 ./_build/default/test-bin/calc.bc connect capnp://sha-256:LPp-7l74zqvGcRgcP8b7-kdSpwwzxlA555lYC8W8prc@/tmp/calc.socket
 ```
 
-You can also use `--disable-tls` if you prefer to run without encryption
+You can also use `--capnp-disable-tls` if you prefer to run without encryption
 (e.g. for interoperability with another Cap'n Proto implementation that doesn't support TLS).
 In that case, the client URL would be `capnp://insecure@/tmp/calc.socket`.
 

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -275,7 +275,7 @@ let config_result = cmd_result vat_config
 let test_options () =
   let term = (Capnp_rpc_unix.Vat_config.cmd, Cmdliner.Term.info "main") in
   let config = Cmdliner.Term.eval
-      ~argv:[| "main"; "--secret-key-file=key.pem"; "--listen-address"; "unix:/run/socket" |] term in
+      ~argv:[| "main"; "--capnp-secret-key-file=key.pem"; "--capnp-listen-address"; "unix:/run/socket" |] term in
   let expected = `Ok (Capnp_rpc_unix.Vat_config.create
                         ~secret_key:(`File "key.pem")
                         (`Unix "/run/socket")
@@ -287,9 +287,9 @@ let test_options () =
                        (`TCP ("0.0.0.0", 7000))
                      ) in
   Cmdliner.Term.eval ~argv:[| "main";
-                              "--secret-key-file=key.pem";
-                              "--public-address"; "tcp:1.2.3.4:7001";
-                              "--listen-address"; "tcp:0.0.0.0:7000" |] term
+                              "--capnp-secret-key-file=key.pem";
+                              "--capnp-public-address"; "tcp:1.2.3.4:7001";
+                              "--capnp-listen-address"; "tcp:0.0.0.0:7000" |] term
   |> Alcotest.check config_result "Using TCP" expected
 
 let expect_ok = function

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -115,3 +115,5 @@ let serve ?switch ?tags ?restore config =
 let client_only_vat ?switch ?tags ?restore () =
   let secret_key = lazy (Capnp_rpc_lwt.Auth.Secret_key.generate ()) in
   Vat.create ?switch ?tags ?restore ~secret_key ()
+
+let manpage_capnp_options = Vat_config.docs

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -98,3 +98,7 @@ val client_only_vat :
   ?restore:Restorer.t ->
   unit -> Vat.t
 (** [client_only_vat ()] is a new vat that does not listen for incoming connections. *)
+
+val manpage_capnp_options : string
+(** [manpage_capnp_options] is the title of the section of the man-page containing the Cap'n Proto options.
+    This can be used to control where these options appear in the page (e.g. to put them below the other options). *)

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -1,5 +1,7 @@
 open Astring
 
+let docs = "CAP'N PROTO OPTIONS"
+
 module Auth = Capnp_rpc_lwt.Auth
 module Log = Capnp_rpc.Debug.Log
 
@@ -27,7 +29,7 @@ module Listen_address = struct
   let addr_conv = Arg.conv (of_string, pp)
 
   let cmd =
-    let i = Arg.info ["listen-address"] ~docv:"ADDR" ~doc:"Address to listen on, e.g. $(b,unix:/run/my.socket)." in
+    let i = Arg.info ~docs ["listen-address"] ~docv:"ADDR" ~doc:"Address to listen on, e.g. $(b,unix:/run/my.socket)." in
     Arg.(required @@ opt (some addr_conv) None i)
 end
 
@@ -57,7 +59,7 @@ let hashed_secret t = Secret_hash.to_string @@ snd @@ Lazy.force t.secret_key
 
 let secret_key_file =
   let open Cmdliner in
-  let i = Arg.info ["secret-key-file"] ~docv:"PATH"
+  let i = Arg.info ~docs ["secret-key-file"] ~docv:"PATH"
       ~doc:"File in which to store secret key (or \"\" for an ephemeral key)." in
   Arg.(required @@ opt (some string) None i)
 
@@ -141,11 +143,11 @@ let equal {backlog; secret_key; serve_tls; listen_address; public_address} b =
   Auth.Secret_key.equal (fst @@ Lazy.force secret_key) (fst @@ Lazy.force b.secret_key)
 
 let public_address =
-  let i = Arg.info ["public-address"] ~docv:"ADDR" ~doc:"Address to tell others to connect on." in
+  let i = Arg.info ~docs ["public-address"] ~docv:"ADDR" ~doc:"Address to tell others to connect on." in
   Arg.(value @@ opt (some Listen_address.addr_conv) None i)
 
 let disable_tls =
-  let i = Arg.info ["disable-tls"] ~doc:"Do not use TLS for incoming connections." in
+  let i = Arg.info ~docs ["disable-tls"] ~doc:"Do not use TLS for incoming connections." in
   Arg.(value @@ flag i)
 
 let cmd =

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -29,7 +29,7 @@ module Listen_address = struct
   let addr_conv = Arg.conv (of_string, pp)
 
   let cmd =
-    let i = Arg.info ~docs ["listen-address"] ~docv:"ADDR" ~doc:"Address to listen on, e.g. $(b,unix:/run/my.socket)." in
+    let i = Arg.info ~docs ["capnp-listen-address"] ~docv:"ADDR" ~doc:"Address to listen on, e.g. $(b,unix:/run/my.socket)." in
     Arg.(required @@ opt (some addr_conv) None i)
 end
 
@@ -59,7 +59,7 @@ let hashed_secret t = Secret_hash.to_string @@ snd @@ Lazy.force t.secret_key
 
 let secret_key_file =
   let open Cmdliner in
-  let i = Arg.info ~docs ["secret-key-file"] ~docv:"PATH"
+  let i = Arg.info ~docs ["capnp-secret-key-file"] ~docv:"PATH"
       ~doc:"File in which to store secret key (or \"\" for an ephemeral key)." in
   Arg.(required @@ opt (some string) None i)
 
@@ -143,11 +143,11 @@ let equal {backlog; secret_key; serve_tls; listen_address; public_address} b =
   Auth.Secret_key.equal (fst @@ Lazy.force secret_key) (fst @@ Lazy.force b.secret_key)
 
 let public_address =
-  let i = Arg.info ~docs ["public-address"] ~docv:"ADDR" ~doc:"Address to tell others to connect on." in
+  let i = Arg.info ~docs ["capnp-public-address"] ~docv:"ADDR" ~doc:"Address to tell others to connect on." in
   Arg.(value @@ opt (some Listen_address.addr_conv) None i)
 
 let disable_tls =
-  let i = Arg.info ~docs ["disable-tls"] ~doc:"Do not use TLS for incoming connections." in
+  let i = Arg.info ~docs ["capnp-disable-tls"] ~doc:"Do not use TLS for incoming connections." in
   Arg.(value @@ flag i)
 
 let cmd =


### PR DESCRIPTION
Otherwise, they can easily conflict with other options (e.g. a web-server's listen address). Also, put our cmdliner options in their own section of the man-page.