### PR TITLE
Convert many info-level log messages to debug level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,7 +1026,7 @@ Using `Capability.with_ref` makes it easier to ensure that `dec_ref` gets called
 First, always make sure logging is enabled so you can at least see warnings.
 The `main.ml` examples in this document enable some basic logging.
 
-If you turn up the log level to `Info` (or even `Debug`), you'll see lots of information about what is going on.
+If you turn up the log level to `Debug`, you'll see lots of information about what is going on.
 Turning on colour in the logs will help too - see `test-bin/calc.ml` for an example.
 
 Many references will be displayed with their reference count (e.g. as `rc=3`).
@@ -1268,7 +1268,7 @@ The calculator example can also be run across two Unix processes.
 Start the server with:
 
 ```
-$ ./_build/default/test-bin/calc.bc serve \
+$ dune exec -- ./test-bin/calc.bc serve \
     --capnp-listen-address unix:/tmp/calc.socket \
     --capnp-secret-key-file=key.pem
 Waiting for incoming connections at:
@@ -1280,7 +1280,7 @@ Note that `key.pem` does not need to exist. A new key will be generated and save
 In another terminal, run the client and connect to the address displayed by the server:
 
 ```
-./_build/default/test-bin/calc.bc connect capnp://sha-256:LPp-7l74zqvGcRgcP8b7-kdSpwwzxlA555lYC8W8prc@/tmp/calc.socket
+dune exec -- ./test-bin/calc.bc connect capnp://sha-256:LPp-7l74zqvGcRgcP8b7-kdSpwwzxlA555lYC8W8prc@/tmp/calc.socket/
 ```
 
 You can also use `--capnp-disable-tls` if you prefer to run without encryption

--- a/capnp-rpc-lwt/capability.ml
+++ b/capnp-rpc-lwt/capability.ml
@@ -53,7 +53,7 @@ let equal a b =
   | _ -> Error `Unsettled
 
 let call (target : 't capability_t) (m : ('t, 'a, 'b) method_t) (req : 'a Request.t) =
-  Log.info (fun f -> f "Calling %a" Capnp.RPC.MethodID.pp m);
+  Log.debug (fun f -> f "Calling %a" Capnp.RPC.MethodID.pp m);
   let msg = Request.finish m req in
   let results, resolver = Local_struct_promise.make () in
   target#call resolver msg;

--- a/capnp-rpc-lwt/service.ml
+++ b/capnp-rpc-lwt/service.ml
@@ -39,7 +39,7 @@ let local (s:#generic) =
       let call = Msg.Request.readable msg in
       let interface_id = Call.interface_id_get call in
       let method_id = Call.method_id_get call in
-      Log.info (fun f -> f "Invoking local method %a" pp_method (interface_id, method_id));
+      Log.debug (fun f -> f "Invoking local method %a" pp_method (interface_id, method_id));
       let p = Call.params_get call in
       let m : abstract_method_t = s#dispatch ~interface_id ~method_id in
       let release_params () = Core_types.Request_payload.release msg in

--- a/capnp-rpc-net/capTP_capnp.ml
+++ b/capnp-rpc-net/capTP_capnp.ml
@@ -54,11 +54,11 @@ module Make (Network : S.NETWORK) = struct
   let async_tagged label fn =
     Lwt.async
       (fun () ->
-        Lwt.catch fn
-          (fun ex ->
-             Log.warn (fun f -> f "Uncaught async exception in %S: %a" label Fmt.exn ex);
-             Lwt.return_unit
-          )
+         Lwt.catch fn
+           (fun ex ->
+              Log.warn (fun f -> f "Uncaught async exception in %S: %a" label Fmt.exn ex);
+              Lwt.return_unit
+           )
       )
 
   let pp_msg f call =
@@ -106,7 +106,7 @@ module Make (Network : S.NETWORK) = struct
     if was_idle then async_tagged "Message sender thread" (fun () -> flush ~xmit_queue endpoint)
 
   let return_not_implemented t x =
-    Log.info (fun f -> f ~tags:(tags t) "Returning Unimplemented");
+    Log.debug (fun f -> f ~tags:(tags t) "Returning Unimplemented");
     let open Builder in
     let m = Message.init_root () in
     let _ : Builder.Message.t = Message.unimplemented_set_reader m x in
@@ -122,7 +122,7 @@ module Make (Network : S.NETWORK) = struct
         Prometheus.Counter.inc_one Metrics.messages_inbound_received_total;
         match Parse.message msg with
         | #Endpoint_types.In.t as msg ->
-          Log.info (fun f ->
+          Log.debug (fun f ->
               let tags = Endpoint_types.In.with_qid_tag (Conn.tags t.conn) msg in
               f ~tags "<- %a" (Endpoint_types.In.pp_recv pp_msg) msg);
           begin match msg with

--- a/test-bin/calc.ml
+++ b/test-bin/calc.ml
@@ -82,7 +82,7 @@ let cmds = [serve_cmd; connect_cmd]
 let () =
   Fmt_tty.setup_std_outputs ();
   Logs.set_reporter reporter;
-  Logs.set_level ~all:true (Some Logs.Info);
+  Logs.set_level ~all:true (Some Logs.Debug);
   match Term.eval_choice ~catch:false default_cmd cmds with
   | exception Failure msg -> Fmt.epr "%s@." msg; exit 1
   | status -> Term.exit status


### PR DESCRIPTION
This information is only really useful when debugging the library.