### PR TITLE
Add echo benchmark test

### DIFF
--- a/test-bin/echo/dune
+++ b/test-bin/echo/dune
@@ -1,7 +1,6 @@
 (executable
  (name echo_bench)
  (libraries lwt.unix capnp-rpc capnp-rpc-lwt capnp-rpc-net capnp-rpc-unix logs.fmt)
- (preprocess (pps lwt_ppx))
  (flags (:standard -w -53-55)))
 
 (rule

--- a/test-bin/echo/dune
+++ b/test-bin/echo/dune
@@ -1,0 +1,10 @@
+(executable
+ (name echo_bench)
+ (libraries lwt.unix capnp-rpc capnp-rpc-lwt capnp-rpc-net capnp-rpc-unix logs.fmt)
+ (preprocess (pps lwt_ppx))
+ (flags (:standard -w -53-55)))
+
+(rule
+ (targets echo_api.ml echo_api.mli)
+ (deps    echo_api.capnp)
+ (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))

--- a/test-bin/echo/echo.ml
+++ b/test-bin/echo/echo.ml
@@ -1,0 +1,29 @@
+module Api = Echo_api.MakeRPC(Capnp_rpc_lwt)
+
+open Lwt.Infix
+open Capnp_rpc_lwt
+
+(*-- Server ----------------------------------------*)
+let local =
+  let module Echo = Api.Service.Echo in
+
+  Echo.local @@ object
+    inherit Echo.service
+
+    method ping_impl params release_param_caps =
+      let open Echo.Ping in
+      let msg = Params.msg_get params in
+      release_param_caps ();
+      let response, results = Service.Response.create Results.init_pointer in
+      Results.reply_set results ("echo:" ^ msg);
+      Service.return response
+  end
+
+(*-- Client ----------------------------------------*)
+module Echo = Api.Client.Echo
+
+let ping t msg =
+  let open Echo.Ping in
+  let request, params = Capability.Request.create Params.init_pointer in
+  Params.msg_set params msg;
+  Capability.call_for_value_exn t method_id request >|= Results.reply_get

--- a/test-bin/echo/echo_api.capnp
+++ b/test-bin/echo/echo_api.capnp
@@ -1,0 +1,5 @@
+@0xb13fc2f2a4c1d65b;
+
+interface Echo {
+  ping @0 (msg :Text) -> (reply :Text);
+}

--- a/test-bin/echo/echo_bench.ml
+++ b/test-bin/echo/echo_bench.ml
@@ -13,11 +13,11 @@ let run_client service =
       let payload = Int.to_string i in
       let desired_result = "echo:" ^ payload in
       fun () -> 
-        Echo.ping service payload >>= fun res ->
-        Lwt.return (res = desired_result)
+        Echo.ping service payload >|= fun res ->
+        assert (res = desired_result)
     ) in
   let st = Unix.gettimeofday () in
-  Lwt_list.map_p (fun v -> v ()) ops >>= fun _ ->
+  Lwt_list.iter_p (fun v -> v ()) ops >>= fun () ->
   let ed = Unix.gettimeofday () in 
   let rate = (Int.to_float n) /. (ed -. st) in
   Logs.info (fun m -> m "rate = %f" rate );

--- a/test-bin/echo/echo_bench.ml
+++ b/test-bin/echo/echo_bench.ml
@@ -15,11 +15,11 @@ let run_client service =
   let n = 100000. in
   let ops = n |> create_for (fun i -> 
       fun () -> 
-        let%lwt res = Echo.ping service (Float.to_string i) in
+        Echo.ping service (Float.to_string i) >>= fun res ->
         Lwt.return (res = "echo:" ^ (Float.to_string i))
     ) in
   let st = Unix.gettimeofday () in
-  let%lwt _res = Lwt_list.map_p (fun v -> v ()) ops in
+  Lwt_list.map_p (fun v -> v ()) ops >>= fun _ ->
   let ed = Unix.gettimeofday () in 
   let rate = n /. (ed -. st) in
   Logs.info (fun m -> m "rate = %f" rate );
@@ -41,6 +41,6 @@ let () =
     Fmt.pr "Connecting to echo service at: %a@." Uri.pp_hum uri;
     let client_vat = Capnp_rpc_unix.client_only_vat () in
     let sr = Capnp_rpc_unix.Vat.import_exn client_vat uri in
-    let%lwt proxy = Sturdy_ref.connect_exn sr in
+    Sturdy_ref.connect_exn sr >>= fun proxy -> 
     run_client proxy
   end

--- a/test-bin/echo/echo_bench.ml
+++ b/test-bin/echo/echo_bench.ml
@@ -1,0 +1,46 @@
+
+open Lwt.Infix
+
+open Capnp_rpc_lwt 
+
+let () =
+  Logs.set_level (Some Logs.Info);
+  Logs.set_reporter (Logs_fmt.reporter ())
+
+let rec create_for v = function
+  | 0. -> []
+  | n -> v n :: (create_for v (n-.1.))
+
+let run_client service = 
+  let n = 100000. in
+  let ops = n |> create_for (fun i -> 
+      fun () -> 
+        let%lwt res = Echo.ping service (Float.to_string i) in
+        Lwt.return (res = "echo:" ^ (Float.to_string i))
+    ) in
+  let st = Unix.gettimeofday () in
+  let%lwt _res = Lwt_list.map_p (fun v -> v ()) ops in
+  let ed = Unix.gettimeofday () in 
+  let rate = n /. (ed -. st) in
+  Logs.info (fun m -> m "rate = %f" rate );
+  Lwt.return_unit
+
+let secret_key = `Ephemeral
+let listen_address = `TCP ("127.0.0.1", 7000)
+
+let start_server () =
+  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~serve_tls:false listen_address in
+  let service_id = Capnp_rpc_unix.Vat_config.derived_id config "main" in
+  let restore = Capnp_rpc_net.Restorer.single service_id Echo.local in
+  Capnp_rpc_unix.serve config ~restore >|= fun vat ->
+  Capnp_rpc_unix.Vat.sturdy_uri vat service_id
+
+let () =
+  Lwt_main.run begin
+    start_server () >>= fun uri ->
+    Fmt.pr "Connecting to echo service at: %a@." Uri.pp_hum uri;
+    let client_vat = Capnp_rpc_unix.client_only_vat () in
+    let sr = Capnp_rpc_unix.Vat.import_exn client_vat uri in
+    let%lwt proxy = Sturdy_ref.connect_exn sr in
+    run_client proxy
+  end

--- a/test-bin/echo/echo_bench.ml
+++ b/test-bin/echo/echo_bench.ml
@@ -7,21 +7,19 @@ let () =
   Logs.set_level (Some Logs.Info);
   Logs.set_reporter (Logs_fmt.reporter ())
 
-let rec create_for v = function
-  | 0. -> []
-  | n -> v n :: (create_for v (n-.1.))
-
 let run_client service = 
-  let n = 100000. in
-  let ops = n |> create_for (fun i -> 
+  let n = 100000 in
+  let ops = List.init n (fun i -> 
+      let payload = Int.to_string i in
+      let desired_result = "echo:" ^ payload in
       fun () -> 
-        Echo.ping service (Float.to_string i) >>= fun res ->
-        Lwt.return (res = "echo:" ^ (Float.to_string i))
+        Echo.ping service payload >>= fun res ->
+        Lwt.return (res = desired_result)
     ) in
   let st = Unix.gettimeofday () in
   Lwt_list.map_p (fun v -> v ()) ops >>= fun _ ->
   let ed = Unix.gettimeofday () in 
-  let rate = n /. (ed -. st) in
+  let rate = (Int.to_float n) /. (ed -. st) in
   Logs.info (fun m -> m "rate = %f" rate );
   Lwt.return_unit
 


### PR DESCRIPTION
The PR adds a small benchmark for one common use case: accessing a capability over the network (in this case via localhost).

Things to note is that it does not separate the client and server into two separate processes which does impact the performance (since this is a CPU limited benchmark).

