### PR TITLE
Disable CI on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - windows-latest
+          #- windows-latest
         ocaml-compiler:
           - 4.13.x
 


### PR DESCRIPTION
It has never worked. Currently failing with:

    [ERROR] No solution for capnp-rpc-lwt & capnp-rpc-mirage & capnp-rpc-net & capnp-rpc-unix & capnp-rpc: The following dependencies couldn't be met:
            - capnp-rpc-unix -> cmdliner >= 1.1.0
                no matching version

/cc @MisterDA

Can re-enable once someone makes a PR that passes.