### PR TITLE
Add `Service.fail_lwt` convenience function

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -252,6 +252,12 @@ module Service : sig
 
   val fail : ?ty:Capnp_rpc.Exception.ty -> ('a, Format.formatter, unit, 'b StructRef.t) format4 -> 'a
   (** [fail msg] is an exception with reason [msg]. *)
+
+  val fail_lwt :
+    ?ty:Capnp_rpc.Exception.ty ->
+    ('a, Format.formatter, unit, (_, [> `Capnp of Capnp_rpc.Error.t]) Lwt_result.t) format4 ->
+     'a
+  (** [fail_lwt msg] is like [fail msg], but can be used with [return_lwt]. *)
 end
 
 (**/**)

--- a/capnp-rpc-lwt/service.ml
+++ b/capnp-rpc-lwt/service.ml
@@ -62,8 +62,8 @@ let return_empty () =
   return @@ Response.create_empty ()
 
 (* A convenient way to implement a simple blocking local function, where
-   pipelining is not supported (further messages will be queued up at this
-   host until it returns). *)
+   pipelining is not supported (messages sent to the result promise will be
+   queued up at this host until it returns). *)
 let return_lwt fn =
   let result, resolver = Local_struct_promise.make () in
   Lwt.async (fun () ->
@@ -81,3 +81,7 @@ let return_lwt fn =
   result
 
 let fail = Core_types.fail
+
+let fail_lwt ?ty fmt =
+  fmt |> Fmt.kstr @@ fun msg ->
+  Lwt_result.fail (`Capnp (`Exception (Capnp_rpc.Exception.v ?ty msg)))


### PR DESCRIPTION
Allows replacing e.g.
```ocaml
Lwt_result.fail (`Capnp (Capnp_rpc.Error.exn "Unknown client %S" name))
```
with
```ocaml
Service.fail_lwt "Unknown client %S" name
```