### PR TITLE
Expose the endpoint logger

### DIFF
--- a/capnp-rpc-net/endpoint.mli
+++ b/capnp-rpc-net/endpoint.mli
@@ -1,5 +1,11 @@
 (** Send and receive capnp messages over a byte-stream. *)
 
+module Log : Logs.LOG
+(** The endpoint library's logger. *)
+
+val src : Logs.src
+(** Control the log level for [Log]. *)
+
 type t
 (** A wrapper for a byte-stream (flow). *)
 

--- a/capnp-rpc-net/endpoint.mli
+++ b/capnp-rpc-net/endpoint.mli
@@ -1,10 +1,7 @@
 (** Send and receive capnp messages over a byte-stream. *)
 
-module Log : Logs.LOG
-(** The endpoint library's logger. *)
-
 val src : Logs.src
-(** Control the log level for [Log]. *)
+(** Control the log level. *)
 
 type t
 (** A wrapper for a byte-stream (flow). *)

--- a/mirage/capnp_rpc_mirage.ml
+++ b/mirage/capnp_rpc_mirage.ml
@@ -38,12 +38,12 @@ module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stac
     match listen_address with
     | `TCP port ->
       Stack.listen_tcpv4 t.stack ~port (fun flow ->
-          Logs.info (fun f -> f ?tags "Accepting new connection");
+          Log.info (fun f -> f ?tags "Accepting new connection");
           let secret_key = if serve_tls then Some (Vat_config.secret_key config) else None in
           Lwt.async (fun () -> handle_connection ?tags ~secret_key vat flow);
           Lwt.return_unit
         );
-      Logs.info (fun f -> f ?tags "Waiting for %s connections on %a"
+      Log.info (fun f -> f ?tags "Waiting for %s connections on %a"
                     (if serve_tls then "(encrypted)" else "UNENCRYPTED")
                     Vat_config.Listen_address.pp listen_address);
       Lwt.return vat

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -124,14 +124,14 @@ let serve ?switch ?tags ?restore config =
       socket
   in
   Unix.listen socket backlog;
-  Logs.info (fun f -> f ?tags "Waiting for %s connections on %a"
+  Log.info (fun f -> f ?tags "Waiting for %s connections on %a"
                 (if serve_tls then "(encrypted)" else "UNENCRYPTED")
                 Vat_config.Listen_address.pp listen_address);
   let lwt_socket = Lwt_unix.of_unix_file_descr socket in
   let rec loop () =
     Lwt_switch.check switch;
     Lwt_unix.accept lwt_socket >>= fun (client, _addr) ->
-    Logs.info (fun f -> f ?tags "Accepting new connection");
+    Log.info (fun f -> f ?tags "Accepting new connection");
     let secret_key = if serve_tls then Some (Vat_config.secret_key config) else None in
     Lwt.async (fun () -> handle_connection ?tags ~secret_key vat client);
     loop ()


### PR DESCRIPTION
It is currently possible to disable the `capnp-rpc` logging source, but not `endpoint` when debugging application logic.

This PR exposes that source in `capnp-rpc-net/endpoint.mli`.

I've copied the formatting in `capnp-rpc/debug.mli`, but another style may be optimal.

Additionally there is currently logging to `application` which may be undesirable.