### PR TITLE
update to mirage-crypto-rng 0.11 and dns 7.0.0 API changes

### DIFF
--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -15,7 +15,7 @@ depends: [
   "capnp-rpc-net" {= version}
   "fmt" {>= "0.8.7"}
   "logs"
-  "dns-client" {>= "6.0.0"}
+  "dns-client-mirage" {>= "7.0.0"}
   "tls-mirage"
   "tcpip" {>= "7.0.0"}
   "alcotest" {>= "1.0.1" & with-test}

--- a/capnp-rpc-mirage.opam
+++ b/capnp-rpc-mirage.opam
@@ -26,7 +26,7 @@ depends: [
   "ethernet" {>= "3.0.0" & with-test}
   "io-page-unix" {with-test}
   "mirage-vnetif" {with-test}
-  "mirage-crypto-rng" {>= "0.7.0" & with-test}
+  "mirage-crypto-rng-lwt" {>= "0.11.0" & with-test}
   "dune" {>= "3.0"}
 ]
 build: [

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "3.0"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" { >= "1.0.1" & with-test}
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
   "mdx" {with-test}
   "lwt"
   "asetmap" {with-test}

--- a/mirage/dune
+++ b/mirage/dune
@@ -1,4 +1,4 @@
 (library
  (name capnp_rpc_mirage)
  (public_name capnp-rpc-mirage)
- (libraries capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs dns-client.mirage tcpip))
+ (libraries capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs dns-client-mirage tcpip))

--- a/test-mirage/dune
+++ b/test-mirage/dune
@@ -3,4 +3,4 @@
  (package capnp-rpc-mirage)
  (libraries io-page-unix capnp-rpc-lwt capnp-rpc-mirage alcotest-lwt testlib
    logs.fmt testbed tcpip.ipv4 tcpip.ipv6 tcpip.stack-direct mirage-vnetif ethernet
-   arp.mirage tcpip.tcp tcpip.icmpv4 mirage-crypto-rng.lwt))
+   arp.mirage tcpip.tcp tcpip.icmpv4 mirage-crypto-rng-lwt))

--- a/test-mirage/test_mirage.ml
+++ b/test-mirage/test_mirage.ml
@@ -75,7 +75,7 @@ let create_iface network cidr =
   let dns = Mirage.Network.Dns.create stack in
   Mirage.network ~dns stack
 
-let () = Mirage_crypto_rng_lwt.initialize ()
+let () = Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna)
 let server_key = Auth.Secret_key.generate ()
 let client_key = Auth.Secret_key.generate ()
 

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 module Log = Capnp_rpc.Debug.Log
 module Unix_flow = Unix_flow
 
-let () = Mirage_crypto_rng_lwt.initialize ()
+let () = Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna)
 
 type flow = Unix_flow.flow
 

--- a/unix/dune
+++ b/unix/dune
@@ -2,4 +2,4 @@
  (name capnp_rpc_unix)
  (public_name capnp-rpc-unix)
  (libraries lwt.unix astring capnp-rpc-lwt capnp-rpc-net capnp-rpc fmt logs
-   mirage-crypto-rng.lwt cmdliner cstruct-lwt extunix))
+   mirage-crypto-rng-lwt cmdliner cstruct-lwt extunix))


### PR DESCRIPTION
requires https://github.com/ocaml/opam-repository/pull/23332 to be merged