### PR TITLE
gha: pin compiler and caml-config.2 on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          ocaml-compiler: ocaml-variants.4.14.0+mingw64c,ocaml-config.2
           opam-repositories: |
             default: https://github.com/fdopen/opam-repository-mingw.git#opam2
             opam: https://github.com/ocaml/opam-repository.git


### PR DESCRIPTION
A temporary hack to make sure `ocaml-config.2` is installed, from opam-repository-mingw, and not `ocaml-config.3` from opam-repository. When we switch to opam-repository and upstream opam for Windows, this can be reverted.