### PR TITLE
Switch from mirage-{stack,protocols} to tcpip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Main workflow
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+        ocaml-compiler:
+          - 4.13.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install . --deps-only --with-test
+
+      - run: opam exec -- dune build
+
+      - run: opam exec -- dune runtest

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -13,23 +13,21 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "capnp" {>= "3.1.0"}
   "capnp-rpc-net" {= version}
-  "astring" {with-test}
   "fmt" {>= "0.8.7"}
   "logs"
   "dns-client" {>= "6.0.0"}
   "tls-mirage"
-  "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "6.0.0"}
-  "arp" {>= "2.3.0" & with-test}
+  "tcpip" {>= "7.0.0"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
+  "arp" {>= "3.0.0" & with-test}
+  "asetmap" {with-test}
+  "astring" {with-test}
+  "ethernet" {>= "3.0.0" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {>= "6.1.0" & with-test}
   "mirage-vnetif" {with-test}
   "mirage-crypto-rng" {>= "0.7.0" & with-test}
   "dune" {>= "2.0"}
-  "asetmap" {with-test}
-  "ethernet" {>= "2.2.0" & with-test}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/mirage/capnp_rpc_mirage.ml
+++ b/mirage/capnp_rpc_mirage.ml
@@ -4,7 +4,7 @@ module Log = Capnp_rpc.Debug.Log
 
 module Location = Network.Location
 
-module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Mirage_stack.V4V6) = struct
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Tcpip.Stack.V4V6) = struct
 
   module Dns = Dns_client_mirage.Make(R)(T)(M)(P)(Stack)
   module Network = Network.Make(R)(T)(M)(P)(Stack)

--- a/mirage/capnp_rpc_mirage.mli
+++ b/mirage/capnp_rpc_mirage.mli
@@ -4,7 +4,7 @@ open Capnp_rpc_net
 
 module Location = Network.Location
 
-module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Mirage_stack.V4V6) : sig
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Tcpip.Stack.V4V6) : sig
   include Capnp_rpc_net.VAT_NETWORK with
     type flow = Stack.TCP.flow and
     module Network = Network.Make(R)(T)(M)(P)(Stack)

--- a/mirage/dune
+++ b/mirage/dune
@@ -1,4 +1,4 @@
 (library
  (name capnp_rpc_mirage)
  (public_name capnp-rpc-mirage)
- (libraries capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs mirage-stack dns-client.mirage))
+ (libraries capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs dns-client.mirage tcpip))

--- a/mirage/network.ml
+++ b/mirage/network.ml
@@ -17,7 +17,7 @@ module Location = struct
   let equal = ( = )
 end
 
-module Make  (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Mirage_stack.V4V6) = struct
+module Make  (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Tcpip.Stack.V4V6) = struct
 
   module Dns = Dns_client_mirage.Make(R)(T)(M)(P)(Stack)
   module Tls_wrapper = Capnp_rpc_net.Tls_wrapper.Make(Stack.TCP)

--- a/mirage/network.mli
+++ b/mirage/network.mli
@@ -13,7 +13,7 @@ module Location : sig
   (** [tcp ~host port] is [`TCP (host, port)]. *)
 end
 
-module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Mirage_stack.V4V6) : sig
+module Make (R : Mirage_random.S) (T : Mirage_time.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (Stack : Tcpip.Stack.V4V6) : sig
 
   module Dns : module type of Dns_client_mirage.Make(R)(T)(M)(P)(Stack)
 


### PR DESCRIPTION
mirage-stack and mirage-protocols are deprecated, depend on recent version of tcpip, arp, ethernet instead.
Add setup-ocaml for foolproof. 