### PR TITLE
Include version number in opam license field

### DIFF
--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -6,7 +6,7 @@ This package provides a version of the Cap'n Proto RPC system using the Cap'n
 Proto serialisation format and Lwt for concurrency."""
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
-license: "Apache"
+license: "Apache-2.0"
 homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -5,7 +5,7 @@ description:
   "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
-license: "Apache"
+license: "Apache-2.0"
 homepage: "https://github.com/mirage/capnp-rpc"
 doc: "https://mirage.github.io/capnp-rpc/"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"

--- a/capnp-rpc-net.opam
+++ b/capnp-rpc-net.opam
@@ -6,7 +6,7 @@ This package provides support for using Cap'n Proto services over a network,
 optionally using TLS."""
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
-license: "Apache"
+license: "Apache-2.0"
 homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -5,7 +5,7 @@ description:
   "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
-license: "Apache"
+license: "Apache-2.0"
 homepage: "https://github.com/mirage/capnp-rpc"
 doc: "https://mirage.github.io/capnp-rpc/"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"

--- a/capnp-rpc.opam
+++ b/capnp-rpc.opam
@@ -7,7 +7,7 @@ Users will normally want to use `capnp-rpc-lwt` and, in most cases,
 `capnp-rpc-unix` rather than using this one directly."""
 maintainer: "Thomas Leonard <talex5@gmail.com>"
 authors: "Thomas Leonard <talex5@gmail.com>"
-license: "Apache"
+license: "Apache-2.0"
 homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"


### PR DESCRIPTION
The opam-repository linter wants it like this.