### PR TITLE
Don't GC imports with callbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 
 test:
 	rm -rf _build/_tests
-	dune build test/test.exe test-lwt/test_lwt.exe test-bin/calc.exe test-mirage/test_mirage.exe
+	dune build test/test.exe test-lwt/test_lwt.exe test-bin/calc.exe test-mirage/test_mirage.exe test-bin/echo/echo_bench.exe @install
 	#./_build/default/test/test.bc test core -ev 36
 	#./_build/default/test-lwt/test.bc test lwt -ev 3
 	dune build @runtest --no-buffer -j 1

--- a/test-bin/echo/echo_bench.ml
+++ b/test-bin/echo/echo_bench.ml
@@ -39,5 +39,5 @@ let () =
     Fmt.pr "Connecting to echo service at: %a@." Uri.pp_hum uri;
     let client_vat = Capnp_rpc_unix.client_only_vat () in
     let sr = Capnp_rpc_unix.Vat.import_exn client_vat uri in
-    Sturdy_ref.with_ref_exn sr run_client
+    Sturdy_ref.with_cap_exn sr run_client
   end


### PR DESCRIPTION
Normally, there are two references to an import: the application's reference and the reference that the network system uses to update it when it becomes resolved.

The reference held by the network system is a weak ref so that we can detect if the application leaks the import without releasing it, and log a warning about that.

However, it is possible that an application is only interested in an import if it becomes resolved. In this case, the application's reference to the import is only via a callback function attached to the import itself. The result is that the import may be released early (with a warning logged) and the application will find itself holding a broken reference. This is likely to happen when using `Capability.wait_until_settled`.