### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v3

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-crypto-rng-eio" {>= "1.1.0" & with-test}
   "mdx" {>= "2.4.1" & with-test}
   "eio_main" {with-test}
-  "eio" {>= "1.1"}
+  "eio" {>= "1.2"}
 ]
 conflicts: [
   "jbuilder"

--- a/capnp-rpc.opam
+++ b/capnp-rpc.opam
@@ -15,7 +15,7 @@ depends: [
   "conf-capnproto" {build}
   "capnp" {>= "3.6.0"}
   "stdint" {>= "0.6.0"}
-  "eio" {>= "1.1"}
+  "eio" {>= "1.2"}
   "astring"
   "fmt" {>= "0.8.7"}
   "logs"


### PR DESCRIPTION
- Work around file renaming problem
- Update to Eio 1.2
- Only disconnect socket when sending is done

Fixes https://github.com/mirage/capnp-rpc/issues/286.