### PR TITLE
Add Prometheus metrics for connections

### DIFF
--- a/capnp-rpc-net.opam
+++ b/capnp-rpc-net.opam
@@ -27,6 +27,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"
+  "prometheus" {>= "0.5"}
   "asn1-combinators" {>= "0.2.0"}
   "x509" {>= "0.8.0"}
   "dune" {>= "1.0"}

--- a/capnp-rpc-net/dune
+++ b/capnp-rpc-net/dune
@@ -2,4 +2,4 @@
  (name capnp_rpc_net)
  (public_name capnp-rpc-net)
  (libraries astring capnp capnp-rpc-lwt fmt logs mirage-flow-lwt nocrypto.lwt
-   tls.mirage base64 uri ptime))
+   tls.mirage base64 uri ptime prometheus))


### PR DESCRIPTION
`capnp-rpc-net` now reports:

- The current number of active connections.
- The total number of messages received.
- The total number of messages enqueued, sent and dropped (from which you can work out the current number of queued messages).