### PR TITLE
Add API for managing persistent collections

### DIFF
--- a/capnp-rpc-lwt/persistence.ml
+++ b/capnp-rpc-lwt/persistence.ml
@@ -54,3 +54,23 @@ let save_exn cap =
   save cap >>= function
   | Error (`Capnp e) -> Lwt.fail_with (Fmt.to_to_string Capnp_rpc.Error.pp e)
   | Ok x -> Lwt.return x
+
+class type ['a, 'args] backend =
+  object
+    method add : 'args -> 'a Capability.t Lwt.t
+    method remove : string -> unit
+    method list : (string * 'args) list
+    method find_all : 'args -> string list
+  end
+
+type ('a, 'args) collection = {
+  backend : ('a, 'args) backend;
+}
+
+type id = string
+
+let collection backend = { backend }
+let add t args = t.backend#add args
+let remove t id = t.backend#remove id
+let list t = t.backend#list
+let find_all t args = t.backend#find_all args

--- a/capnp-rpc-net/capnp_rpc_net.ml
+++ b/capnp-rpc-net/capnp_rpc_net.ml
@@ -24,3 +24,4 @@ module Persistence = Persistence
 module Two_party_network = Two_party_network
 module Auth = Auth
 module Tls_wrapper = Tls_wrapper
+module Mock = Mock

--- a/capnp-rpc-net/mock.ml
+++ b/capnp-rpc-net/mock.ml
@@ -1,0 +1,86 @@
+open Lwt
+open Capnp_rpc_lwt
+
+module Persistent_store (T : sig type args end) = struct
+  module Secret = Restorer.Id
+  module Collection_map = Map.Make(String)
+
+  type load_fn =
+      Load : (validate:(unit -> bool) ->
+              sturdy_ref:'a Sturdy_ref.t ->
+              T.args ->
+              Restorer.resolution Lwt.t) -> load_fn [@@unboxed]
+
+  module Loader = struct
+
+    (* Note: we could simplify this by removing [collections], or even [db] and
+       just keeping everything in the table. However, this code is intended to
+       be used as a template for writing real stores, which will typically need
+       some unique string to identify collections across restarts. *)
+    type t = {
+      make_sturdy_uri : Secret.t -> Uri.t;
+      db : (string, string * T.args) Hashtbl.t;         (* digest -> (collection, args) *)
+      mutable collections : load_fn Collection_map.t;
+    }
+
+    let create ~make_sturdy_uri () =
+      let db = Hashtbl.create 10 in
+      let collections = Collection_map.empty in
+      { make_sturdy_uri; db; collections }
+
+    let hash _ = `SHA256
+
+    let validate t digest () =
+      Hashtbl.mem t.db digest
+
+    let load t self digest =
+      match Hashtbl.find_opt t.db digest with
+      | None -> Lwt.return Restorer.unknown_service_id
+      | Some (cname, data) ->
+        match Collection_map.find_opt cname t.collections with
+        | None -> Fmt.failwith "Unregistered collection %S found in database!" cname
+        | Some (Load fn) -> fn ~validate:(validate t digest) ~sturdy_ref:(Capnp_rpc_lwt.Sturdy_ref.cast self) data
+
+    let make_sturdy t = t.make_sturdy_uri
+  end
+
+  type t = {
+    loader : Loader.t;
+    table : Restorer.Table.t;
+    restorer : Restorer.t;
+  }
+
+  let create ~make_sturdy_uri () =
+    let loader = Loader.create ~make_sturdy_uri () in
+    let table = Restorer.Table.of_loader (module Loader) loader in
+    let restorer = Restorer.of_table table in
+    { loader; table; restorer }, restorer
+
+  let register_collection t name load =
+    let loader = t.loader in
+    if Collection_map.mem name loader.collections then Fmt.invalid_arg "Collection %S already registered!" name;
+    loader.collections <- Collection_map.add name (Load load) loader.collections;
+    Persistence.collection @@ object (self : ('a, 'args) Persistence.backend)
+      method add args =
+        let secret = Secret.generate () in
+        let digest = Secret.digest (Loader.hash ()) secret in
+        Hashtbl.add loader.db digest (name, args);
+        Restorer.restore t.restorer secret >|= function
+        | Ok cap -> cap
+        | Error ex -> Capability.broken ex
+
+      method remove digest =
+        if not (Hashtbl.mem loader.db digest) then raise Not_found;
+        Hashtbl.remove loader.db digest;
+        Restorer.Table.remove_digest t.table digest
+
+      method list =
+        Hashtbl.fold (fun k (n, args) acc -> if n = name then (k, args) :: acc else acc) loader.db []
+
+      method find_all args =
+        List.filter_map (fun (k, a) -> if a = args then Some k else None) self#list
+    end
+
+  let table t = t.table
+  let restorer t = t.restorer
+end

--- a/capnp-rpc-net/restorer.ml
+++ b/capnp-rpc-net/restorer.ml
@@ -158,13 +158,14 @@ module Table = struct
     | Manual cap -> Core_types.dec_ref cap;
     | Cached _ -> ()
 
-  let remove t id =
-    let id = hash t id in
-    match Hashtbl.find t.cache id with
+  let remove_digest t digest =
+    match Hashtbl.find t.cache digest with
     | exception Not_found -> failwith "Service ID not in restorer table"
     | value ->
       release value;
-      Hashtbl.remove t.cache id
+      Hashtbl.remove t.cache digest
+
+  let remove t id = remove_digest t (hash t id)
 
   let clear t =
     Hashtbl.iter (fun _ v -> release v) t.cache;


### PR DESCRIPTION
This allows libraries to support persistence without forcing a particular backend. This should allow composing services from different libraries more easily.

This also adds `Capnp_rpc_net.Mock.Persistent_store`, which can be used for unit-tests, and would also make a good template for writing a real store.