### PR TITLE
Record a trace event for method calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@ New features:
 
 API changes:
 
-- Eio port (@talex5 #280 #284 #298 #292 #297 #300).
+- Eio port (@talex5 #280 #284 #298 #292 #297 #300 #304).
 
   This switches capnp-rpc from Lwt to Eio.
   One particularly nice side effect of this is that `Service.return_lwt` has gone,

--- a/capnp-rpc/service.ml
+++ b/capnp-rpc/service.ml
@@ -38,7 +38,10 @@ let local (s:#generic) =
       let call = Msg.Request.readable msg in
       let interface_id = Call.interface_id_get call in
       let method_id = Call.method_id_get call in
-      Log.debug (fun f -> f "Invoking local method %a" pp_method (interface_id, method_id));
+      Log.debug (fun f ->
+          Eio.Private.Trace.log (Fmt.str "%a" pp_method (interface_id, method_id));
+          f "Invoking local method %a" pp_method (interface_id, method_id)
+        );
       let p = Call.params_get call in
       let m : abstract_method_t = s#dispatch ~interface_id ~method_id in
       let release_params () = Core_types.Request_payload.release msg in


### PR DESCRIPTION
Makes traces easier to navigate.

Currently only enabled when debug logging is on (ideally it should be enabled when tracing is on, but OCaml doesn't tell us that).