### PR TITLE
Also configure TCP keep-alives for incoming connections

### DIFF
--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -16,7 +16,7 @@ depends: [
   "astring" {with-test}
   "fmt"
   "logs"
-  "dns-client" {>= "4.5.0"}
+  "dns-client" {>= "4.5.0" & < "5.0.0"}
   "tls-mirage"
   "mirage-stack" {>= "2.0.0"}
   "arp-mirage" {with-test}

--- a/capnp-rpc-net.opam
+++ b/capnp-rpc-net.opam
@@ -27,7 +27,7 @@ depends: [
   "ptime"
   "prometheus" {>= "0.5"}
   "asn1-combinators" {>= "0.2.0"}
-  "x509" {>= "0.11.0"}
+  "x509" {>= "0.11.0" & < "0.12.0"}
   "tls-mirage"
   "dune" {>= "2.0"}
   "mirage-crypto"

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -199,6 +199,8 @@ let serve ?switch ?tags ?restore config =
     | `TCP (host, port) ->
       let socket = Unix.(socket PF_INET SOCK_STREAM 0) in
       Unix.setsockopt socket Unix.SO_REUSEADDR true;
+      Unix.setsockopt socket Unix.SO_KEEPALIVE true;
+      Keepalive.try_set_idle socket 60;
       Unix.bind socket (Unix.ADDR_INET (addr_of_host host, port));
       socket
   in

--- a/unix/keepalive.ml
+++ b/unix/keepalive.ml
@@ -1,0 +1,8 @@
+let have_tcp_keepidle =
+  try ExtUnix.All.have_sockopt_int ExtUnix.All.TCP_KEEPIDLE
+  with ExtUnix.All.Not_available _ -> false
+
+let try_set_idle socket i =
+  if have_tcp_keepidle then (
+    ExtUnix.All.setsockopt_int socket ExtUnix.All.TCP_KEEPIDLE i
+  )


### PR DESCRIPTION
This is needed when the client machine crashes without resetting the connection.