### PR TITLE
Prepare release

### DIFF
--- a/capnp-rpc-lwt/capnp_rpc_lwt.mli
+++ b/capnp-rpc-lwt/capnp_rpc_lwt.mli
@@ -1,6 +1,7 @@
-(** Cap'n Proto RPC using the Cap'n Proto serialisation and Lwt for concurrency. *)
+(** Lwt compatibility wrappers.
 
-[@@@deprecated "Use Capnp_rpc instead. See https://github.com/mirage/capnp-rpc/blob/master/CHANGES.md for migration instructions."]
+    This module wraps {!Capnp_rpc} to provide the old Lwt API, to make upgrading easier.
+    See {{:https://github.com/mirage/capnp-rpc/blob/master/CHANGES.md}} for migration instructions. *)
 
 open Capnp.RPC
 


### PR DESCRIPTION
This updates the changelog and the migration instructions.

It also removes the deprecation alert from `Capnp_rpc_lwt` for now, as that makes upgrading more annoying than it needs to be.