### PR TITLE
Partially revert "Remove some unused dependencies"

### DIFF
--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -22,6 +22,8 @@ depends: [
   "asetmap"
   "mirage-flow-lwt"
   "tls" {>= "0.8.0"}
+  "mirage-kv-lwt"
+  "mirage-clock"
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -20,8 +20,6 @@ depends: [
   "mirage-dns"
   "mirage-stack-lwt"
   "base64" {>= "3.0.0"}
-  "mirage-kv-lwt"
-  "mirage-clock"
   "alcotest-lwt" {with-test}
   "io-page-unix" {with-test}
   "tcpip" {with-test}


### PR DESCRIPTION
It turns out that we do need to depend on `mirage-kv-lwt` and `mirage-clock`, in order to get the `tls.mirage` library built, even though we don't use them directly.

This partially reverts commit 1aab6f1f1bae706e043c273a55f6b23d87e363ce.

(@hannesm - maybe there should be a `tls-mirage` opam package that knows what you need to depend on to get TLS built with Mirage support?)