### PR TITLE
Set TCP_NODELAY to avoid Nagle's algorithm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,7 +64,7 @@ API changes:
 
 Performance and bug fixes:
 
-- Add buffering of outgoing messages (@talex5 #287).  
+- Add buffering of outgoing messages (@talex5 #287 #303).  
   Sending each message in its own TCP packet isn't very efficient, and also interacts very badly with Nagle's algorithm.
   See <https://roscidus.com/blog/blog/2024/07/22/performance/> for details.
 


### PR DESCRIPTION
Avoids 40ms delays in some cases. We already do our own buffering, so having the OS do it isn't useful.

Before (`test-bin/calc.ml`):
![before](https://github.com/user-attachments/assets/626bc36b-0ce8-4181-bc99-9a8164891280)

After:
![after](https://github.com/user-attachments/assets/dc4ede05-94ba-4af0-918b-19d9c07ba81f)

Also, don't fail to set options if the socket has no Unix FD. Allows testing with a mock network.