### PR TITLE
Show how to make a connection directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See [LICENSE.md](LICENSE.md) for details.
 	* [How can I import a sturdy ref that I need to start my vat?](#how-can-i-import-a-sturdy-ref-that-i-need-to-start-my-vat)
 	* [How can I release other resources when my service is released?](#how-can-i-release-other-resources-when-my-service-is-released)
 	* [Is there an interactive version I can use for debugging?](#is-there-an-interactive-version-i-can-use-for-debugging)
+	* [Can I set up a direct 2-party connection over a pre-existing channel?](#can-i-set-up-a-direct-2-party-connection-over-a-pre-existing-channel)
 	* [How can I use this with Mirage?](#how-can-i-use-this-with-mirage)
 * [Contributing](#contributing)
 	* [Conceptual model](#conceptual-model)
@@ -1133,6 +1134,28 @@ capnp.wait_forever()
 
 Note that calling `wait_forever` prevents further use of the session, however.
 
+### Can I set up a direct 2-party connection over a pre-existing channel?
+
+The normal way to connect to a remote service is using a sturdy ref, as described above.
+This uses the [NETWORK][] to open a new connection to the server, or reuses an existing connection
+if there is one. However, it is sometimes useful to use a pre-existing connection directly.
+
+For example, a process may want to spawn a child process and communicate with it
+over a socketpair. The [calc_direct.ml][] example shows how to do this:
+
+```
+$ dune exec -- ./test-bin/calc_direct.exe
+parent: application: Connecting to child process...
+parent: application: Sending request...
+ child: application: Serving requests...
+ child: application: 21.000000 op 2.000000 -> 42.000000
+parent: application: Result: 42.000000
+parent: application: Shutting down...
+parent:   capnp-rpc: Connection closed
+parent: application: Waiting for child to exit...
+parent: application: Done
+```
+
 ### How can I use this with Mirage?
 
 Note: `capnp` uses the `stdint` library, which has C stubs and
@@ -1324,3 +1347,5 @@ We should also test with some malicious vats (that don't follow the protocol cor
 [Mirage]: https://mirage.io/
 [ocaml-ci]: https://github.com/ocaml-ci/ocaml-ci
 [api]: https://mirage.github.io/capnp-rpc/
+[NETWORK]: https://mirage.github.io/capnp-rpc/capnp-rpc-net/Capnp_rpc_net/S/module-type-NETWORK/index.html
+[calc_direct.ml]: ./test-bin/calc_direct.ml

--- a/test-bin/calc_direct.ml
+++ b/test-bin/calc_direct.ml
@@ -1,0 +1,106 @@
+(* Run the calc service as a child process, connecting directly over a socketpair.
+   Unlike a normal connection, there is no encryption or use of sturdy refs here. *)
+
+open Lwt.Infix
+
+module Calc = Examples.Calc
+
+let service_name = Capnp_rpc_net.Restorer.Id.public "my-service"
+(* The name of the service that the child offers and the parent requests.
+   It doesn't matter what this is, as long as they both use the same string. *)
+
+module Logging = struct
+  let reporter id =
+    let report src _level ~over k msgf =
+      let src = Logs.Src.name src in
+      msgf @@ fun ?header:_ ?tags:_ fmt ->
+      let print _ =
+        over ();
+        k ()
+      in
+      Fmt.kpf print Fmt.stdout ("%6s: %a: @[" ^^ fmt ^^ "@]@.")
+        id Fmt.(styled `Magenta string) (Printf.sprintf "%11s" src)
+    in
+    { Logs.report = report }
+
+  let init id =
+    Fmt_tty.setup_std_outputs ();
+    Logs.(set_level (Some Info));
+    Logs.set_reporter (reporter id)
+end
+
+module Parent = struct
+  let run socket =
+    Logging.init "parent";
+    (* Run Cap'n Proto RPC protocol on [socket]: *)
+    Lwt_switch.with_switch @@ fun switch ->
+    let p = Lwt_unix.of_unix_file_descr socket
+            |> Capnp_rpc_unix.Unix_flow.connect ~switch
+            |> Capnp_rpc_net.Endpoint.of_flow (module Capnp_rpc_unix.Unix_flow)
+              ~peer_id:Capnp_rpc_net.Auth.Digest.insecure
+              ~switch in
+    Logs.info (fun f -> f "Connecting to child process...");
+    let conn = Capnp_rpc_unix.CapTP.connect ~restore:Capnp_rpc_net.Restorer.none p in
+    (* Get the child's service object: *)
+    let calc = Capnp_rpc_unix.CapTP.bootstrap conn service_name in
+    (* Use the service: *)
+    Logs.app (fun f -> f "Sending request...");
+    let remote_mul = Calc.getOperator calc `Multiply in
+    let result = Calc.evaluate calc Calc.Expr.(Call (remote_mul, [Float 21.0; Float 2.0])) in
+    Calc.Value.read result >>= fun v ->
+    Logs.app (fun f -> f "Result: %f" v);
+    Logs.app (fun f -> f "Shutting down...");
+    Lwt.return_unit
+end
+
+module Child = struct
+  let service = Calc.local
+
+  let run socket =
+    Logging.init "child";
+    Lwt_main.run begin
+      Lwt_switch.with_switch @@ fun switch ->
+      let restore = Capnp_rpc_net.Restorer.single service_name service in
+      (* Run Cap'n Proto RPC protocol on [socket]: *)
+      let endpoint = Capnp_rpc_unix.Unix_flow.connect (Lwt_unix.of_unix_file_descr socket)
+                     |> Capnp_rpc_net.Endpoint.of_flow (module Capnp_rpc_unix.Unix_flow)
+                       ~peer_id:Capnp_rpc_net.Auth.Digest.insecure
+                       ~switch
+      in
+      let _ : Capnp_rpc_unix.CapTP.t = Capnp_rpc_unix.CapTP.connect ~restore endpoint in
+      Logs.info (fun f -> f "Serving requests...");
+      fst (Lwt.wait ()) (* Wait forever *)
+    end
+end
+
+let find_our_path prog =
+  if Sys.file_exists prog then prog
+  else (
+    (* Hack for running under "dune exec" *)
+    let prog = "./_build/default/" ^ prog in
+    if Sys.file_exists prog then prog
+    else Fmt.failwith "Can't find path to own binary %S from %S" prog (Sys.getcwd ())
+  )
+
+let () =
+  Lwt_main.run begin
+    match Sys.argv with
+    | [| prog |] ->
+      (* We are the parent. *)
+      let prog = find_our_path prog in
+      let p, c = Unix.(socketpair PF_UNIX SOCK_STREAM 0 ~cloexec:true) in
+      Unix.clear_close_on_exec c;
+      (* Run the child, passing the socket as its stdin. *)
+      let child = Lwt_process.open_process_none ~stdin:(`FD_move c) ("", [| prog; "--child" |]) in
+      Parent.run p >>= fun () ->
+      Logs.info (fun f -> f "Waiting for child to exit...");
+      child#terminate;
+      child#status >>= fun _ ->
+      Logs.info (fun f -> f "Done");
+      Lwt.return_unit
+    | [| _prog; "--child" |] ->
+      (* We are the child. Our socket is on stdin. *)
+      Child.run Unix.stdin
+    | _ ->
+      failwith "Run this command without arguments."
+  end

--- a/test-bin/calc_direct.mli
+++ b/test-bin/calc_direct.mli
@@ -1,0 +1,1 @@
+(** Run the calc server as a direct child process, connecting directly over a socketpair. *)

--- a/test-bin/dune
+++ b/test-bin/dune
@@ -1,3 +1,3 @@
-(executable
- (name calc)
+(executables
+ (names calc calc_direct)
  (libraries examples cmdliner astring logs.fmt fmt.tty capnp-rpc-unix))

--- a/test/testbed/dune
+++ b/test/testbed/dune
@@ -1,3 +1,3 @@
 (library
  (name testbed)
- (libraries astring fmt logs capnp-rpc alcotest asetmap))
+ (libraries astring fmt logs logs.fmt capnp-rpc alcotest asetmap))


### PR DESCRIPTION
The new `test-bin/calc_direct.ml` example shows how a parent process can spawn a child and communicate with it directly over a socketpair.