### PR TITLE
Set TCP_KEEPIDLE=60 if possible

### DIFF
--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -17,6 +17,7 @@ depends: [
   "astring"
   "fmt" {>= "0.8.4"}
   "logs"
+  "extunix"
   "base64" {>= "3.0.0"}
   "dune" {>= "2.0"}
   "alcotest-lwt" {with-test & >= "1.0.1"}

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name capnp_rpc_unix)
  (public_name capnp-rpc-unix)
  (libraries lwt.unix astring capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs
-   mirage-crypto-rng.unix cmdliner cstruct-lwt))
+   mirage-crypto-rng.unix cmdliner cstruct-lwt extunix))

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -68,6 +68,14 @@ let addr_of_host host =
     else
       addr.Unix.h_addr_list.(0)
 
+let have_tcp_keepidle = ExtUnix.All.have_sockopt_int ExtUnix.All.TCP_KEEPIDLE
+
+let try_set_keepalive_idle socket i =
+  if have_tcp_keepidle then (
+    let socket = Lwt_unix.unix_file_descr socket in
+    ExtUnix.All.setsockopt_int socket ExtUnix.All.TCP_KEEPIDLE i
+  )
+
 let connect_socket = function
   | `Unix path ->
     Logs.info (fun f -> f "Connecting to %S..." path);
@@ -81,6 +89,7 @@ let connect_socket = function
     Lwt.catch
       (fun () ->
          Lwt_unix.setsockopt socket Unix.SO_KEEPALIVE true;
+         try_set_keepalive_idle socket 60;
          Lwt_unix.connect socket (Unix.ADDR_INET (addr_of_host host, port)) >|= fun () ->
          socket
       )


### PR DESCRIPTION
Cap'n Proto connections tend to be long lived and we therefore turn on the `SO_KEEPALIVE` option. However, the default keepalive timeout of 2 hours is much too long for some networks. In particular, Docker's libnetwork silently drops idle connections after about 10 minutes.

The OCaml standard library doesn't provide a way to control the timeout, but extunix does.