### PR TITLE
Revert "Work around FreeBSD close problem"

### DIFF
--- a/unix/capnp_rpc_unix.ml
+++ b/unix/capnp_rpc_unix.ml
@@ -175,18 +175,12 @@ let create_server ?tags ?restore ~sw config =
                Vat_config.Listen_address.pp listen_address);
   vat, socket
 
-(* Work-around for FreeBSD returning errors from close.
-   Should ideally be fixed in Eio. *)
-let close x =
-  try Eio.Net.close x
-  with Eio.Io (Eio.Net.E Connection_reset _, _) -> ()
-
 let listen ?tags ~sw (config, vat, socket) =
   while true do
     (* This is like [Eio.Net.accept_fork], but using [fork_daemon] instead of [fork]. *)
     let child_started = ref false in
     let client, addr = Eio.Net.accept ~sw socket in
-    Fun.protect ~finally:(fun () -> if !child_started = false then close client)
+    Fun.protect ~finally:(fun () -> if !child_started = false then Eio.Net.close client)
       (fun () ->
          Log.info (fun f -> f ?tags "Accepting new connection from %a" Eio.Net.Sockaddr.pp addr);
          Fiber.fork_daemon ~sw (fun () ->
@@ -195,9 +189,9 @@ let listen ?tags ~sw (config, vat, socket) =
                let secret_key = if config.Vat_config.serve_tls then Some (Vat_config.secret_key config) else None in
                handle_connection ?tags ~secret_key vat client
              with
-             | () -> close client; `Stop_daemon
+             | () -> Eio.Net.close client; `Stop_daemon
              | exception ex ->
-               close client;
+               Eio.Net.close client;
                Fiber.check ();
                Log.info (fun f -> f ?tags "Error handling connection from %a: %a" Eio.Net.Sockaddr.pp addr Eio.Exn.pp ex);
                `Stop_daemon

--- a/unix/network.ml
+++ b/unix/network.ml
@@ -65,12 +65,6 @@ let error fmt =
 
 let parse_third_party_cap_id _ = `Two_party_only
 
-(* Work-around for FreeBSD returning errors from close.
-   Should ideally be fixed in Eio. *)
-let close x =
-  try Eio.Net.close x
-  with Eio.Io (Eio.Net.E Connection_reset _, _) -> ()
-
 let try_set_nodelay socket =
   try Eio.Net.setsockopt socket Eio.Net.Sockopt.TCP_NODELAY true
   with Eio.Io _ -> ()         (* Probably a Unix-domain socket *)
@@ -87,7 +81,6 @@ let connect net ~sw ~secret_key (addr, auth) =
   Log.info (fun f -> f "Connecting to %a..." Eio.Net.Sockaddr.pp eio_addr);
   match Eio.Net.connect ~sw net eio_addr with
   | socket ->
-    Switch.on_release sw (fun () -> close socket);      (* Work-around *)
     begin match addr with
       | `Unix _ -> ()
       | `TCP _ ->


### PR DESCRIPTION
Not needed since Eio 1.3.

This reverts commit 6d897a8be6ec27fbe3f86b4f4c60ffd6e6203bd8.