### PR TITLE
Add mirage_time parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocurrent/opam@sha256:7cec1ab422d97bf498c309a38b685e7c2650a0daa2d6ddef5fb4428de0535f26
 #FROM ocurrent/opam:alpine-3.10-ocaml-4.08
-RUN cd ~/opam-repository && git fetch && git reset --hard 732bf30283b1065a4818a2bed4c3e7bfb6de678d && opam update
+RUN cd ~/opam-repository && git fetch && git reset --hard 5406460dc52fbfb6e7b34deae0b712dbea3efa41 && opam update
 RUN opam depext -i capnp afl-persistent conf-capnproto tls tls-mirage mirage-flow ptime cmdliner dns-client dns-mirage
 ADD --chown=opam *.opam /home/opam/capnp-rpc/
 WORKDIR /home/opam/capnp-rpc/

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -16,7 +16,7 @@ depends: [
   "astring"
   "fmt"
   "logs"
-  "dns-client"
+  "dns-client" {>= "4.5.0"}
   "tls-mirage"
   "mirage-stack" {>="2.0.0"}
   "arp-mirage" {with-test}

--- a/mirage/capnp_rpc_mirage.ml
+++ b/mirage/capnp_rpc_mirage.ml
@@ -4,10 +4,10 @@ module Log = Capnp_rpc.Debug.Log
 
 module Location = Network.Location
 
-module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) = struct
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) = struct
 
-  module Dns = Dns_client_mirage.Make(R)(C)(Stack)
-  module Network = Network.Make(R)(C)(Stack)
+  module Dns = Dns_client_mirage.Make(R)(T)(C)(Stack)
+  module Network = Network.Make(R)(T)(C)(Stack)
   module Vat_config = Vat_config.Make(Network)
   module Vat_network = Capnp_rpc_net.Networking(Network)(Stack.TCPV4)
 

--- a/mirage/capnp_rpc_mirage.mli
+++ b/mirage/capnp_rpc_mirage.mli
@@ -4,10 +4,10 @@ open Capnp_rpc_net
 
 module Location = Network.Location
 
-module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) : sig
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) : sig
   include Capnp_rpc_net.VAT_NETWORK with
     type flow = Stack.TCPV4.flow and
-    module Network = Network.Make(R)(C)(Stack)
+    module Network = Network.Make(R)(T)(C)(Stack)
 
   module Vat_config : sig
     module Listen_address : sig

--- a/mirage/network.ml
+++ b/mirage/network.ml
@@ -17,9 +17,9 @@ module Location = struct
   let equal = ( = )
 end
 
-module Make  (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) = struct
+module Make  (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) = struct
 
-  module Dns = Dns_client_mirage.Make(R)(C)(Stack)
+  module Dns = Dns_client_mirage.Make(R)(T)(C)(Stack)
   module Tls_wrapper = Capnp_rpc_net.Tls_wrapper.Make(Stack.TCPV4)
 
   module Address = struct

--- a/mirage/network.mli
+++ b/mirage/network.mli
@@ -13,9 +13,9 @@ module Location : sig
   (** [tcp ~host port] is [`TCP (host, port)]. *)
 end
 
-module Make (R : Mirage_random.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) : sig
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (C : Mirage_clock.MCLOCK) (Stack : Mirage_stack.V4) : sig
 
-  module Dns : module type of Dns_client_mirage.Make(R)(C)(Stack)  
+  module Dns : module type of Dns_client_mirage.Make(R)(T)(C)(Stack)  
 
   type t = {
     stack : Stack.t;

--- a/test-mirage/test.ml
+++ b/test-mirage/test.ml
@@ -5,7 +5,9 @@ open Examples
 
 module Time = struct
   let sleep_ns ns = Lwt_unix.sleep (Duration.to_f ns)
+end 
 
+module Clock = struct
   let period_ns () = None
   let elapsed_ns () = 0L
 end
@@ -21,9 +23,9 @@ module Stack = struct
   module V = Vnetif.Make(B)
   module E = Ethernet.Make(V)
   module A = Arp.Make(E)(Time)
-  module I = Static_ipv4.Make(Random)(Time)(E)(A)
+  module I = Static_ipv4.Make(Random)(Clock)(E)(A)
   module U = Udp.Make(I)(Random)
-  module T = Tcp.Flow.Make(I)(Time)(Time)(Random)
+  module T = Tcp.Flow.Make(I)(Time)(Clock)(Random)
   module Icmp = Icmpv4.Make(I)
   include Tcpip_stack_direct.Make(Time)(Random)(V)(E)(A)(I)(Icmp)(U)(T)
 
@@ -39,7 +41,7 @@ module Stack = struct
     Icmp.connect i >>= fun icmp ->
     connect v e a i icmp u t
 end
-module Mirage = Capnp_rpc_mirage.Make(Random)(Time)(Stack)
+module Mirage = Capnp_rpc_mirage.Make(Random)(Time)(Clock)(Stack)
 module Vat = Mirage.Vat
 
 type cs = {


### PR DESCRIPTION
The `Dns_mirage_client.Make` now requires a `Mirage_time` parameter. This PR adds that.

This should make the CI no longer fail.