### PR TITLE
Update GH actions to OCaml 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
           - macos-latest
           - windows-latest
         ocaml-compiler:
-          - 4.14.x
+          - 5
 
     runs-on: ${{ matrix.os }}
 
@@ -25,17 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        if: runner.os == 'Windows'
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          opam-repositories: |
-            opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
-            default: https://github.com/ocaml/opam-repository.git
-
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        if: runner.os != 'Windows'
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
@@ -44,6 +34,7 @@ jobs:
         shell: bash
         env:
           CAPNP_VERSION: 1.0.1
+          SHELLOPTS: igncr
         run: |
           curl -LO https://capnproto.org/capnproto-c++-win32-$CAPNP_VERSION.zip && \
           unzip -j capnproto-c++-win32-$CAPNP_VERSION.zip capnproto-tools-win32-$CAPNP_VERSION/capnp.exe -d /usr/bin


### PR DESCRIPTION
Test with OCaml 5.

Updated setup-ocaml to v3.

Had to add `SHELLOPTS: igncr`, to fix:

    line 1: $'\r': command not found

See https://github.com/ocaml/setup-ocaml/issues/815#issuecomment-2201506179

Removed opam-repository-mingw.git#sunset. It doesn't seem to be needed now, and was causing ocamlfind to fail to install.