### PR TITLE
OCaml 5.2 is the minimum version

### DIFF
--- a/capnp-rpc-lwt.opam
+++ b/capnp-rpc-lwt.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.2"}
   "capnp-rpc" {>= version}
   "lwt_eio" {>= "0.5.1"}
   "dune" {>= "3.16"}

--- a/capnp-rpc-net.opam
+++ b/capnp-rpc-net.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "5.2"}
   "conf-capnproto" {build}
   "capnp" {>= "3.6.0"}
   "capnp-rpc" {= version}

--- a/capnp-rpc-unix.opam
+++ b/capnp-rpc-unix.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 doc: "https://mirage.github.io/capnp-rpc/"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "5.2"}
   "capnp-rpc-net" {= version}
   "cmdliner" {>= "1.1.0"}
   "cstruct" {>= "6.2.0"}
@@ -20,6 +20,7 @@ depends: [
   "extunix"
   "base64" {>= "3.0.0"}
   "dune" {>= "3.16"}
+  "ipaddr" {>= "5.3.0" }
   "alcotest" {>= "1.6.0" & with-test}
   "mirage-crypto-rng-eio" {>= "1.1.0" & with-test}
   "mdx" {>= "2.4.1" & with-test}

--- a/capnp-rpc.opam
+++ b/capnp-rpc.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "5.2"}
   "conf-capnproto" {build}
   "capnp" {>= "3.6.0"}
   "stdint" {>= "0.6.0"}


### PR DESCRIPTION
5.1 fails with:

    File "capnp-rpc/leak_handler.ml", line 1:
    Error: The implementation capnp-rpc/leak_handler.ml
           does not match the interface capnp-rpc/.capnp_rpc.objs/byte/capnp_rpc__Leak_handler.cmi:
            Values do not match:
              val run : unit -> unit
            is not included in
              val run : unit -> 'a

Also, we need ipaddr 5.3.0 for `with_port_of_string`.