### PR TITLE
No SIGPIPE on Windows

### DIFF
--- a/unix/unix_flow.ml
+++ b/unix/unix_flow.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 (* Slightly rude to set signal handlers in a library, but SIGPIPE makes no sense
    in a modern application. *)
-let () = Sys.(set_signal sigpipe Signal_ignore)
+let () = if not Sys.win32 then Sys.(set_signal sigpipe Signal_ignore)
 
 type flow = {
   fd : Lwt_unix.file_descr;


### PR DESCRIPTION
Arguably mean of `Sys.set_signal` to fail when you ask it to ignore a signal which isn't available, but we are where we are!

I haven't checked, but `SIGPIPE` should be available on Cygwin, so it's intentional that this is just `Sys.win32`