### PR TITLE
Remove some unused dependencies

### DIFF
--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -22,8 +22,6 @@ depends: [
   "asetmap"
   "mirage-flow-lwt"
   "tls" {>= "0.8.0"}
-  "mirage-kv-lwt"
-  "mirage-clock"
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -20,6 +20,8 @@ depends: [
   "mirage-dns"
   "mirage-stack-lwt"
   "base64" {>= "3.0.0"}
+  "mirage-kv-lwt"
+  "mirage-clock"
   "alcotest-lwt" {with-test}
   "io-page-unix" {with-test}
   "tcpip" {with-test}

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -12,7 +12,6 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.03.0"}
   "capnp-rpc-lwt" {= version}
-  "mirage-flow-unix"
   "cmdliner"
   "cstruct-lwt"
   "astring"

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name capnp_rpc_unix)
  (public_name capnp-rpc-unix)
  (libraries lwt.unix astring capnp-rpc-lwt capnp-rpc fmt logs
-   mirage-flow-unix cmdliner cstruct-lwt))
+   cmdliner cstruct-lwt))


### PR DESCRIPTION
- Remove `mirage-flow-unix`; it hasn't been used since b19c6a01f.

- Move `mirage-kv-lwt` and `mirage-clock` to `capnp-rpc-mirage`.
  They're needed only to get Mirage support in `tls`.