### PR TITLE
Switch from "capnpc" to "capnp compile"

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Here's a suitable `dune` file to compile the schema file and then the generated 
 (rule
  (targets echo_api.ml echo_api.mli)
  (deps    echo_api.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))
 ```
 
 The service is now usable:
@@ -541,7 +541,7 @@ Edit the `dune` file to build a client and server:
 (rule
  (targets echo_api.ml echo_api.mli)
  (deps    echo_api.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))
 ```
 
 Here's a suitable `server.ml`:

--- a/capnp-rpc-lwt/dune
+++ b/capnp-rpc-lwt/dune
@@ -8,9 +8,9 @@
 (rule
  (targets rpc_schema.ml rpc_schema.mli)
  (deps rpc_schema.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))
 
 (rule
  (targets persistent.ml persistent.mli)
  (deps persistent.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))

--- a/examples/dune
+++ b/examples/dune
@@ -6,9 +6,9 @@
 (rule
  (targets test_api.ml test_api.mli)
  (deps test_api.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))
 
 (rule
  (targets calculator.ml calculator.mli)
  (deps calculator.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))

--- a/test-bin/echo/dune
+++ b/test-bin/echo/dune
@@ -6,4 +6,4 @@
 (rule
  (targets echo_api.ml echo_api.mli)
  (deps    echo_api.capnp)
- (action (run capnpc -o %{bin:capnpc-ocaml} %{deps})))
+ (action (run capnp compile -o %{bin:capnpc-ocaml} %{deps})))


### PR DESCRIPTION
`capnpc` seems to be the old name, and isn't present on Windows.