### PR TITLE
Depend on new capnp for stdint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocurrent/opam@sha256:4d2dc158efda4a5920440e007638ff08dc2ad8c3af1d0a9ed777924ce6db94fa
 #FROM ocurrent/opam:alpine-3.10-ocaml-4.08
-RUN cd ~/opam-repository && git fetch && git reset --hard 69f81992a5b3ca023f34da67e68c8054d18c7776 && opam update
+RUN cd ~/opam-repository && git fetch && git reset --hard f412620d14e52a588975517bf940aea115523f44 && opam update
 RUN opam depext -i capnp afl-persistent conf-capnproto tls mirage-flow-lwt mirage-kv-lwt mirage-clock ptime cmdliner mirage-dns
 ADD --chown=opam *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/

--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -13,7 +13,7 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.0.0"}
+  "capnp" {>= "3.4.0"}
   "capnp-rpc" {>= "0.3"}
   "lwt"
   "astring"


### PR DESCRIPTION
We rely on the generated bindings using stdint (or a new enough version of uint), so ensure this by depending on the latest capnp.