### PR TITLE
Remove debug information from `call_for_value_exn` errors

### DIFF
--- a/capnp-rpc-lwt/capability.ml
+++ b/capnp-rpc-lwt/capability.ml
@@ -86,11 +86,11 @@ let call_for_value_exn cap m req =
   call_for_value cap m req >>= function
   | Ok x -> Lwt.return x
   | Error (`Capnp e) ->
-    let msg = Fmt.strf "Error calling %t(%a): %a"
-        cap#pp
-        Capnp.RPC.MethodID.pp m
-        Capnp_rpc.Error.pp e in
-    Lwt.fail (Failure msg)
+    Log.debug (fun f -> f "Error calling %t(%a): %a"
+                  cap#pp
+                  Capnp.RPC.MethodID.pp m
+                  Capnp_rpc.Error.pp e);
+    Fmt.failwith "%a: %a" Capnp.RPC.MethodID.pp m Capnp_rpc.Error.pp e
 
 let call_for_unit cap m req =
   call_for_value cap m req >|= function


### PR DESCRIPTION
Before:
```ocaml
Error calling field(8) -> switchable(18) (unset, rc=1) -> far-ref(17) -> i2(Value.read): Failed: test
```
After:
```ocaml
Value.read: Failed: test
```
The hidden information is now logged (at debug level) instead.