### PR TITLE
Disable opam tests on macos

### DIFF
--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -32,6 +32,6 @@ conflicts: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 dev-repo: "git+https://github.com/mirage/capnp-rpc.git"


### PR DESCRIPTION
opam's macos sandbox prevents tests from running.

Suggested by @kit-ty-kate.