### PR TITLE
Add buffering of outgoing messages

### DIFF
--- a/capnp-rpc-net/endpoint.mli
+++ b/capnp-rpc-net/endpoint.mli
@@ -6,11 +6,15 @@ val src : Logs.src
 type t
 (** A wrapper for a byte-stream (flow). *)
 
-val send : t -> 'a Capnp.BytesMessage.Message.t -> (unit, [`Closed | `Msg of string]) result
-(** [send t msg] transmits [msg]. *)
+val send : t -> 'a Capnp.BytesMessage.Message.t -> unit
+(** [send t msg] enqueues [msg]. *)
 
-val recv : t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [> `Closed]) result
-(** [recv t] reads the next message from the remote peer.
+val run_writer : tags:Logs.Tag.set -> t -> unit
+(** [run_writer ~tags t] runs a loop that transmits batches of messages from [t].
+    It returns when the flow is closed. *)
+
+val recv : tags:Logs.Tag.set -> t -> (Capnp.Message.ro Capnp.BytesMessage.Message.t, [> `Closed]) result
+(** [recv ~tags t] reads the next message from the remote peer.
     It returns [Error `Closed] if the connection to the peer is lost. *)
 
 val of_flow : peer_id:Auth.Digest.t -> _ Eio.Flow.two_way -> t
@@ -19,6 +23,10 @@ val of_flow : peer_id:Auth.Digest.t -> _ Eio.Flow.two_way -> t
 val peer_id : t -> Auth.Digest.t
 (** [peer_id t] is the fingerprint of the peer's public key,
     or [Auth.Digest.insecure] if TLS isn't being used. *)
+                     
+val flush : t -> unit
+(** [flush t] is useful to try to send any buffered data before disconnecting.
+    Otherwise, the final abort message is likely to get lost. *)
 
 val disconnect : t -> unit
 (** [disconnect t] shuts down the underlying flow. *)

--- a/unix/network.mli
+++ b/unix/network.mli
@@ -36,6 +36,6 @@ val accept_connection :
   secret_key:Capnp_rpc_net.Auth.Secret_key.t option ->
   [> Eio.Flow.two_way_ty | Eio.Resource.close_ty] r ->
   (Capnp_rpc_net.Endpoint.t, [> `Msg of string]) result
-(** [accept_connection ~switch ~secret_key flow] is a new endpoint for [flow].
+(** [accept_connection ~secret_key flow] is a new endpoint for [flow].
     If [secret_key] is not [None], it is used to perform a TLS server-side handshake.
     Otherwise, the connection is not encrypted. *)


### PR DESCRIPTION
Sending each message in its own TCP packet isn't very efficient, and also interacts very badly with Nagle's algorithm. See https://roscidus.com/blog/blog/2024/07/22/performance/ for details.

Note: The Prometheus metrics `messages_outbound_sent_total` and `messages_outbound_dropped_total` have gone. They weren't very useful and we no longer know the number of messages by the time the connection is dropped (could report dropped bytes if needed though).

    dune exec -- ./test-bin/echo/echo_bench.exe
    echo_bench.exe: [INFO] rate = 522.989613	# Before
    echo_bench.exe: [INFO] rate = 62439.433376  # After