### PR TITLE
Enable SO_KEEPALIVE for TCP connections

### DIFF
--- a/unix/network.ml
+++ b/unix/network.ml
@@ -75,6 +75,7 @@ let connect_socket = function
   | `TCP (host, port) ->
     Logs.info (fun f -> f "Connecting to %s:%d..." host port);
     let socket = Unix.(socket PF_INET SOCK_STREAM 0) in
+    Unix.setsockopt socket Unix.SO_KEEPALIVE true;
     Unix.connect socket (Unix.ADDR_INET (addr_of_host host, port));
     socket
 


### PR DESCRIPTION
Cap'n Proto connections are often long-lived, but some networking systems (particularly Docker's libnetwork) silently drop idle connections after a while.

For use with Docker's libnetwork, try something like this in your `stack.yml`:

    sysctls:
      - 'net.ipv4.tcp_keepalive_time=60'