### PR TITLE
Don't warn on Unix.ENOTCONN

### DIFF
--- a/unix/unix_flow.ml
+++ b/unix/unix_flow.ml
@@ -49,6 +49,7 @@ let write t buf =
     (fun () -> aux buf)
     (function
       | Unix.Unix_error (Unix.ECONNRESET, _, _)
+      | Unix.Unix_error (Unix.ENOTCONN, _, _)           (* macos *)
       | Unix.Unix_error (Unix.EPIPE, _, _) -> Lwt.return @@ Error `Closed
       | ex -> Lwt.return @@ Error (`Exception ex))
 


### PR DESCRIPTION
Seen in CI on macos. Treat this the same as `EPIPE`.