### PR TITLE
Support ipv6 hosts

### DIFF
--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -171,8 +171,8 @@ let handle_connection ?tags ~secret_key vat client =
 let addr_of_host host =
   match Unix.getaddrinfo host "" [Unix.AI_SOCKTYPE Unix.SOCK_STREAM] with
   | {ai_addr = ADDR_INET(addr, _) ; _} :: _ -> addr
+  | {ai_addr = ADDR_UNIX _ ; _} :: _ -> Capnp_rpc.Debug.failf "Unknown host %S" host
   | [] -> Capnp_rpc.Debug.failf "No addresses found for host name %S" host
-  | _ -> Capnp_rpc.Debug.failf "Unknown host %S" host
 
 let serve ?switch ?tags ?restore config =
   let {Vat_config.backlog; secret_key = _; serve_tls; listen_address; public_address} = config in

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -61,8 +61,8 @@ let parse_third_party_cap_id _ = `Two_party_only
 let addr_of_host host =
   match Unix.getaddrinfo host "" [Unix.AI_SOCKTYPE Unix.SOCK_STREAM] with
   | {ai_addr = ADDR_INET(addr, _) ; _} :: _ -> addr
+  | {ai_addr = ADDR_UNIX _ ; _} :: _ -> Capnp_rpc.Debug.failf "Unknown host %S" host
   | [] -> Capnp_rpc.Debug.failf "No addresses found for host name %S" host
-  | _ -> Capnp_rpc.Debug.failf "Unknown host %S" host
 
 let connect_socket = function
   | `Unix path ->


### PR DESCRIPTION
The PR following https://github.com/mirage/capnp-rpc/issues/278

This is adding support for ipv6 in capnp-rpc-unix.

This has been tested with ocurrent rpc on the server and the client.

1. Unix.getaddrinfo is used instead of Unix.gethostbyname as discussed in the issue
2. Unix.socket now needs to dynamically chose the socket_domain based on the address
3. parse_tcp needs to be able to parse ipv6 address. 

For 3. I don’t think this is the best way to do : the format of ip6 host would be `tcp:::1:7000` which is not so readable.
It is probably better to do `tcp:[::1]:7000` but this require more change than simply adding `~rev:true`.

Tell me what do you think of it