### PR TITLE
 Port to latest x509, tls, alcotest, mirage-crypto and mirage interfaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### dev
+
+- Port to latest interfaces for x509 (0.10+), mirage-crypto,
+  alcotest (1.0+), and mirage-types post the `-lwt` package
+  merge (@avsm #190, review by @talex5 @hannesm)
+
 ### v0.5.0
 
 Breaking changes:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ocurrent/opam@sha256:4d2dc158efda4a5920440e007638ff08dc2ad8c3af1d0a9ed777924ce6db94fa
+FROM ocurrent/opam@sha256:7cec1ab422d97bf498c309a38b685e7c2650a0daa2d6ddef5fb4428de0535f26
 #FROM ocurrent/opam:alpine-3.10-ocaml-4.08
-RUN cd ~/opam-repository && git fetch && git reset --hard ca18b54339548dc814304558e87517e776016293 && opam update
-RUN opam depext -i capnp afl-persistent conf-capnproto tls mirage-flow-lwt mirage-kv-lwt mirage-clock ptime cmdliner mirage-dns
+RUN cd ~/opam-repository && git fetch && git reset --hard e73f271b6d37f11a33bdf48c5572735c0d322466 && opam update
+RUN opam depext -i capnp afl-persistent conf-capnproto tls tls-mirage mirage-flow mirage-kv mirage-clock ptime cmdliner dns-client dns-mirage
 ADD --chown=opam *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/
 RUN opam pin add -yn capnp-rpc.dev . && \
@@ -11,4 +11,4 @@ RUN opam pin add -yn capnp-rpc.dev . && \
     opam pin add -yn capnp-rpc-mirage.dev . 
 RUN opam install --deps-only -t .
 ADD --chown=opam . /home/opam/capnp-rpc
-RUN opam config exec -- make all test
+RUN opam exec -- make all test

--- a/README.md
+++ b/README.md
@@ -1253,6 +1253,7 @@ To build:
     cd capnp-rpc
     opam pin add -nyk git capnp-rpc .
     opam pin add -nyk git capnp-rpc-lwt .
+    opam pin add -nyk git capnp-rpc-net .
     opam pin add -nyk git capnp-rpc-unix .
     opam depext capnp-rpc-lwt alcotest
     opam install --deps-only -t capnp-rpc-unix

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -16,11 +16,11 @@ depends: [
   "astring"
   "fmt"
   "logs"
-  "arp-mirage"
-  "mirage-dns"
-  "mirage-stack-lwt"
-  "base64" {>= "3.0.0"}
-  "alcotest-lwt" {< "1.0.0" & with-test}
+  "dns-client"
+  "tls-mirage"
+  "mirage-stack" {>="2.0.0"}
+  "arp-mirage" {with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
   "tcpip" {with-test}
   "mirage-vnetif" {with-test}

--- a/capnp-rpc-net.opam
+++ b/capnp-rpc-net.opam
@@ -20,16 +20,17 @@ depends: [
   "fmt"
   "logs"
   "asetmap"
-  "mirage-flow-lwt"
+  "mirage-flow" {>="2.0.0"}
   "tls" {>= "0.8.0"}
-  "mirage-kv-lwt"
-  "mirage-clock"
+  "mirage-kv" {>="3.0.0"}
+  "mirage-clock" {>="3.0.0"}
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"
   "prometheus" {>= "0.5"}
   "asn1-combinators" {>= "0.2.0"}
-  "x509" {>= "0.8.0"}
+  "x509" {>= "0.10.0"}
+  "tls-mirage"
   "dune" {>= "1.0"}
 ]
 build: [

--- a/capnp-rpc-net/auth.mli
+++ b/capnp-rpc-net/auth.mli
@@ -34,7 +34,7 @@ module Digest : sig
       to the correct values for [t]. Note that although we use the "password" field,
       this is not secret. *)
 
-  val authenticator : t -> X509_lwt.authenticator option
+  val authenticator : t -> X509.Authenticator.t option
   (** [authenticator t] is an authenticator that checks that the peer's public key
       matches [t]. Returns [None] if [t] is [insecure].
       Note: it currently also requires the DN field to be "capnp". *)
@@ -55,8 +55,9 @@ module Secret_key : sig
 
   val generate : unit -> t
   (** [generate ()] is a fresh secret key.
-      You must call [Nocrypto_entropy_lwt.initialize] before using this (it will give an
-      error if you forget). *)
+      You must call the relevant entropy initialization function
+      (e.g. {!Mirage_crypto_rng_unix.initialize}) before using this, or it
+      will raise an error if you forget. *)
 
   val digest : ?hash:hash -> t -> Digest.t
   (** [digest ~hash t] is the digest of [t]'s public key, using [hash]. *)

--- a/capnp-rpc-net/capnp_rpc_net.ml
+++ b/capnp-rpc-net/capnp_rpc_net.ml
@@ -11,7 +11,7 @@ module type VAT_NETWORK = S.VAT_NETWORK with
   type service_id := Restorer.Id.t and
   type 'a sturdy_ref := 'a Sturdy_ref.t
 
-module Networking (N : S.NETWORK) (F : Mirage_flow_lwt.S) = struct
+module Networking (N : S.NETWORK) (F : Mirage_flow.S) = struct
   type flow = F.flow
 
   module Network = N

--- a/capnp-rpc-net/capnp_rpc_net.mli
+++ b/capnp-rpc-net/capnp_rpc_net.mli
@@ -141,7 +141,7 @@ module type VAT_NETWORK = S.VAT_NETWORK with
   type service_id := Restorer.Id.t and
   type 'a sturdy_ref := 'a Sturdy_ref.t
 
-module Networking (N : S.NETWORK) (Flow : Mirage_flow_lwt.S) : VAT_NETWORK with
+module Networking (N : S.NETWORK) (Flow : Mirage_flow.S) : VAT_NETWORK with
   module Network = N and
   type flow = Flow.flow
 

--- a/capnp-rpc-net/dune
+++ b/capnp-rpc-net/dune
@@ -1,5 +1,5 @@
 (library
  (name capnp_rpc_net)
  (public_name capnp-rpc-net)
- (libraries astring capnp capnp-rpc-lwt fmt logs mirage-flow-lwt nocrypto.lwt
-   tls.mirage base64 uri ptime prometheus))
+ (libraries astring capnp capnp-rpc-lwt fmt logs mirage-flow mirage-crypto mirage-crypto-rng
+   tls-mirage base64 uri ptime prometheus))

--- a/capnp-rpc-net/endpoint.ml
+++ b/capnp-rpc-net/endpoint.ml
@@ -7,7 +7,7 @@ let compression = `None
 
 let record_sent_messages = false
 
-type flow = Flow : (module Mirage_flow_lwt.S with type flow = 'a) * 'a -> flow
+type flow = Flow : (module Mirage_flow.S with type flow = 'a) * 'a -> flow
 
 type t = {
   flow : flow;
@@ -18,7 +18,7 @@ type t = {
 
 let peer_id t = t.peer_id
 
-let of_flow (type flow) ~switch ~peer_id (module F : Mirage_flow_lwt.S with type flow = flow) (flow:flow) =
+let of_flow (type flow) ~switch ~peer_id (module F : Mirage_flow.S with type flow = flow) (flow:flow) =
   let generic_flow = Flow ((module F), flow) in
   let decoder = Capnp.Codecs.FramedStream.empty compression in
   { flow = generic_flow; decoder; switch; peer_id }

--- a/capnp-rpc-net/endpoint.mli
+++ b/capnp-rpc-net/endpoint.mli
@@ -12,7 +12,7 @@ val recv : t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [> `Closed]) res
     (this will also happen if the switch is turned off). *)
 
 val of_flow : switch:Lwt_switch.t -> peer_id:Auth.Digest.t ->
-  (module Mirage_flow_lwt.S with type flow = 'flow) -> 'flow -> t
+  (module Mirage_flow.S with type flow = 'flow) -> 'flow -> t
 (** [of_flow ~switch ~peer_id (module F) flow] sends and receives on [flow].
     The caller should arrange for [flow] to be closed when the switch is turned off.
     If the flow is closed, the switch will be turned off.

--- a/capnp-rpc-net/tls_wrapper.ml
+++ b/capnp-rpc-net/tls_wrapper.ml
@@ -7,7 +7,7 @@ let error fmt =
   fmt |> Fmt.kstrf @@ fun msg ->
   Error (`Msg msg)
 
-module Make (Underlying : Mirage_flow_lwt.S) = struct
+module Make (Underlying : Mirage_flow.S) = struct
   module Flow = struct
     include Tls_mirage.Make(Underlying)
 

--- a/capnp-rpc-net/tls_wrapper.mli
+++ b/capnp-rpc-net/tls_wrapper.mli
@@ -1,6 +1,6 @@
 open Auth
 
-module Make (Underlying : Mirage_flow_lwt.S) : sig
+module Make (Underlying : Mirage_flow.S) : sig
   (** Make an [Endpoint] from an [Underlying.flow], using TLS if appropriate. *)
 
   val connect_as_server :

--- a/capnp-rpc-net/vat.ml
+++ b/capnp-rpc-net/vat.ml
@@ -5,7 +5,7 @@ module Log = Capnp_rpc.Debug.Log
 
 module ID_map = Auth.Digest.Map
 
-module Make (Network : S.NETWORK) (Underlying : Mirage_flow_lwt.S) = struct
+module Make (Network : S.NETWORK) (Underlying : Mirage_flow.S) = struct
   module CapTP = CapTP_capnp.Make (Network)
 
   let hash = `SHA256 (* Only support a single hash for now *)

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "base64" {>= "3.0.0"}
   "dune" {>= "1.0"}
-  "alcotest-lwt" {with-test & >= "0.8.0" & < "1.0.0"}
+  "alcotest-lwt" {with-test & >= "1.0.1"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/capnp-rpc.opam
+++ b/capnp-rpc.opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "asetmap"
   "dune" {>= "1.0"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.0.1"}
   "afl-persistent" {with-test}
 ]
 build: [

--- a/mirage/capnp_rpc_mirage.ml
+++ b/mirage/capnp_rpc_mirage.ml
@@ -4,8 +4,10 @@ module Log = Capnp_rpc.Debug.Log
 
 module Location = Network.Location
 
-module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) = struct
-  module Network = Network.Make(Stack)(Dns)
+module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) = struct
+
+  module Dns = Dns_client_mirage.Make(R)(C)(Stack)
+  module Network = Network.Make(R)(C)(Stack)
   module Vat_config = Vat_config.Make(Network)
   module Vat_network = Capnp_rpc_net.Networking(Network)(Stack.TCPV4)
 

--- a/mirage/capnp_rpc_mirage.mli
+++ b/mirage/capnp_rpc_mirage.mli
@@ -4,10 +4,10 @@ open Capnp_rpc_net
 
 module Location = Network.Location
 
-module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) : sig
+module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) : sig
   include Capnp_rpc_net.VAT_NETWORK with
     type flow = Stack.TCPV4.flow and
-    module Network = Network.Make(Stack)(Dns)
+    module Network = Network.Make(R)(C)(Stack)
 
   module Vat_config : sig
     module Listen_address : sig
@@ -50,7 +50,7 @@ module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) : sig
         created by [t]. *)
   end
 
-  val network : dns:Dns.t -> Stack.t -> Network.t
+  val network : dns:Network.Dns.t -> Stack.t -> Network.t
 
   val serve :
     ?switch:Lwt_switch.t ->

--- a/mirage/dune
+++ b/mirage/dune
@@ -1,4 +1,4 @@
 (library
  (name capnp_rpc_mirage)
  (public_name capnp-rpc-mirage)
- (libraries capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs mirage-stack-lwt mirage-dns))
+ (libraries capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs mirage-stack mirage-time dns-client.mirage))

--- a/mirage/network.mli
+++ b/mirage/network.mli
@@ -13,7 +13,9 @@ module Location : sig
   (** [tcp ~host port] is [`TCP (host, port)]. *)
 end
 
-module Make (Stack : Mirage_stack_lwt.V4) (Dns : Dns_resolver_mirage.S) : sig
+module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) : sig
+
+  module Dns : module type of Dns_client_mirage.Make(R)(C)(Stack)  
 
   type t = {
     stack : Stack.t;

--- a/mirage/vat_config.ml
+++ b/mirage/vat_config.ml
@@ -9,7 +9,7 @@ module Secret_hash : sig
 end = struct
   type t = string
 
-  let of_pem_data data = Nocrypto.Hash.SHA256.digest (Cstruct.of_string data) |> Cstruct.to_string
+  let of_pem_data data = Mirage_crypto.Hash.SHA256.digest (Cstruct.of_string data) |> Cstruct.to_string
   let to_string x = x
 end
 

--- a/test-lwt/test.ml
+++ b/test-lwt/test.ml
@@ -631,7 +631,7 @@ let test_store switch =
   Capability.dec_ref store;
   Lwt.return_unit
 
-let run name fn = Alcotest.test_case name `Quick fn
+let run name fn = Alcotest_lwt.test_case_sync name `Quick fn
 
 let rpc_tests = [
   run_lwt "Simple"              (test_simple ~serve_tls:false);
@@ -661,6 +661,6 @@ let rpc_tests = [
 ]
 
 let () =
-  Alcotest.run ~and_exit:false "capnp-rpc" [
+  Alcotest_lwt.run ~and_exit:false "capnp-rpc" [
     "lwt", rpc_tests;
-  ]
+  ] |> Lwt_main.run

--- a/test-mirage/dune
+++ b/test-mirage/dune
@@ -2,7 +2,7 @@
  (name test)
  (libraries io-page-unix capnp-rpc-lwt capnp-rpc-mirage alcotest-lwt examples
    logs.fmt testbed tcpip.ipv4 tcpip.stack-direct mirage-vnetif ethernet
-   arp-mirage tcpip.tcp tcpip.icmpv4))
+   arp-mirage tcpip.tcp tcpip.icmpv4 mirage-crypto-rng.unix))
 
 (alias
  (name runtest)

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 module Log = Capnp_rpc.Debug.Log
 module Unix_flow = Unix_flow
 
-let () = Nocrypto_entropy_unix.initialize ()
+let () = Mirage_crypto_rng_unix.initialize ()
 
 type flow = Unix_flow.flow
 

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name capnp_rpc_unix)
  (public_name capnp-rpc-unix)
  (libraries lwt.unix astring capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs
-   cmdliner cstruct-lwt))
+   mirage-crypto-rng.unix cmdliner cstruct-lwt))

--- a/unix/unix_flow.ml
+++ b/unix/unix_flow.ml
@@ -4,7 +4,6 @@ open Lwt.Infix
    in a modern application. *)
 let () = Sys.(set_signal sigpipe Signal_ignore)
 
-type buffer = Cstruct.t
 type flow = {
   fd : Lwt_unix.file_descr;
   mutable current_write : int Lwt.t option;
@@ -13,7 +12,6 @@ type flow = {
 }
 type error = [`Exception of exn]
 type write_error = [`Closed | `Exception of exn]
-type 'a io = 'a Lwt.t
 
 let opt_cancel = function
   | None -> ()

--- a/unix/unix_flow.mli
+++ b/unix/unix_flow.mli
@@ -1,6 +1,6 @@
 (** Wraps a Unix [file_descr] to provide the Mirage flow API. *)
 
-include Mirage_flow_lwt.S
+include Mirage_flow.S
 
 val connect : ?switch:Lwt_switch.t -> Lwt_unix.file_descr -> flow
 

--- a/unix/vat_config.ml
+++ b/unix/vat_config.ml
@@ -21,7 +21,7 @@ module Secret_hash : sig
 end = struct
   type t = string
 
-  let of_pem_data data = Nocrypto.Hash.SHA256.digest (Cstruct.of_string data) |> Cstruct.to_string
+  let of_pem_data data = Mirage_crypto.Hash.SHA256.digest (Cstruct.of_string data) |> Cstruct.to_string
   let to_string x = x
 end
 


### PR DESCRIPTION
With apologies for a single monolithic commit, but the upper bounds were a bit too interwined on my system to turn it into more discrete changes. I can split them up once reviewed.

I'm not too sure about the Mirage DNS changes. It seems we're missing a `Dns_client.S` and the static resolver code that made testing with the earlier version easier.  Need to write one and contribute it back to ocaml-dns, but could prototype it in here too. 