### PR TITLE
Wrap errors with Capnp tag

### DIFF
--- a/capnp-rpc-lwt/capability.ml
+++ b/capnp-rpc-lwt/capability.ml
@@ -64,7 +64,7 @@ let call_and_wait cap (m : ('t, 'a, 'b StructStorage.reader_t) method_t) req =
   let finish = lazy (Core_types.dec_ref result) in
   Lwt.on_cancel p (fun () -> Lazy.force finish);
   result#when_resolved (function
-      | Error _ as e -> Lwt.wakeup r e
+      | Error e -> Lwt.wakeup r (Error (`Capnp e))
       | Ok resp ->
         Lazy.force finish;
         let payload = Msg.Response.readable resp in
@@ -84,7 +84,7 @@ let call_for_value cap m req =
 let call_for_value_exn cap m req =
   call_for_value cap m req >>= function
   | Ok x -> Lwt.return x
-  | Error e ->
+  | Error (`Capnp e) ->
     let msg = Fmt.strf "Error calling %t(%a): %a"
         cap#pp
         Capnp.RPC.MethodID.pp m

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -88,7 +88,7 @@ module Capability : sig
       instead for a simpler interface). *)
 
   val call_and_wait : 't t -> ('t, 'a, 'b StructStorage.reader_t) MethodID.t ->
-    'a Request.t -> ('b StructStorage.reader_t * (unit -> unit)) or_error Lwt.t
+    'a Request.t -> (('b StructStorage.reader_t * (unit -> unit)), [> `Capnp of Capnp_rpc.Error.t]) Lwt_result.t
   (** [call_and_wait t m req] does [call t m req] and waits for the response.
       This is simpler than using [call], but doesn't support pipelining
       (you can't use any capabilities in the response in another message until the
@@ -102,7 +102,7 @@ module Capability : sig
       for remote calls. *)
 
   val call_for_value : 't t -> ('t, 'a, 'b StructStorage.reader_t) MethodID.t ->
-    'a Request.t -> 'b StructStorage.reader_t or_error Lwt.t
+    'a Request.t -> ('b StructStorage.reader_t, [> `Capnp of Capnp_rpc.Error.t]) Lwt_result.t
   (** [call_for_value t m req] is similar to [call_and_wait], but automatically
       releases any capabilities in the response before returning. Use this if
       you aren't expecting any capabilities in the response. *)
@@ -112,7 +112,7 @@ module Capability : sig
   (** Wrapper for [call_for_value] that turns errors into Lwt failures. *)
 
   val call_for_unit : 't t -> ('t, 'a, 'b StructStorage.reader_t) MethodID.t ->
-    'a Request.t -> unit or_error Lwt.t
+    'a Request.t -> (unit, [> `Capnp of Capnp_rpc.Error.t]) Lwt_result.t
   (** Wrapper for [call_for_value] that ignores the result. *)
 
   val call_for_unit_exn : 't t -> ('t, 'a, 'b StructStorage.reader_t) MethodID.t ->
@@ -432,7 +432,7 @@ module Persistence : sig
   (** [with_sturdy_ref sr Service.Foo.local obj] is like [Service.Foo.local obj],
       but responds to [save] calls by returning [sr]. *)
 
-  val save : 'a Capability.t -> (Uri.t, Capnp_rpc.Error.t) result Lwt.t
+  val save : 'a Capability.t -> (Uri.t, [> `Capnp of Capnp_rpc.Error.t]) Lwt_result.t
   (** [save cap] calls the persistent [save] method on [cap].
       Note that not all capabilities can be saved.
       todo: this should return an ['a Sturdy_ref.t]; see {!Sturdy_ref.reader}. *)

--- a/capnp-rpc-lwt/persistence.ml
+++ b/capnp-rpc-lwt/persistence.ml
@@ -52,5 +52,5 @@ let save cap =
 
 let save_exn cap =
   save cap >>= function
-  | Error e -> Lwt.fail_with (Fmt.to_to_string Capnp_rpc.Error.pp e)
+  | Error (`Capnp e) -> Lwt.fail_with (Fmt.to_to_string Capnp_rpc.Error.pp e)
   | Ok x -> Lwt.return x

--- a/examples/echo.mli
+++ b/examples/echo.mli
@@ -9,7 +9,7 @@ val ping : t -> ?slow:bool -> string -> string Lwt.t
 (** [ping t msg] sends [msg] to [t] and returns its response.
     If [slow] is given, the service will wait until [unblock] is called before replying. *)
 
-val ping_result : t -> ?slow:bool -> string -> (string, Capnp_rpc.Error.t) Lwt_result.t
+val ping_result : t -> ?slow:bool -> string -> (string, [> `Capnp of Capnp_rpc.Error.t]) Lwt_result.t
 (** [ping t msg] sends [msg] to [t] and returns its response.
     If [slow] is given, the service will wait until [unblock] is called before replying. *)
 

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -562,7 +562,7 @@ let test_crossed_calls switch =
       Sturdy_ref.connect_exn sr_to_server >>= fun to_server ->
       Capability.with_ref to_server @@ fun to_server ->
       Echo.ping to_server "ping" >|= fun c_got -> (c_got, y)
-    | Error e1, Error e2 ->
+    | Error (`Capnp e1), Error (`Capnp e2) ->
       Fmt.failwith "@[<v>Both connections failed!@,%a@,%a@]"
         Capnp_rpc.Error.pp e1
         Capnp_rpc.Error.pp e2


### PR DESCRIPTION
This makes it easier to compose Cap'n Proto calls with other calls that also return errors.