### PR TITLE
Only disconnect socket when sending is done

### DIFF
--- a/capnp-rpc-net/capTP_capnp.ml
+++ b/capnp-rpc-net/capTP_capnp.ml
@@ -77,7 +77,6 @@ module Make (Network : S.NETWORK) = struct
     if not t.disconnecting then (
       t.disconnecting <- true;
       send_abort t ex;
-      Endpoint.disconnect t.endpoint;
       Conn.disconnect t.conn ex
     )
 

--- a/capnp-rpc-net/vat.ml
+++ b/capnp-rpc-net/vat.ml
@@ -119,7 +119,7 @@ module Make (Network : S.NETWORK) = struct
         let my_id = Auth.Secret_key.digest ~hash (Lazy.force t.secret_key) in
         let keep_new = (my_id > peer_id) = (mode = `Connect) in
         if keep_new then (
-          let reason = Capnp_rpc.Exception.v "Closing duplicate connection" in
+          let reason = Capnp_rpc.Exception.v "Invalidated by newer connection" in
           CapTP.disconnect existing reason;
           run_connection_tls t endpoint r
         ) else (


### PR DESCRIPTION
Before, we also disconnected on receiving end-of-file, but that prevents sending the final abort message.

Also, bootstrap now returns a broken cap if the connection got shut down, rather than raising an exception. This allows handling crossed calls more consistently.