### PR TITLE
Add OCaml 4.14 support

### DIFF
--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -19,6 +19,7 @@ depends: [
   "dns-client" {>= "6.0.0"}
   "tls-mirage"
   "mirage-stack" {>= "2.2.0"}
+  "mirage-protocols" {>= "6.0.0"}
   "arp" {>= "2.3.0" & with-test}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}

--- a/capnp-rpc/struct_proxy.ml
+++ b/capnp-rpc/struct_proxy.ml
@@ -170,7 +170,10 @@ module Make (C : S.CORE_TYPES) = struct
         | PromiseField p -> p.sr#field_sealed_dispatch p.path brand
     end
 
-  class virtual ['promise] t init = object (self : #C.struct_ref)
+  class virtual ['promise] t init = object (self : 'self)
+    constraint 'self = #C.struct_ref
+    constraint 'self = #C.struct_resolver
+
     val mutable state =
       Unresolved {
         target = init;

--- a/mirage/capnp_rpc_mirage.ml
+++ b/mirage/capnp_rpc_mirage.ml
@@ -37,7 +37,7 @@ module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) 
     in
     match listen_address with
     | `TCP port ->
-      Stack.listen_tcp t.stack ~port (fun flow ->
+      Stack.TCP.listen (Stack.tcp t.stack) ~port (fun flow ->
           Log.info (fun f -> f ?tags "Accepting new connection");
           let secret_key = if serve_tls then Some (Vat_config.secret_key config) else None in
           Lwt.async (fun () -> handle_connection ?tags ~secret_key vat flow);

--- a/test-mirage/test_mirage.ml
+++ b/test-mirage/test_mirage.ml
@@ -37,7 +37,7 @@ module Stack = struct
   module Icmp = Icmpv4.Make(I4)
   include Tcpip_stack_direct.MakeV4V6(Time)(Random)(V)(E)(A)(I)(Icmp)(U)(T)
 
-  let create_network () = B.create ~use_async_readers:true ~yield:Lwt_unix.yield ()
+  let create_network () = B.create ~use_async_readers:true ~yield:Lwt.pause ()
 
   let create_interface backend cidr =
     V.connect backend >>= fun v ->


### PR DESCRIPTION
This fixes issue with OCaml 4.14 whose handling of intersection between classes and subtyping in the type-checker has changed from previous version. See https://github.com/ocaml/ocaml/issues/10773

Fix from @octachron