### PR TITLE
Handle vat shutdown while connecting

### DIFF
--- a/test-lwt/test_lwt.ml
+++ b/test-lwt/test_lwt.ml
@@ -527,8 +527,9 @@ let test_parallel_fails switch =
   service >>= fun service ->
   service2 >>= fun service2 ->
   Lwt_switch.turn_off cs.server_switch >>= fun () ->
-  Capability.await_settled_exn service >>= fun () ->
-  Capability.await_settled_exn service2 >>= fun () ->
+  let p, r = Lwt.wait () in
+  Capability.when_broken (Lwt.wakeup r) service2;
+  p >>= fun _ ->
   Alcotest.check cap "Shared failure" service service2;
   Capability.dec_ref service;
   Capability.dec_ref service2;


### PR DESCRIPTION
When a vat is shut down it ends all registered connections and stops accepting new ones. However, if a connection was in progress (e.g. doing the TLS handshake but not yet registered) then we would miss it.

The `test_parallel_fails` test got upgraded to the stricter `await_settled_exn` in #233, which was wrong but that wasn't detected due to this bug.