### PR TITLE
Opam doesn't allow with-test in conflicts

### DIFF
--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -28,7 +28,7 @@ depends: [
   "asetmap" {with-test}
 ]
 conflicts: [
-  "jbuilder" {with-test}
+  "jbuilder"
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
So, we have to conflict with jbuilder in all cases (which isn't very good, but there aren't many such packages left).

Suggested by @kit-ty-kate.