### PR TITLE
Move net to Vat_config.t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ clean:
 
 test:
 	rm -rf _build/_tests
-	dune build test test-bin @install
+	dune build test test-bin examples @install
 	dune build @runtest --no-buffer -j 1

--- a/examples/pipelining/main.ml
+++ b/examples/pipelining/main.ml
@@ -23,12 +23,12 @@ let secret_key = `Ephemeral
 let listen_address = `TCP ("127.0.0.1", 7000)
 
 let start_server ~sw ~delay net =
-  let config = Capnp_rpc_unix.Vat_config.create ~secret_key listen_address in
+  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~net listen_address in
   let service_id = Capnp_rpc_unix.Vat_config.derived_id config "main" in
   let service = Echo.local ~delay in
   Switch.on_release sw (fun () -> Capability.dec_ref service);
   let restore = Capnp_rpc_net.Restorer.single service_id service in
-  let vat = Capnp_rpc_unix.serve ~sw ~net ~restore config in
+  let vat = Capnp_rpc_unix.serve ~sw ~restore config in
   Capnp_rpc_unix.Vat.sturdy_uri vat service_id
 
 let () =

--- a/examples/sturdy-refs-2/main.ml
+++ b/examples/sturdy-refs-2/main.ml
@@ -15,14 +15,14 @@ let or_fail = function
   | Error (`Msg m) -> failwith m
 
 let start_server ~sw net =
-  let config = Capnp_rpc_unix.Vat_config.create ~secret_key listen_address in
+  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~net listen_address in
   let make_sturdy = Capnp_rpc_unix.Vat_config.sturdy_uri config in
   let services = Restorer.Table.create make_sturdy in
   let restore = Restorer.of_table services in
   let root_id = Capnp_rpc_unix.Vat_config.derived_id config "root" in
   let root = Logger.local "root" in
   Restorer.Table.add services root_id root;
-  let _vat = Capnp_rpc_unix.serve ~sw ~net ~restore config in
+  let _vat = Capnp_rpc_unix.serve ~sw ~restore config in
   Capnp_rpc_unix.Vat_config.sturdy_uri config root_id
 
 (* $MDX part-begin=main *)

--- a/examples/sturdy-refs-3/main.ml
+++ b/examples/sturdy-refs-3/main.ml
@@ -15,7 +15,7 @@ let or_fail = function
   | Error (`Msg m) -> failwith m
 
 let start_server ~sw net =
-  let config = Capnp_rpc_unix.Vat_config.create ~secret_key listen_address in
+  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~net listen_address in
   let make_sturdy = Capnp_rpc_unix.Vat_config.sturdy_uri config in
   let services = Restorer.Table.create make_sturdy in
   Switch.on_release sw (fun () -> Restorer.Table.clear services);
@@ -28,7 +28,7 @@ let start_server ~sw net =
   in
   (* $MDX part-end *)
   Restorer.Table.add services root_id root;
-  let _vat = Capnp_rpc_unix.serve ~sw ~net ~restore config in
+  let _vat = Capnp_rpc_unix.serve ~sw ~restore config in
   Capnp_rpc_unix.Vat_config.sturdy_uri config root_id
 
 let run_client ~net cap_file =

--- a/examples/sturdy-refs-4/main.ml
+++ b/examples/sturdy-refs-4/main.ml
@@ -14,13 +14,11 @@ let or_fail = function
   | Error (`Msg m) -> failwith m
 
 (* $MDX part-begin=server *)
-let serve config =
-  Eio_main.run @@ fun env ->
-  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
+let serve store_dir config =
   Switch.run @@ fun sw ->
   (* Create the on-disk store *)
   let make_sturdy = Capnp_rpc_unix.Vat_config.sturdy_uri config in
-  let db, set_loader = Db.create ~make_sturdy (env#cwd / "store") in
+  let db, set_loader = Db.create ~make_sturdy store_dir in
   (* Create the restorer *)
   let services = Restorer.Table.of_loader ~sw (module Db) db in
   Switch.on_release sw (fun () -> Restorer.Table.clear services);
@@ -39,41 +37,40 @@ let serve config =
   (* Tell the database how to restore saved loggers *)
   Promise.resolve set_loader (fun sr ~label -> Restorer.grant @@ Logger.local ~persist_new sr label);
   (* Run the server *)
-  let _vat = Capnp_rpc_unix.serve ~sw ~net:env#net ~restore config in
+  let _vat = Capnp_rpc_unix.serve ~sw ~restore config in
   let uri = Capnp_rpc_unix.Vat_config.sturdy_uri config root_id in
   Capnp_rpc_unix.Cap_file.save_uri uri "admin.cap" |> or_fail;
   print_endline "Wrote admin.cap";
   Fiber.await_cancel ()
 (* $MDX part-end *)
 
-let log cap_file msg =
-  Eio_main.run @@ fun env ->
-  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
+let log net cap_file msg =
   Switch.run @@ fun sw ->
-  let vat = Capnp_rpc_unix.client_only_vat ~sw env#net in
+  let vat = Capnp_rpc_unix.client_only_vat ~sw net in
   let sr = Capnp_rpc_unix.Cap_file.load vat cap_file |> or_fail in
   Sturdy_ref.with_cap_exn sr @@ fun logger ->
   Logger.log logger msg
 
-let sub cap_file label =
-  Eio_main.run @@ fun env ->
-  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
+let sub env cap_file label =
   Switch.run @@ fun sw ->
   let sub_file = label ^ ".cap" in
   if Sys.file_exists sub_file then Fmt.failwith "%S already exists!" sub_file;
   let vat = Capnp_rpc_unix.client_only_vat ~sw env#net in
   let sr = Capnp_rpc_unix.Cap_file.load vat cap_file |> or_fail in
-  Sturdy_ref.with_cap_exn sr @@ fun logger ->
+  Sturdy_ref.with_cap_exn sr @@ fun root ->
   let uri = Capability.with_ref (Logger.sub root "alice") Capnp_rpc.Persistence.save_exn in
   Capnp_rpc_unix.Cap_file.save_uri uri sub_file |> or_fail;
   Printf.printf "Wrote %S\n%!" sub_file;
 
 open Cmdliner
 
-let serve_cmd =
+let ( $ ) = Term.( $ )
+let ( $$ ) f x = Term.const f $ x
+
+let serve_cmd env =
   let doc = "run the server" in
   let info = Cmd.info "serve" ~doc in
-  Cmd.v info Term.(const serve $ Capnp_rpc_unix.Vat_config.cmd)
+  Cmd.v info (serve (env#cwd / "store") $$ Capnp_rpc_unix.Vat_config.cmd env)
 
 let cap_file =
   let i = Arg.info [] ~docv:"PATH" ~doc:"logger.cap file" in
@@ -87,19 +84,21 @@ let label =
   let i = Arg.info [] ~docv:"LABEL" ~doc:"Tag for new logger" in
   Arg.(required @@ pos 1 (some string) None i)
 
-let log_cmd =
+let log_cmd env =
   let doc = "log a message" in
   let info = Cmd.info "log" ~doc in
-  Cmd.v info Term.(const log $ cap_file $ msg)
+  Cmd.v info Term.(log env#net $$ cap_file $ msg)
 
-let sub_cmd =
+let sub_cmd env =
   let doc = "create a sub-logger" in
   let info = Cmd.info "sub" ~doc in
-  Cmd.v info Term.(const sub $ cap_file $ label)
+  Cmd.v info Term.(sub env $$ cap_file $ label)
 
-let cmds = [serve_cmd; sub_cmd; log_cmd]
+let cmds env = [serve_cmd env; sub_cmd env; log_cmd env]
 
 let () =
   let doc = "a command-line interface for logger service" in
   let info = Cmd.info ~doc "logger-client" in
-  exit (Cmd.eval @@ Cmd.group info cmds)
+  exit @@ Eio_main.run @@ fun env ->
+  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
+  Cmd.eval @@ Cmd.group info (cmds env)

--- a/examples/sturdy-refs/main.ml
+++ b/examples/sturdy-refs/main.ml
@@ -22,12 +22,12 @@ let make_service ~config ~services name =
   name, id
 
 let start_server ~sw net =
-  let config = Capnp_rpc_unix.Vat_config.create ~secret_key listen_address in
+  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~net listen_address in
   let make_sturdy = Capnp_rpc_unix.Vat_config.sturdy_uri config in
   let services = Restorer.Table.create make_sturdy in
   let restore = Restorer.of_table services in
   let services = List.map (make_service ~config ~services) ["alice"; "bob"] in
-  let vat = Capnp_rpc_unix.serve ~sw ~net ~restore config in
+  let vat = Capnp_rpc_unix.serve ~sw ~restore config in
   services |> List.iter (fun (name, id) ->
       let cap_file = name ^ ".cap" in
       Capnp_rpc_unix.Cap_file.save_service vat id cap_file |> or_fail;

--- a/examples/v3/main.ml
+++ b/examples/v3/main.ml
@@ -18,10 +18,10 @@ let secret_key = `Ephemeral
 let listen_address = `TCP ("127.0.0.1", 7000)
 
 let start_server ~sw ~delay net =
-  let config = Capnp_rpc_unix.Vat_config.create ~secret_key listen_address in
+  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~net listen_address in
   let service_id = Capnp_rpc_unix.Vat_config.derived_id config "main" in
   let restore = Capnp_rpc_net.Restorer.single service_id (Echo.local ~delay) in
-  let vat = Capnp_rpc_unix.serve ~sw ~net ~restore config in
+  let vat = Capnp_rpc_unix.serve ~sw ~restore config in
   Capnp_rpc_unix.Vat.sturdy_uri vat service_id
 
 let () =

--- a/examples/v4/server.ml
+++ b/examples/v4/server.ml
@@ -9,14 +9,11 @@ let () =
 
 let cap_file = "echo.cap"
 
-let serve config =
-  Eio_main.run @@ fun env ->
-  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
-  let delay = Eio.Time.Timeout.seconds env#mono_clock delay in
+let serve ~delay config =
   Switch.run @@ fun sw ->
   let service_id = Capnp_rpc_unix.Vat_config.derived_id config "main" in
   let restore = Restorer.single service_id (Echo.local ~delay) in
-  let vat = Capnp_rpc_unix.serve ~sw ~net:env#net ~restore config in
+  let vat = Capnp_rpc_unix.serve ~sw ~restore config in
   match Capnp_rpc_unix.Cap_file.save_service vat service_id cap_file with
   | Error `Msg m -> failwith m
   | Ok () ->
@@ -25,10 +22,15 @@ let serve config =
 
 open Cmdliner
 
-let serve_cmd =
+let ( $$ ) f x = Term.(const f $ x)
+
+let serve_cmd env =
   let doc = "run the server" in
   let info = Cmd.info "serve" ~doc in
-  Cmd.v info Term.(const serve $ Capnp_rpc_unix.Vat_config.cmd)
+  let delay = Eio.Time.Timeout.seconds env#mono_clock delay in
+  Cmd.v info (serve ~delay $$ Capnp_rpc_unix.Vat_config.cmd env)
 
 let () =
-  exit (Cmd.eval serve_cmd)
+  exit @@ Eio_main.run @@ fun env ->
+  Mirage_crypto_rng_eio.run (module Mirage_crypto_rng.Fortuna) env @@ fun () ->
+  Cmd.eval (serve_cmd env)

--- a/test-bin/echo/echo_bench.ml
+++ b/test-bin/echo/echo_bench.ml
@@ -25,10 +25,10 @@ let secret_key = `Ephemeral
 let listen_address = `TCP ("127.0.0.1", 7000)
 
 let start_server ~sw net =
-  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~serve_tls:false listen_address in
+  let config = Capnp_rpc_unix.Vat_config.create ~secret_key ~serve_tls:false ~net listen_address in
   let service_id = Capnp_rpc_unix.Vat_config.derived_id config "main" in
   let restore = Capnp_rpc_net.Restorer.single service_id Echo.local in
-  let vat = Capnp_rpc_unix.serve ~sw ~net ~restore config in
+  let vat = Capnp_rpc_unix.serve ~sw ~restore config in
   Capnp_rpc_unix.Vat.sturdy_uri vat service_id
 
 let () =

--- a/test/dune
+++ b/test/dune
@@ -2,4 +2,4 @@
  (package capnp-rpc-unix)
  (name test)
  (libraries capnp-rpc capnp-rpc-unix testlib logs.fmt
-   mirage-crypto-rng-eio testbed eio_main))
+   mirage-crypto-rng-eio testbed eio_main eio.mock))

--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -150,8 +150,8 @@ let handle_connection ?tags ~secret_key vat client =
     Log.warn (fun f -> f ?tags "Rejecting new connection: %s" msg)
   | Ok ep -> Vat.run_connection vat ~mode:`Accept ep ignore
 
-let create_server ?tags ?restore ~sw ~net config =
-  let {Vat_config.backlog; secret_key = _; serve_tls; listen_address; public_address} = config in
+let create_server ?tags ?restore ~sw config =
+  let {Vat_config.net; backlog; secret_key = _; serve_tls; listen_address; public_address} = config in
   let vat =
     let auth = Vat_config.auth config in
     let secret_key = lazy (fst (Lazy.force config.secret_key)) in
@@ -200,9 +200,8 @@ let listen ?tags ~sw (config, vat, socket) =
       )
   done
 
-let serve ?tags ?restore ~sw ~net config =
-  let net = (net :> [`Generic] Eio.Net.ty r) in
-  let (vat, socket) = create_server ?tags ?restore ~sw ~net config in
+let serve ?tags ?restore ~sw config =
+  let (vat, socket) = create_server ?tags ?restore ~sw config in
   Fiber.fork_daemon ~sw (fun () ->
       listen ?tags ~sw (config, vat, socket)
     );


### PR DESCRIPTION
It's more logical to keep the network next to the addresses on it. Also, this will allow using Eio paths more easily in future.

I also moved cmdliner inside of `Eio_main.run` in the examples, which allows Eio to be used in more places.