### PR TITLE
use Mirage_crypto_rng_lwt.initialize instead of Mirage_crypto_rng_unix.initialize

### DIFF
--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "capnp" {>= "3.1.0"}
   "capnp-rpc-net" {= version}
   "astring"
@@ -24,6 +24,7 @@ depends: [
   "io-page-unix" {with-test}
   "tcpip" {>= "5.0.0" & with-test}
   "mirage-vnetif" {with-test}
+  "mirage-crypto-rng" {>= "0.7.0" & with-test}
   "dune" {>= "2.0"}
 ]
 build: [

--- a/capnp-rpc-net.opam
+++ b/capnp-rpc-net.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "conf-capnproto" {build}
   "capnp" {>= "3.4.0"}
   "capnp-rpc" {= version}
@@ -30,6 +30,8 @@ depends: [
   "x509" {>= "0.11.0"}
   "tls-mirage"
   "dune" {>= "2.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/capnp-rpc-net/auth.mli
+++ b/capnp-rpc-net/auth.mli
@@ -56,7 +56,7 @@ module Secret_key : sig
   val generate : unit -> t
   (** [generate ()] is a fresh secret key.
       You must call the relevant entropy initialization function
-      (e.g. {!Mirage_crypto_rng_unix.initialize}) before using this, or it
+      (e.g. {!Mirage_crypto_rng_lwt.initialize}) before using this, or it
       will raise an error if you forget. *)
 
   val digest : ?hash:hash -> t -> Digest.t

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "capnp-rpc-net" {= version}
   "cmdliner"
   "cstruct-lwt"
@@ -21,6 +21,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "dune" {>= "2.0"}
   "alcotest-lwt" {with-test & >= "1.0.1"}
+  "mirage-crypto-rng" {>= "0.7.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/test-mirage/dune
+++ b/test-mirage/dune
@@ -3,4 +3,4 @@
  (package capnp-rpc-mirage)
  (libraries io-page-unix capnp-rpc-lwt capnp-rpc-mirage alcotest-lwt examples
    logs.fmt testbed tcpip.ipv4 tcpip.stack-direct mirage-vnetif ethernet
-   arp-mirage tcpip.tcp tcpip.icmpv4 tcpip.unix mirage-crypto-rng.unix))
+   arp-mirage tcpip.tcp tcpip.icmpv4 tcpip.unix mirage-crypto-rng.lwt))

--- a/test-mirage/test_mirage.ml
+++ b/test-mirage/test_mirage.ml
@@ -65,7 +65,7 @@ let create_iface network cidr =
   let dns = Mirage.Network.Dns.create stack in
   Mirage.network ~dns stack
 
-let () = Mirage_crypto_rng_unix.initialize ()
+let () = Mirage_crypto_rng_lwt.initialize ()
 let server_key = Auth.Secret_key.generate ()
 let client_key = Auth.Secret_key.generate ()
 

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 module Log = Capnp_rpc.Debug.Log
 module Unix_flow = Unix_flow
 
-let () = Mirage_crypto_rng_unix.initialize ()
+let () = Mirage_crypto_rng_lwt.initialize ()
 
 type flow = Unix_flow.flow
 

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name capnp_rpc_unix)
  (public_name capnp-rpc-unix)
  (libraries lwt.unix astring capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs
-   mirage-crypto-rng.unix cmdliner cstruct-lwt extunix))
+   mirage-crypto-rng.lwt cmdliner cstruct-lwt extunix))


### PR DESCRIPTION
the former periodically feeds more entropy to the RNG, while the latter only
seeds the RNG once.

this bumps the lower bound of ocaml to 4.08 (since mirage-crypto 0.7.0+ is required).