### PR TITLE
Update to capnp 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,7 @@ Here's a suitable `dune` file to compile the schema file and then the generated 
 ```
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc logs.fmt))
 
 (rule
  (targets echo_api.ml echo_api.mli)
@@ -573,8 +572,7 @@ Edit the `dune` file to build a client and server:
 ```
 (executables
  (names client server)
- (libraries lwt.unix capnp-rpc logs.fmt capnp-rpc-unix)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc logs.fmt capnp-rpc-unix))
 
 (rule
  (targets echo_api.ml echo_api.mli)

--- a/capnp-rpc-net.opam
+++ b/capnp-rpc-net.opam
@@ -13,7 +13,7 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.08.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.4.0"}
+  "capnp" {>= "3.6.0"}
   "capnp-rpc" {= version}
   "astring"
   "fmt" {>= "0.8.7"}

--- a/capnp-rpc.opam
+++ b/capnp-rpc.opam
@@ -13,7 +13,7 @@ doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
   "ocaml" {>= "4.08.0"}
   "conf-capnproto" {build}
-  "capnp" {>= "3.4.0"}
+  "capnp" {>= "3.6.0"}
   "stdint" {>= "0.6.0"}
   "lwt" {>= "5.6.1"}
   "astring"

--- a/capnp-rpc/dune
+++ b/capnp-rpc/dune
@@ -1,8 +1,6 @@
 (library
  (name capnp_rpc)
  (public_name capnp-rpc)
- (ocamlc_flags :standard -w -55-53)
- (ocamlopt_flags :standard -w -55-53)
  (libraries astring capnp capnp-rpc.proto fmt logs lwt uri))
 
 (rule

--- a/examples/pipelining/dune
+++ b/examples/pipelining/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc-unix logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc-unix logs.fmt))
 
 (rule
  (targets echo_api.ml echo_api.mli)

--- a/examples/sturdy-refs-2/dune
+++ b/examples/sturdy-refs-2/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc-unix logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc-unix logs.fmt))
 
 (rule
  (targets api.ml api.mli)

--- a/examples/sturdy-refs-3/dune
+++ b/examples/sturdy-refs-3/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc-unix logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc-unix logs.fmt))
 
 (rule
  (targets api.ml api.mli)

--- a/examples/sturdy-refs-4/dune
+++ b/examples/sturdy-refs-4/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc-unix logs.fmt cmdliner)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc-unix logs.fmt cmdliner))
 
 (rule
  (targets api.ml api.mli)

--- a/examples/sturdy-refs/dune
+++ b/examples/sturdy-refs/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc-unix logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc-unix logs.fmt))
 
 (rule
  (targets api.ml api.mli)

--- a/examples/testlib/dune
+++ b/examples/testlib/dune
@@ -1,7 +1,6 @@
 (library
  (name testlib)
- (libraries astring capnp-rpc capnp-rpc-net)
- (flags :standard -w -53-55))
+ (libraries astring capnp-rpc capnp-rpc-net))
 
 (rule
  (targets test_api.ml test_api.mli)

--- a/examples/v1/dune
+++ b/examples/v1/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc logs.fmt))
 
 (rule
  (targets echo_api.ml echo_api.mli)

--- a/examples/v2/dune
+++ b/examples/v2/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc logs.fmt))
 
 (rule
  (targets echo_api.ml echo_api.mli)

--- a/examples/v3/dune
+++ b/examples/v3/dune
@@ -1,7 +1,6 @@
 (executable
  (name main)
- (libraries lwt.unix capnp-rpc-unix logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc-unix logs.fmt))
 
 (rule
  (targets echo_api.ml echo_api.mli)

--- a/examples/v4/dune
+++ b/examples/v4/dune
@@ -1,7 +1,6 @@
 (executables
  (names client server)
- (libraries lwt.unix capnp-rpc logs.fmt capnp-rpc-unix)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc logs.fmt capnp-rpc-unix))
 
 (rule
  (targets echo_api.ml echo_api.mli)

--- a/test-bin/echo/dune
+++ b/test-bin/echo/dune
@@ -1,7 +1,6 @@
 (executable
  (name echo_bench)
- (libraries lwt.unix capnp-rpc capnp-rpc-net capnp-rpc-unix logs.fmt)
- (flags (:standard -w -53-55)))
+ (libraries lwt.unix capnp-rpc capnp-rpc-net capnp-rpc-unix logs.fmt))
 
 (rule
  (targets echo_api.ml echo_api.mli)


### PR DESCRIPTION
Suppressing compiler warnings is no longer needed with that version.