### PR TITLE
Add some convenience functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Here's a suitable `dune` file to compile the schema file and then the generated 
 (rule
  (targets echo_api.ml echo_api.mli)
  (deps    echo_api.capnp)
- (action (run capnpc -o ocaml %{deps})))
+ (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
 ```
 
 The service is now usable:

--- a/capnp-rpc-lwt/dune
+++ b/capnp-rpc-lwt/dune
@@ -8,14 +8,10 @@
 
 (rule
  (targets rpc_schema.ml rpc_schema.mli)
- (deps
-  (:< rpc_schema.capnp))
- (action
-  (run capnpc -o ocaml %{<})))
+ (deps rpc_schema.capnp)
+ (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
 
 (rule
  (targets persistent.ml persistent.mli)
- (deps
-  (:< persistent.capnp))
- (action
-  (run capnpc -o ocaml %{<})))
+ (deps persistent.capnp)
+ (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))

--- a/capnp-rpc-lwt/s.ml
+++ b/capnp-rpc-lwt/s.ml
@@ -131,7 +131,7 @@ module type VAT_NETWORK = sig
     val sturdy_uri : t -> service_id -> Uri.t
     (** [sturdy_uri t id] is [sturdy_ref t id |> export t]. *)
 
-    val import : t -> Uri.t -> ('a sturdy_ref, [`Msg of string]) result
+    val import : t -> Uri.t -> ('a sturdy_ref, [> `Msg of string]) result
     (** [import t uri] parses [uri] as a "capnp://" URI. *)
 
     val import_exn : t -> Uri.t -> 'a sturdy_ref

--- a/examples/dune
+++ b/examples/dune
@@ -5,14 +5,10 @@
 
 (rule
  (targets test_api.ml test_api.mli)
- (deps
-  (:< test_api.capnp))
- (action
-  (run capnpc -o ocaml %{<})))
+ (deps test_api.capnp)
+ (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
 
 (rule
  (targets calculator.ml calculator.mli)
- (deps
-  (:< calculator.capnp))
- (action
-  (run capnpc -o ocaml %{<})))
+ (deps calculator.capnp)
+ (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))

--- a/unix/capnp_rpc_unix.mli
+++ b/unix/capnp_rpc_unix.mli
@@ -79,6 +79,18 @@ module File_store : sig
   (** [remove t ~digest] removes the stored data for [digest]. *)
 end
 
+module Cap_file : sig
+  val load : Vat.t -> string -> (_ Sturdy_ref.t, [> `Msg of string]) result
+  (** [load vat path] loads the contents of [path] as a capability URI. *)
+
+  val save_sturdy : Vat.t -> _ Sturdy_ref.t -> string -> (unit, [> `Msg of string]) result
+  (** [save_sturdy vat sr path] saves [sr] to [path], with a mode of [0o600]. *)
+
+  val save_service : Vat.t -> Capnp_rpc_lwt.Restorer.Id.t -> string ->
+    (unit, [> `Msg of string]) result
+  (** [save_service vat id path] saves [vat/id] to [path], with a mode of [0o600]. *)
+end
+
 val sturdy_uri : Uri.t Cmdliner.Arg.conv
 (** A cmdliner argument converter for a "capnp://" URI (or the path of a file containing such a URI). *)
 

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -18,6 +18,10 @@ module Location : sig
 
   val tcp : host:string -> port:int -> t
   (** [tcp ~host port] is [`TCP (host, port)]. *)
+
+  val of_string : string -> (t, [> `Msg of string]) result
+
+  val cmdliner_conv : t Cmdliner.Arg.conv
 end
 
 include Capnp_rpc_lwt.S.NETWORK with


### PR DESCRIPTION
- Add Unix Cap_file module to load and save `Sturdy_refs`. In particular, this ensures that saved cap files get a mode of `0o600`, since they contain secrets.
- Export cmdliner network address parsing. This is useful if you don't want to use the default option parsing. For example, if you want to make Cap'n Proto an optional feature of your program.
- Update README's dune file to allow duniverse / vendored builds.