### PR TITLE
depend on tcpip.unix

### DIFF
--- a/test-mirage/dune
+++ b/test-mirage/dune
@@ -3,4 +3,4 @@
  (package capnp-rpc-mirage)
  (libraries io-page-unix capnp-rpc-lwt capnp-rpc-mirage alcotest-lwt examples
    logs.fmt testbed tcpip.ipv4 tcpip.stack-direct mirage-vnetif ethernet
-   arp-mirage tcpip.tcp tcpip.icmpv4 mirage-crypto-rng.unix))
+   arp-mirage tcpip.tcp tcpip.icmpv4 tcpip.unix mirage-crypto-rng.unix))


### PR DESCRIPTION
since tcpip 6.0.0, the tcpip.unix sublibrary provides the checksum stubs -- no longer tcpip