### PR TITLE
remove tcpip.unix dependency from dune -- which has been deprecated since tcpip 6.1.0

### DIFF
--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -24,7 +24,7 @@ depends: [
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {>= "6.0.0" & with-test}
+  "tcpip" {>= "6.1.0" & with-test}
   "mirage-vnetif" {with-test}
   "mirage-crypto-rng" {>= "0.7.0" & with-test}
   "dune" {>= "2.0"}

--- a/test-mirage/dune
+++ b/test-mirage/dune
@@ -3,4 +3,4 @@
  (package capnp-rpc-mirage)
  (libraries io-page-unix capnp-rpc-lwt capnp-rpc-mirage alcotest-lwt examples
    logs.fmt testbed tcpip.ipv4 tcpip.ipv6 tcpip.stack-direct mirage-vnetif ethernet
-   arp.mirage tcpip.tcp tcpip.icmpv4 tcpip.unix mirage-crypto-rng.lwt))
+   arp.mirage tcpip.tcp tcpip.icmpv4 mirage-crypto-rng.lwt))


### PR DESCRIPTION
this makes it also compatible with tcpip 7.0.0 (that removed tcpip.unix)