### PR TITLE
Prevent crash if ExtUnix wasn't build with sockopt

### DIFF
--- a/unix/network.ml
+++ b/unix/network.ml
@@ -68,7 +68,9 @@ let addr_of_host host =
     else
       addr.Unix.h_addr_list.(0)
 
-let have_tcp_keepidle = ExtUnix.All.have_sockopt_int ExtUnix.All.TCP_KEEPIDLE
+let have_tcp_keepidle =
+  try ExtUnix.All.have_sockopt_int ExtUnix.All.TCP_KEEPIDLE
+  with ExtUnix.All.Not_available _ -> false
 
 let try_set_keepalive_idle socket i =
   if have_tcp_keepidle then (


### PR DESCRIPTION
If ExtUnix isn't build with sockopt then the symbol `have_sockopt_int`
isn't available and an exception is raised.

This may be the case on some environments (e.g., ExtUnix build with
mingw-w64). It is a workaround until support for TCP_KEEPIDLE is added
for these environments (e.g., using Winsock instead).