### PR TITLE
Replace `wait_until_settled` with safer `await_settled`

### DIFF
--- a/capnp-rpc-lwt/capability.ml
+++ b/capnp-rpc-lwt/capability.ml
@@ -25,7 +25,7 @@ let when_broken = Core_types.when_broken
 let when_released (x:Core_types.cap) f = x#when_released f
 let problem x = x#problem
 
-let wait_until_settled x =
+let wait_until_settled (x : _ t) =
   let result, set_result = Lwt.wait () in
   let rec aux x =
     if x#blocker = None then (
@@ -39,6 +39,18 @@ let wait_until_settled x =
   in
   aux x;
   result
+
+let await_settled t =
+  wait_until_settled t >|= fun () ->
+  match problem t with
+  | None -> Ok ()
+  | Some ex -> Error ex
+
+let await_settled_exn t =
+  wait_until_settled t >|= fun () ->
+  match problem t with
+  | None -> ()
+  | Some e -> Fmt.failwith "%a" Capnp_rpc.Exception.pp e
 
 let equal a b =
   match a#blocker, b#blocker with

--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -55,12 +55,21 @@ module Capability : sig
       believed to be healthy. Once a capability is broken, it will never
       work again and any calls made on it will fail with exception [ex]. *)
 
-  val wait_until_settled : 'a t -> unit Lwt.t
-  (** [wait_until_settled x] resolves once [x] is a "settled" (non-promise) reference.
-      If [x] is a near, far or broken reference, this returns immediately.
+  val await_settled : 'a t -> (unit, Capnp_rpc.Exception.t) Lwt_result.t
+  (** [await_settled t] resolves once [t] is a "settled" (non-promise) reference.
+      If [t] is a near, far or broken reference, this returns immediately.
       If it is currently a local or remote promise, it waits until it isn't.
-      [wait_until_settled] takes ownership of [x] until it returns (you must not
-      [dec_ref] it before then). *)
+      [wait_until_settled] takes ownership of [t] until it returns (you must not
+      [dec_ref] it before then).
+      @return [Ok ()] on success, or [Error _] if [t] failed.
+      @since 1.2 *)
+
+  val await_settled_exn : 'a t -> unit Lwt.t
+  (** Like [await_settled], but raises an exception on error.
+      @since 1.2 *)
+
+  val wait_until_settled : 'a t -> unit Lwt.t
+  [@@deprecated "Use await_settled instead."]
 
   val equal : 'a t -> 'a t -> (bool, [`Unsettled]) result
   (** [equal a b] indicates whether [a] and [b] designate the same settled service.


### PR DESCRIPTION
`wait_until_settled` makes it too easy to ignore errors.